### PR TITLE
Upgrade lychee-action and let Dependabot watch GitHub Actions (#296)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,7 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: "typescript"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.4
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -26,7 +26,6 @@ jobs:
           args: >-
             --verbose
             --no-progress
-            --exclude-mail
             --exclude-loopback
             --exclude "file:///.*/issues.*"
             --exclude "file:///home/runner/work/.*"


### PR DESCRIPTION
Closes #296.

## Bevinding (empirisch)

De `check-links`-fouten waren **geen WAF-false-positives op geldige links**. Uit de `check-links`-log van #299 (draait de ongewijzigde main-workflow):

- `✔ [200] https://eur-lex.europa.eu/legal-content/NL/TXT/HTML/?uri=OJ:L_202401689#art_27`
- `✔ [200] https://www.rijksoverheid.nl/documenten/2026/02/16/toelichtingsdocument-impact-assessment-mensenrechten-en-algoritmes`
- `🚫 Errors: 0` → job slaagt

De rijksoverheid-fout was een **echte 404** op de oude `/rapporten/`-URL (opgelost in #297 via #299); eur-lex geeft nu 200. Brede domein-excludes zouden geldige links permanent ongecontroleerd laten en echte breuk verbergen — daarom **niet** toegevoegd.

## Wijzigingen (root cause)

- **`lycheeverse/lychee-action` `v1.5.4` → `v2.8.0`** — nieuwere lychee-binary met betere retry-/redirect-afhandeling. De workflow zet al `fail: true` (v2's nieuwe default) en koppelt issue-aanmaak aan `failure()`, niet aan de naar `GITHUB_OUTPUT` verplaatste exit-code-output, dus geen verdere aanpassingen nodig.
- **`github-actions`-ecosystem toegevoegd aan `dependabot.yaml`** — Dependabot bewaakte alleen `npm` in `/form-app/`, waardoor de action-pin stil verouderde. Nu worden workflow-actions automatisch gebumpt.

## Opruimen

De auto-gegenereerde duplicaat-issues uit #296 (#293/#292/#285/#284) zijn al gesloten; alleen #296 en #297 stonden nog open.