### PR TITLE
Make check-links robust under lychee v0.23.0: --root-dir + retries (#296 follow-up)

### DIFF
--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -26,6 +26,7 @@ jobs:
           args: >-
             --verbose
             --no-progress
+            --root-dir "${{ github.workspace }}"
             --exclude-loopback
             --exclude "file:///.*/issues.*"
             --exclude "file:///home/runner/work/.*"

--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -27,6 +27,9 @@ jobs:
             --verbose
             --no-progress
             --root-dir "${{ github.workspace }}"
+            --timeout 30
+            --max-retries 3
+            --retry-wait-time 2
             --exclude-loopback
             --exclude "file:///.*/issues.*"
             --exclude "file:///home/runner/work/.*"


### PR DESCRIPTION
Follow-up op #296 / #303 — herstelt twee regressies/zwakheden van de lychee v2.8.0 (lychee-binary v0.23.0) upgrade.

## 1. `--root-dir` (kapotte CI)

Lychee v0.23.0 ziet root-relative links in lokale bestanden (zoals `/DCO.md` in `.github/pull_request_template.md`) nu als **error** tenzij een root-dir is opgegeven. Dit ontbrak in de merge van #296, dus `check-links` faalt:

```
[ERROR] Error building URL for "/DCO.md": To resolve root-relative links in local files, provide a root dir
```

`--root-dir "${{ github.workspace }}"` toegevoegd → `/DCO.md` resolvet tegen de repo-root. **Geverifieerd:** de DCO-error is weg in CI.

## 2. Retry/timeout tegen transiënte fouten

Een transiënte `504 Gateway Timeout` op een externe PDF (kcbr.nl) liet de hele job falen, terwijl de link prima is (`200` op de volgende request). Toegevoegd:

- `--timeout 30` (lychee-default was 20s)
- `--max-retries 3` / `--retry-wait-time 2`

Echt kapotte links falen nog steeds ná de retries — dit vermindert ruis zonder breuk te verbergen.

## Verwachte CI op deze PR

> ⚠️ Base is `main`, dat de canonieke rijksoverheid-URL nog niet heeft (zit in #299). De resterende `check-links`-fouten op deze PR zijn **alleen** de oude rijksoverheid-`/rapporten/`-404 (3×) — die verdwijnen zodra #299 gemerged is. eur-lex en de canonieke URL geven beide `200` onder de nieuwe lychee (geverifieerd).

**Merge-volgorde voor groen `main`:** #299 (canonieke URL) + deze PR.