### PR TITLE
Fix: deploy

### DIFF
--- a/form-app/package-lock.json
+++ b/form-app/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@nl-rvo/assets": "^1.0.0-alpha.360",
-        "@nl-rvo/component-library-css": "^4.17.0",
-        "@nl-rvo/design-tokens": "^1.12.0",
+        "@nl-rvo/component-library-css": "4.8.0",
+        "@nl-rvo/design-tokens": "1.9.0",
         "@types/pdfmake": "^0.2.11",
         "fp-ts": "^2.16.11",
         "io-ts": "^2.2.22",
@@ -1281,18 +1281,18 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@nl-rvo/component-library-css": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@nl-rvo/component-library-css/-/component-library-css-4.17.0.tgz",
-      "integrity": "sha512-hPK8GoeMrQYMTiLJJTw+Rw1LBHVshr5Ne46Kem4CU2HbpleO8WZTVSyLd7YEO6k8wxNjjURlyf8ts6gcXDv0tA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@nl-rvo/component-library-css/-/component-library-css-4.8.0.tgz",
+      "integrity": "sha512-9mTYqf1JJiaRW7+R0dKNG44FoBOVmj6+UHcTv/ONFmkmmN9QmfzSiXouDlfI/O7E3fcBQuPIVzSlwRlAxuWtwg==",
       "license": "CC0-1.0",
       "dependencies": {
         "modern-normalize": "3.0.1"
       }
     },
     "node_modules/@nl-rvo/design-tokens": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@nl-rvo/design-tokens/-/design-tokens-1.12.0.tgz",
-      "integrity": "sha512-gCMzwEi+H2gtQ2+s2B1ky/O6Y1XVYqb4pcnY1MT6q0fXFNKZ2xEsmSLWlly0+KsaZwBLbjq/zYg8pxwe97ka+A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@nl-rvo/design-tokens/-/design-tokens-1.9.0.tgz",
+      "integrity": "sha512-dkBtuj0JcBbTNLlkaZZfNPxFTzoQNWpSe9jdUCNJkPSgHCSI1V1TEyN2y0eJXlpufJRC39uAHZUaHn3Bvx0Ebw==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/form-app/package.json
+++ b/form-app/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@nl-rvo/assets": "^1.0.0-alpha.360",
-    "@nl-rvo/component-library-css": "^4.17.0",
-    "@nl-rvo/design-tokens": "^1.12.0",
+    "@nl-rvo/component-library-css": "4.8.0",
+    "@nl-rvo/design-tokens": "1.9.0",
     "@types/pdfmake": "^0.2.11",
     "fp-ts": "^2.16.11",
     "io-ts": "^2.2.22",

--- a/form-app/src/utils/pdfExport.ts
+++ b/form-app/src/utils/pdfExport.ts
@@ -1,8 +1,8 @@
 import { type FlatTask, type TaskStoreType } from '@/stores/tasks'
 import { type AnswerStoreType } from '@/stores/answers'
 import { FormType } from '@/models/dpia.ts'
-import * as pdfMake from 'pdfmake/build/pdfmake'
-import * as pdfFonts from 'pdfmake/build/vfs_fonts'
+import pdfMake from 'pdfmake/build/pdfmake'
+import pdfFonts from 'pdfmake/build/vfs_fonts'
 import type { StyleDictionary, TDocumentDefinitions, Content } from 'pdfmake/interfaces'
 import FontService from '@/services/fontService.ts'
 import { renderInstanceLabel } from '@/utils/taskUtils'
@@ -14,7 +14,8 @@ import type { CalculationStoreType } from '@/stores/calculations'
 
 
 // Initialize PDFMake
-(<any>pdfMake).addVirtualFileSystem(pdfFonts)
+// @ts-expect-error pdfmake 0.3.x types not yet in @types/pdfmake
+pdfMake.addVirtualFileSystem(pdfFonts)
 
 const dutchDateFormatter = new Intl.DateTimeFormat('nl-NL', {
   weekday: 'long',

--- a/form-app/src/utils/pdfExport.ts
+++ b/form-app/src/utils/pdfExport.ts
@@ -180,7 +180,12 @@ export async function exportToPdf(
 
     const vfs = await FontService.getVFS()
 
-    pdfMake.createPdf(docDefinition, undefined, fontDefinitions, vfs).download(actualFilename)
+    // pdfmake 0.3: register fonts and VFS on the instance before creating PDF
+    // @ts-expect-error pdfmake 0.3.x types not yet in @types/pdfmake
+    pdfMake.addFonts(fontDefinitions)
+    // @ts-expect-error pdfmake 0.3.x types not yet in @types/pdfmake
+    pdfMake.addVirtualFileSystem(vfs)
+    pdfMake.createPdf(docDefinition).download(actualFilename)
 
     return Promise.resolve()
   } catch (error) {

--- a/form-app/vite.config.ts
+++ b/form-app/vite.config.ts
@@ -7,16 +7,15 @@ import { viteSingleFile } from 'vite-plugin-singlefile'
 
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     vue(),
-    vueDevTools(),
-    viteSingleFile(
-    ),
+    mode === 'development' && vueDevTools(),
+    viteSingleFile(),
   ],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   }
-})
+}))


### PR DESCRIPTION
# Description

  1. Fix: vite-plugin-vue-devtools uit production build — De devtools plugin werd meegebundeld in production, wat een crash veroorzaakte (e.hasOwnProperty is not a 
  function). Opgelost door vueDevTools() alleen in development mode te laden.                                                                                              
  2. Bump Vite 6.3.5 → 7.3.1 — Meegenomen van Dependabot PR #271.                                                                                                          
  3. Fix: pdfMake import voor Vite 7 — Vite 7 handelt CommonJS interop anders af. import * as pdfMake → import pdfMake (default import) zodat addVirtualFileSystem weer    
  werkt.          
  4. Revert & pin @nl-rvo/component-library-css en design-tokens — De bumps (4.8.0→4.17.0 en 1.9.0→1.12.0) braken de button styling. Teruggezet en gepind (zonder ^) zodat
  Dependabot ze niet opnieuw bumpt.

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have tested the changes locally and verified that they work as expected.
- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have read, understood and agree to the [Developer Certificate of Origin](/DCO.md), which this project utilizes.
