### PR TITLE
Add link checker + add links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@ Please check all the boxes that apply to this pull request using "x":
 - [ ] I have followed the project's coding conventions and style guidelines.
 - [ ] I have rebased my branch onto the latest commit of the main branch.
 - [ ] I have squashed or reorganized my commits into logical units.
-- [ ] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
+- [ ] I have read, understood and agree to the [Developer Certificate of Origin](/DCO.md), which this project utilizes.

--- a/.github/workflows/broken-link-checker.yaml
+++ b/.github/workflows/broken-link-checker.yaml
@@ -1,0 +1,49 @@
+name: Check for broken links
+
+on:
+  # Run daily at 9:00 AM
+  schedule:
+    - cron: '0 9 * * *'
+  # Run on PRs to main
+  pull_request:
+    branches: [ main ]
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Target specific files and improve the arguments
+          args: >-
+            --verbose
+            --no-progress
+            --exclude-mail
+            --exclude-loopback
+            --exclude "file:///.*/issues.*"
+            '**/*.yaml'
+            '**/*.md'
+            '**/*.ts'
+            '**/*.vue'
+          # Output file for creating issues
+          output: ./lychee/out.md
+          # Fail if any link is broken
+          fail: true
+
+      # Only create an issue when broken links are found AND running on schedule/manual
+      - name: Create Issue (Only on schedule or manual run)
+        if: ${{ failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Broken links detected
+          content-filepath: ./lychee/out.md
+          labels: broken-links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,6 @@ Enhancement suggestions are tracked as [GitHub issues](../../issues).
 you can also tell which alternatives do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part
 which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on MacOS and
- Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+ Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/phw/peek) on Linux.
 - **Explain why this enhancement would be useful** for the community. You may also want to point out the
 other projects that solved it better and which could serve as inspiration.

--- a/form-app/src/components/LandingView.vue
+++ b/form-app/src/components/LandingView.vue
@@ -16,7 +16,7 @@ defineProps<{
       <p class="rvo-padding-block-end--lg">
         Bij verwerkingen van persoonsgegevens is het belangrijk om vroegtijdig inzicht te krijgen in mogelijke
         privacyrisico’s. Deze tools helpen je daarbij. Ze zijn gebaseerd op het <a
-          href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA">Rijksmodel DPIA Rijksdienst</a> en sluiten aan
+          href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA">Informatiemodellen voor de DPIA en pre-scan DPIA</a> en <a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx">Rapportagemodel DPIA Rijksdienst</a> en sluiten aan
         op rijksbrede kaders, inclusief AI en kinderrechten.
       </p>
 


### PR DESCRIPTION
# Description

In this PR we:

- Add links to datamodel

- Automatic broken link detection:

  - File types to check: .yaml .vue .ts .md
  - Exclude: links to issues, mails and localhosts 
  - Schedule: The check runs every day at 9:00 AM
  - Issue creation: Added a step to create a GitHub issue when broken links are found (only when triggering manually or on schedule)
  - Additional options: Using --verbose for detailed logs

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have tested the changes locally and verified that they work as expected.
- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
