### PR TITLE
ci: deploy op push naar experimenteel/samenwerken (i.p.v. PR #283-gate)

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,8 +1,9 @@
 name: Build and Deploy
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - experimenteel/samenwerken
   workflow_dispatch:
 
 env:
@@ -14,7 +15,6 @@ env:
 
 jobs:
   generate-sources:
-    if: github.event.pull_request.number == 283 || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -155,7 +155,8 @@ jobs:
           project-id: ${{ env.PROJECT_ID }}
           deployment-name: ${{ env.DEPLOYMENT_NAME }}
           wait-for-ready: 'true'
-          comment-on-pr: 'true'
+          # Push-getriggerd: er is geen PR-context om op te reageren.
+          comment-on-pr: 'false'
           components: >-
             [
               {"name": "frontend", "image": "${{ needs.build-frontend.outputs.image }}"},

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -155,8 +155,6 @@ jobs:
           project-id: ${{ env.PROJECT_ID }}
           deployment-name: ${{ env.DEPLOYMENT_NAME }}
           wait-for-ready: 'true'
-          # Push-getriggerd: er is geen PR-context om op te reageren.
-          comment-on-pr: 'false'
           components: >-
             [
               {"name": "frontend", "image": "${{ needs.build-frontend.outputs.image }}"},


### PR DESCRIPTION
## Wat & waarom

De deploy-keten in `build-and-deploy.yaml` was hard gekoppeld aan **PR #283** (`if: github.event.pull_request.number == 283`) en triggerde alleen op `pull_request`. Daardoor:
- deployt een **merge** naar `experimenteel/samenwerken` niet (geen `push`-trigger);
- breekt deploy zodra #283 ooit sluit/merget (geen PR #283 meer).

Deze PR vervangt dat door een **`push`-trigger op `experimenteel/samenwerken`**:
- `on: push` (branch `experimenteel/samenwerken`) + behoud van `workflow_dispatch` voor handmatige runs.
- De `if: == 283`-gate op `generate-sources` verwijderd (de trigger is nu al branch-scoped).
- `comment-on-pr` weggelaten: de `zad-actions/deploy`-default is al `false` én de comment-stap is gegate op `github.event_name == 'pull_request'`, dus op een push gebeurt er sowieso niets. Conform de org-conventie (moza-poc/regelrecht zetten 'm ook niet bij push/productie-deploys).

## ⚠️ Gevolg
Na merge deployt **elke push/merge naar `experimenteel/samenwerken` automatisch naar ZAD `productie`**. Het mergen van déze PR is meteen de eerste zo'n deploy.

## Side-note
Dit repo gebruikt `zad-actions/deploy@v3`; de rest van de org zit op `@v4`. Een bump kan los meegenomen worden.
