### PR TITLE
fix(security): stored XSS + ontbrekende CSP, kwetsbare deps en backend-hardening

### DIFF
--- a/.github/workflows/_build-images.yaml
+++ b/.github/workflows/_build-images.yaml
@@ -68,6 +68,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
@@ -96,6 +97,43 @@ jobs:
       - id: image-ref
         run: echo "image=${{ inputs.backend-image }}:${{ inputs.tag-prefix }}${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+      - name: Trivy image scan (report-only, SARIF)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: ${{ steps.image-ref.outputs.image }}
+          scan-type: image
+          format: sarif
+          output: trivy-backend.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Trivy results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-backend.sarif
+          category: trivy-backend
+      - name: Generate SBOM (CycloneDX)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: ${{ steps.image-ref.outputs.image }}
+          scan-type: image
+          format: cyclonedx
+          output: trivy-sbom-backend.json
+          list-all-pkgs: 'true'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-backend
+          path: trivy-sbom-backend.json
+          retention-days: 30
+
   build-frontend:
     needs: generate-sources
     runs-on: ubuntu-latest
@@ -104,6 +142,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
@@ -131,3 +170,40 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - id: image-ref
         run: echo "image=${{ inputs.frontend-image }}:${{ inputs.tag-prefix }}${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy image scan (report-only, SARIF)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: ${{ steps.image-ref.outputs.image }}
+          scan-type: image
+          format: sarif
+          output: trivy-frontend.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Trivy results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-frontend.sarif
+          category: trivy-frontend
+      - name: Generate SBOM (CycloneDX)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: ${{ steps.image-ref.outputs.image }}
+          scan-type: image
+          format: cyclonedx
+          output: trivy-sbom-frontend.json
+          list-all-pkgs: 'true'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-frontend
+          path: trivy-sbom-frontend.json
+          retention-days: 30

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     uses: ./.github/workflows/_build-images.yaml
     with:
       frontend-image: ghcr.io/minbzk/par-dpia-form/dev/frontend

--- a/.github/workflows/preview-deployment.yaml
+++ b/.github/workflows/preview-deployment.yaml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     uses: ./.github/workflows/_build-images.yaml
     with:
       frontend-image: ghcr.io/minbzk/par-dpia-form/preview/frontend

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,10 @@ jobs:
           python-version: '3.14'
           enable-cache: true
 
+      - name: Security audit (production dependencies)
+        # Fail on HIGH/critical advisories in runtime deps (regression guard).
+        run: pnpm audit --prod --audit-level high
+
       - name: Generate assessment JSON sources
         run: |
           mkdir -p sources/generated

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,6 @@ jobs:
           enable-cache: true
 
       - name: Security audit (production dependencies)
-        # Fail on HIGH/critical advisories in runtime deps (regression guard).
         run: pnpm audit --prod --audit-level high
 
       - name: Generate assessment JSON sources

--- a/apps/boekhouding-backend/package.json
+++ b/apps/boekhouding-backend/package.json
@@ -20,8 +20,8 @@
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
-    "drizzle-orm": "^0.44.2",
-    "fastify": "^5.3.3",
+    "drizzle-orm": "^0.45.2",
+    "fastify": "^5.8.5",
     "jose": "^6.0.11",
     "nanoid": "^5.1.5",
     "postgres": "^3.4.7"

--- a/apps/boekhouding-backend/src/app.ts
+++ b/apps/boekhouding-backend/src/app.ts
@@ -15,12 +15,19 @@ export const API_VERSION = '1.0.0'
 
 export interface BuildAppOptions {
   logger?: boolean
+  /** Expose Swagger UI + /api/openapi.json. Defaults to config.exposeApiDocs. */
+  exposeApiDocs?: boolean
+  /** Fastify trustProxy value (proxy CIDR / hop count). Defaults to config.trustProxy. */
+  trustProxy?: string | boolean | number
 }
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
+  const exposeApiDocs = options.exposeApiDocs ?? config.exposeApiDocs
   const app = Fastify({
     logger: options.logger ?? true,
     bodyLimit: 25 * 1024 * 1024, // 25 MB — assessments with embedded images can be large
+    // Trust the proxy hop so req.ip is the real client (rate limiting); see config.ts.
+    trustProxy: options.trustProxy ?? config.trustProxy,
   })
 
   await app.register(helmet, {
@@ -39,7 +46,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(cors, config.cors)
   await app.register(rateLimit, { max: 300, timeWindow: '1 minute' })
 
-  await app.register(swagger, {
+  if (exposeApiDocs) await app.register(swagger, {
     openapi: {
       info: {
         title: 'Assessment Boekhouding API',
@@ -106,7 +113,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     },
   })
 
-  await app.register(swaggerUi, {
+  if (exposeApiDocs) await app.register(swaggerUi, {
     routePrefix: '/api/docs',
     logo: { content: Buffer.from(''), type: 'image/svg+xml' },
     theme: {
@@ -168,9 +175,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     return reply.redirect('https://www.ncsc.nl/.well-known/security.txt', 301)
   })
 
-  app.get('/api/openapi.json', { schema: { hide: true } }, async (_request, reply) => {
-    return reply.send(app.swagger())
-  })
+  if (exposeApiDocs) {
+    app.get('/api/openapi.json', { schema: { hide: true } }, async (_request, reply) => {
+      return reply.send(app.swagger())
+    })
+  }
 
   return app
 }

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -14,8 +14,6 @@ function parseCorsOrigin(): string | string[] {
 
 const corsOrigin = parseCorsOrigin()
 
-// Numeric TRUST_PROXY = hop count (default 1, one ZAD proxy), else a CIDR/IP list.
-// Coerce numerics: Fastify reads a string as a CIDR, not a hop count.
 function parseTrustProxy(): number | string {
   const v = process.env.TRUST_PROXY
   if (!v) return 1
@@ -25,8 +23,6 @@ function parseTrustProxy(): number | string {
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
-  // API docs (/api/docs + /api/openapi.json): off by default (secure in prod regardless
-  // of NODE_ENV); set EXPOSE_API_DOCS=true to enable (dev/staging).
   exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
   trustProxy: parseTrustProxy(),
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -14,15 +14,21 @@ function parseCorsOrigin(): string | string[] {
 
 const corsOrigin = parseCorsOrigin()
 
+// Numeric TRUST_PROXY = hop count (default 1, one ZAD proxy), else a CIDR/IP list.
+// Coerce numerics: Fastify reads a string as a CIDR, not a hop count.
+function parseTrustProxy(): number | string {
+  const v = process.env.TRUST_PROXY
+  if (!v) return 1
+  return /^\d+$/.test(v) ? Number(v) : v
+}
+
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
   // API docs (/api/docs + /api/openapi.json): off by default (secure in prod regardless
   // of NODE_ENV); set EXPOSE_API_DOCS=true to enable (dev/staging).
   exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
-  // Reverse-proxy hop count (or CIDR) so req.ip is the real client behind the ZAD ingress.
-  // On ZAD set to 1 (single OpenShift router hop). Never 'true' (spoofable). Unset = local/direct.
-  trustProxy: process.env.TRUST_PROXY,
+  trustProxy: parseTrustProxy(),
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
   cors: {
     origin: corsOrigin,

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -17,6 +17,11 @@ const corsOrigin = parseCorsOrigin()
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
+  // API docs (/api/docs + /api/openapi.json): off in production unless EXPOSE_API_DOCS=true.
+  exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true' || process.env.NODE_ENV !== 'production',
+  // Proxy CIDR/hop count so req.ip is the real client behind the ZAD ingress.
+  // Never 'true' (X-Forwarded-For becomes spoofable). Unset for direct/local access.
+  trustProxy: process.env.TRUST_PROXY,
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
   cors: {
     origin: corsOrigin,

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -17,10 +17,11 @@ const corsOrigin = parseCorsOrigin()
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
-  // API docs (/api/docs + /api/openapi.json): off in production unless EXPOSE_API_DOCS=true.
-  exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true' || process.env.NODE_ENV !== 'production',
-  // Proxy CIDR/hop count so req.ip is the real client behind the ZAD ingress.
-  // Never 'true' (X-Forwarded-For becomes spoofable). Unset for direct/local access.
+  // API docs (/api/docs + /api/openapi.json): off by default (secure in prod regardless
+  // of NODE_ENV); set EXPOSE_API_DOCS=true to enable (dev/staging).
+  exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
+  // Reverse-proxy hop count (or CIDR) so req.ip is the real client behind the ZAD ingress.
+  // On ZAD set to 1 (single OpenShift router hop). Never 'true' (spoofable). Unset = local/direct.
   trustProxy: process.env.TRUST_PROXY,
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
   cors: {

--- a/apps/boekhouding-backend/test/cov/app.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/app.cov.test.ts
@@ -6,7 +6,9 @@ import { config } from '../../src/config.js'
 let app: FastifyInstance
 
 beforeAll(async () => {
-  app = await buildApp({ logger: false })
+  // exposeApiDocs is off by default; enable it here to exercise the Swagger UI
+  // + /api/openapi.json routes below.
+  app = await buildApp({ logger: false, exposeApiDocs: true })
 
   app.get('/__cov/throw-no-status', async () => {
     throw new Error('iets ging mis')

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -14,6 +14,7 @@ const ENV_KEYS = [
   'PORT',
   'HOST',
   'DATABASE_SERVER_FULL',
+  'TRUST_PROXY',
 ] as const
 
 const originalEnv: Record<string, string | undefined> = {}
@@ -156,5 +157,24 @@ describe('config — parseCorsOrigin', () => {
     process.env.PUBLIC_HOST = 'https://ignored.example.com'
     const config = await loadConfig()
     expect(config.cors.origin).toBe('https://cors.example.com')
+  })
+})
+
+describe('config — parseTrustProxy', () => {
+  it('defaults to 1 hop when TRUST_PROXY is unset', async () => {
+    const config = await loadConfig()
+    expect(config.trustProxy).toBe(1)
+  })
+
+  it('coerces a numeric TRUST_PROXY to a number (hop count)', async () => {
+    process.env.TRUST_PROXY = '2'
+    const config = await loadConfig()
+    expect(config.trustProxy).toBe(2)
+  })
+
+  it('passes a non-numeric TRUST_PROXY through as a CIDR/IP string', async () => {
+    process.env.TRUST_PROXY = '10.0.0.0/8'
+    const config = await loadConfig()
+    expect(config.trustProxy).toBe('10.0.0.0/8')
   })
 })

--- a/apps/boekhouding-backend/test/routes/apiDocs.test.ts
+++ b/apps/boekhouding-backend/test/routes/apiDocs.test.ts
@@ -1,0 +1,44 @@
+// /api/docs + /api/openapi.json must be gated so they aren't anonymously reachable in production.
+import { describe, it, expect, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { buildApp } from '../../src/app.js'
+
+let app: FastifyInstance | undefined
+
+afterEach(async () => {
+  await app?.close()
+  app = undefined
+})
+
+describe('API docs exposure', () => {
+  it('serves the spec and UI when exposeApiDocs is true', async () => {
+    app = await buildApp({ logger: false, exposeApiDocs: true })
+    await app.ready()
+
+    const spec = await app.inject({ method: 'GET', url: '/api/openapi.json' })
+    const ui = await app.inject({ method: 'GET', url: '/api/docs' })
+
+    expect(spec.statusCode).toBe(200)
+    expect(ui.statusCode).not.toBe(404) // 200 or 302 to /api/docs/
+  })
+
+  it('returns 404 for the spec and UI when exposeApiDocs is false', async () => {
+    app = await buildApp({ logger: false, exposeApiDocs: false })
+    await app.ready()
+
+    const spec = await app.inject({ method: 'GET', url: '/api/openapi.json' })
+    const ui = await app.inject({ method: 'GET', url: '/api/docs' })
+
+    expect(spec.statusCode).toBe(404)
+    expect(ui.statusCode).toBe(404)
+  })
+
+  it('still serves protected routes with auth enforced when docs are disabled', async () => {
+    app = await buildApp({ logger: false, exposeApiDocs: false })
+    await app.ready()
+
+    // Gating swagger must not break the data routes — auth still applies.
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects' })
+    expect(res.statusCode).toBe(401)
+  })
+})

--- a/apps/boekhouding-frontend/src/views/AboutAssessments.vue
+++ b/apps/boekhouding-frontend/src/views/AboutAssessments.vue
@@ -18,11 +18,11 @@ const hasHistory = computed(() => !!window.history.state?.back)
     <p>
       De invulhulpen helpen je bij het invullen van een pre-scan, een volledige DPIA en een IAMA.
       De pre-scan en DPIA zijn gebaseerd op het
-      <a href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA" target="_blank" rel="noopener">Informatiemodellen voor de DPIA en pre-scan DPIA</a>
+      <a href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA" target="_blank" rel="noopener noreferrer">Informatiemodellen voor de DPIA en pre-scan DPIA</a>
       en het
-      <a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx" target="_blank" rel="noopener">Rapportagemodel DPIA Rijksdienst</a>;
+      <a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx" target="_blank" rel="noopener noreferrer">Rapportagemodel DPIA Rijksdienst</a>;
       het IAMA op
-      <a href="https://www.rijksoverheid.nl/documenten/2026/02/16/impact-assessment-mensenrechten-en-algoritmes" target="_blank" rel="noopener">het instrument</a>
+      <a href="https://www.rijksoverheid.nl/documenten/2026/02/16/impact-assessment-mensenrechten-en-algoritmes" target="_blank" rel="noopener noreferrer">het instrument</a>
       ontwikkeld door de Universiteit Utrecht.
       Ze sluiten aan op rijksbrede kaders.
     </p>
@@ -36,7 +36,7 @@ const hasHistory = computed(() => !!window.history.state?.back)
 
     <h3 class="utrecht-heading-3">Bronnen</h3>
     <ul>
-      <li><a href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA" target="_blank" rel="noopener">Informatiemodellen voor de DPIA en pre-scan DPIA</a></li>
+      <li><a href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA" target="_blank" rel="noopener noreferrer">Informatiemodellen voor de DPIA en pre-scan DPIA</a></li>
     </ul>
 
     <h2 class="utrecht-heading-2">DPIA</h2>
@@ -69,8 +69,8 @@ const hasHistory = computed(() => !!window.history.state?.back)
 
     <h3 class="utrecht-heading-3">Bronnen</h3>
     <ul>
-      <li><a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx" target="_blank" rel="noopener">Rapportagemodel DPIA Rijksdienst</a></li>
-      <li><a href="https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/beleidskompas/verplichte-kwaliteitseisen/data-protection-impact-assessment" target="_blank" rel="noopener">Data Protection Impact Assessment - Kenniscentrum voor beleid en regelgeving</a></li>
+      <li><a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx" target="_blank" rel="noopener noreferrer">Rapportagemodel DPIA Rijksdienst</a></li>
+      <li><a href="https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/beleidskompas/verplichte-kwaliteitseisen/data-protection-impact-assessment" target="_blank" rel="noopener noreferrer">Data Protection Impact Assessment - Kenniscentrum voor beleid en regelgeving</a></li>
     </ul>
 
     <h2 class="utrecht-heading-2">IAMA</h2>
@@ -111,7 +111,7 @@ const hasHistory = computed(() => !!window.history.state?.back)
 
     <h2 class="utrecht-heading-2">Zie ook</h2>
     <ul>
-      <li><a href="https://rijksportaal.overheid-i.nl/organisaties/bzk/artikelen/dg-digitalisering-en-overheidsorganisatie-dgdoo/cio-rijk/informatiebeveiliging-en-privacy/privacy-adviseurs-rijk-par.html" target="_blank" rel="noopener">Privacy Adviseurs Rijk (PAR) - Rijksportaal</a></li>
+      <li><a href="https://rijksportaal.overheid-i.nl/organisaties/bzk/artikelen/dg-digitalisering-en-overheidsorganisatie-dgdoo/cio-rijk/informatiebeveiliging-en-privacy/privacy-adviseurs-rijk-par.html" target="_blank" rel="noopener noreferrer">Privacy Adviseurs Rijk (PAR) - Rijksportaal</a></li>
     </ul>
   </div>
 </template>

--- a/apps/boekhouding-frontend/src/views/AccessibilityStatement.vue
+++ b/apps/boekhouding-frontend/src/views/AccessibilityStatement.vue
@@ -18,19 +18,19 @@ const hasHistory = computed(() => !!window.history.state?.back)
     <p>
       Het Ministerie van Binnenlandse Zaken en Koninkrijksrelaties streeft ernaar deze applicatie
       toegankelijk te maken voor iedereen, overeenkomstig het
-      <a href="https://wetten.overheid.nl/BWBR0040936/2018-07-01" target="_blank" rel="noopener">Tijdelijk besluit digitale toegankelijkheid overheid</a>.
+      <a href="https://wetten.overheid.nl/BWBR0040936/2018-07-01" target="_blank" rel="noopener noreferrer">Tijdelijk besluit digitale toegankelijkheid overheid</a>.
     </p>
 
     <h2 class="utrecht-heading-2">Nalevingsstatus</h2>
     <p>
       De Assessment Boekhouding voldoet <strong>gedeeltelijk</strong> aan de
-      <a href="https://www.w3.org/TR/WCAG22/" target="_blank" rel="noopener">Web Content Accessibility Guidelines (WCAG) 2.2</a>
+      <a href="https://www.w3.org/TR/WCAG22/" target="_blank" rel="noopener noreferrer">Web Content Accessibility Guidelines (WCAG) 2.2</a>
       niveau AA. De applicatie is in actieve ontwikkeling en we werken aan volledige naleving.
     </p>
 
     <h2 class="utrecht-heading-2">Wat we doen</h2>
     <ul>
-      <li>We gebruiken het <a href="https://nldesignsystem.nl/" target="_blank" rel="noopener">NL Design System</a> (RVO componentbibliotheek) als basis voor onze interface-componenten</li>
+      <li>We gebruiken het <a href="https://nldesignsystem.nl/" target="_blank" rel="noopener noreferrer">NL Design System</a> (RVO componentbibliotheek) als basis voor onze interface-componenten</li>
       <li>Formulieren zijn voorzien van correcte labels en foutmeldingen</li>
       <li>Interactieve elementen zijn bereikbaar via het toetsenbord</li>
       <li>Foutmeldingen worden aangekondigd aan screenreaders via ARIA-attributen</li>
@@ -48,7 +48,7 @@ const hasHistory = computed(() => !!window.history.state?.back)
     </p>
     <ul>
       <li>E-mail: <a href="mailto:RIG@rijksoverheid.nl">RIG@rijksoverheid.nl</a></li>
-      <li>GitHub: <a href="https://github.com/MinBZK/par-dpia-form/issues" target="_blank" rel="noopener">Issues melden</a></li>
+      <li>GitHub: <a href="https://github.com/MinBZK/par-dpia-form/issues" target="_blank" rel="noopener noreferrer">Issues melden</a></li>
     </ul>
 
     <h2 class="utrecht-heading-2">Escalatie</h2>

--- a/apps/boekhouding-frontend/src/views/PrivacyStatement.vue
+++ b/apps/boekhouding-frontend/src/views/PrivacyStatement.vue
@@ -43,7 +43,7 @@ const hasHistory = computed(() => !!window.history.state?.back)
     <h2 class="utrecht-heading-2">Rechtsgrond</h2>
     <p>
       De verwerking is gebaseerd op gerechtvaardigd belang
-      (<a href="https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX%3A32016R0679#d1e1883-1-1" target="_blank" rel="noopener">artikel 6, lid 1, sub f AVG</a>).
+      (<a href="https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX%3A32016R0679#d1e1883-1-1" target="_blank" rel="noopener noreferrer">artikel 6, lid 1, sub f AVG</a>).
       Het belang is het mogelijk maken om veilig en reproduceerbaar samen te werken aan assessments
       in de context van de overheid.
     </p>
@@ -109,7 +109,7 @@ const hasHistory = computed(() => !!window.history.state?.back)
     <h2 class="utrecht-heading-2">Klacht indienen</h2>
     <p>
       Als je een klacht hebt over de verwerking van je persoonsgegevens, kun je deze indienen
-      bij de <a href="https://www.autoriteitpersoonsgegevens.nl/een-tip-of-klacht-indienen-bij-de-ap" target="_blank" rel="noopener">Autoriteit Persoonsgegevens</a>.
+      bij de <a href="https://www.autoriteitpersoonsgegevens.nl/een-tip-of-klacht-indienen-bij-de-ap" target="_blank" rel="noopener noreferrer">Autoriteit Persoonsgegevens</a>.
     </p>
 
     <h2 class="utrecht-heading-2">Contact</h2>

--- a/containers/backend/Containerfile
+++ b/containers/backend/Containerfile
@@ -38,4 +38,7 @@ COPY --from=build /app/apps/boekhouding-backend/dist apps/boekhouding-backend/di
 COPY --from=build /app/apps/boekhouding-backend/drizzle apps/boekhouding-backend/drizzle
 
 WORKDIR /app/apps/boekhouding-backend
+
+USER 1000
+
 CMD ["sh", "-c", "node dist/db/migrate.js && node dist/index.js"]

--- a/containers/compose.dev.yaml
+++ b/containers/compose.dev.yaml
@@ -52,6 +52,7 @@ services:
       OIDC_REALM: assessment-boekhouding
       OIDC_PUBLIC_CLIENT_ID: boekhouding-frontend
       NODE_ENV: development
+      EXPOSE_API_DOCS: "true"
     depends_on:
       postgres:
         condition: service_healthy

--- a/containers/frontend/default.conf
+++ b/containers/frontend/default.conf
@@ -24,7 +24,15 @@ server {
     # Cache static assets
     location ~* \.(css|js)$ {
         expires 1y;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, immutable" always;
+
+        # A location with its own add_header stops inheriting; re-add the security headers.
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
+        add_header Strict-Transport-Security "max-age=31536000" always;
     }
 
     # Standalone invulhulp (single-file SPA via viteSingleFile)
@@ -45,5 +53,14 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "public, max-age=0, must-revalidate" always;
+
+        # Same caveat: re-add the security headers (keep in sync with the server
+        # block) — without them index.html would ship with no CSP.
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
+        add_header Strict-Transport-Security "max-age=31536000" always;
     }
 }

--- a/containers/frontend/default.conf
+++ b/containers/frontend/default.conf
@@ -8,9 +8,9 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
-    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # NCSC security.txt referentie
     location = /.well-known/security.txt {
@@ -30,9 +30,9 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
-        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     # Standalone invulhulp (single-file SPA via viteSingleFile)
@@ -45,9 +45,9 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';" always;
-        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     location / {
@@ -59,8 +59,8 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
-        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://keycloak.rijksapp.nl; frame-src 'self' https://keycloak.rijksapp.nl; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://keycloak.rijksapp.nl;" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,7 +85,7 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 | `PUBLIC_HOST`          | —                            | Auto-inject (volgt webadres → CORS + OpenAPI `contact.url`) |
 | `PORT`                 | `3000`                       | Default is correct                        |
 | `HOST`                 | `0.0.0.0`                    | Default is correct                        |
-| `TRUST_PROXY`          | — (uit)                      | Zet op `1` (één OpenShift-router-hop) zodat `req.ip` het echte client-IP is en per-IP rate-limiting werkt. Nooit `true`. |
+| `TRUST_PROXY`          | `1` (één hop)                | Default klopt voor ZAD (één OpenShift-router-hop) → `req.ip` is het echte client-IP voor per-IP rate-limiting. Alleen overschrijven voor andere topologie (CIDR) of `0` om uit te zetten. Nooit `true`. |
 | `EXPOSE_API_DOCS`      | — (uit)                      | Laat uit in productie (Swagger UI + `/api/openapi.json` zijn dan niet bereikbaar). Zet op `true` voor dev/staging. |
 
 ### Niet nodig op ZAD

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,8 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 | `PUBLIC_HOST`          | —                            | Auto-inject (volgt webadres → CORS + OpenAPI `contact.url`) |
 | `PORT`                 | `3000`                       | Default is correct                        |
 | `HOST`                 | `0.0.0.0`                    | Default is correct                        |
+| `TRUST_PROXY`          | — (uit)                      | Zet op `1` (één OpenShift-router-hop) zodat `req.ip` het echte client-IP is en per-IP rate-limiting werkt. Nooit `true`. |
+| `EXPOSE_API_DOCS`      | — (uit)                      | Laat uit in productie (Swagger UI + `/api/openapi.json` zijn dan niet bereikbaar). Zet op `true` voor dev/staging. |
 
 ### Niet nodig op ZAD
 

--- a/packages/assessment-core/src/components/PreScanPreview.vue
+++ b/packages/assessment-core/src/components/PreScanPreview.vue
@@ -78,7 +78,8 @@ const formatAnswer = (answer: AnswerValue): string => {
       <div class="rvo-accordion__content">
         <div v-for="item in preScanAnswers" :key="item.taskId">
           <p><strong>{{ item.taskId }}. {{ item.taskTitle }}</strong></p>
-          <p v-html="formatAnswer(item.answer)"></p>
+          <!-- Pre-scan answers are user input; render as text to prevent stored XSS. -->
+          <p>{{ formatAnswer(item.answer) }}</p>
         </div>
       </div>
     </details>

--- a/packages/assessment-core/src/components/task/FormField.vue
+++ b/packages/assessment-core/src/components/task/FormField.vue
@@ -306,7 +306,8 @@ const handleCheckboxInput = (event: Event) => {
             :checked="Array.isArray(currentValue) && (currentValue as string[]).includes(option)"
             :name="`group-${task.id}-${instanceId}`" @change="handleCheckboxInput" class="rvo-checkbox__input"
             type="checkbox" />
-          <span v-html="option"></span>
+          <!-- option is a user free-text answer (getSourceOptions): render as text, not v-html. -->
+          <span>{{ option }}</span>
         </label>
       </div>
     </div>

--- a/packages/assessment-core/src/components/task/ImageField.vue
+++ b/packages/assessment-core/src/components/task/ImageField.vue
@@ -138,7 +138,7 @@ watch(() => imageData.value?.description, () => {
     <!-- Legacy string/URL reference -->
     <div v-if="legacyValue" class="rvo-alert rvo-alert--warning rvo-alert--padding-sm rvo-margin-block-end--md">
       <p>Bestaande referentie:
-        <a v-if="legacyIsUrl" :href="legacyValue" target="_blank" rel="noopener">{{ legacyValue }}</a>
+        <a v-if="legacyIsUrl" :href="legacyValue" target="_blank" rel="noopener noreferrer">{{ legacyValue }}</a>
         <span v-else>{{ legacyValue }}</span>
       </p>
       <p>Upload een afbeelding om deze referentie te vervangen.</p>

--- a/packages/assessment-core/src/utils/escapeHtml.ts
+++ b/packages/assessment-core/src/utils/escapeHtml.ts
@@ -1,0 +1,12 @@
+/**
+ * Escape a string for safe interpolation into HTML text or a quoted attribute.
+ * `&` is replaced first so existing entities are not double-encoded.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/packages/assessment-core/src/utils/markdown.ts
+++ b/packages/assessment-core/src/utils/markdown.ts
@@ -1,5 +1,6 @@
 import { Marked, type Tokens, type Token, type MarkedToken } from 'marked'
 import type { Content } from 'pdfmake/interfaces'
+import { escapeHtml } from './escapeHtml'
 
 // Marked instance with a custom renderer that acts as an allowlist.
 // Only safe HTML tags are produced; raw HTML input and images are stripped.
@@ -12,7 +13,8 @@ const safeMarked = new Marked({
     link({ href, tokens }: Tokens.Link) {
       const text = this.parser.parseInline(tokens)
       if (!/^https?:\/\/|^mailto:/i.test(href)) return text
-      return `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`
+      // Escape href: marked keeps quotes/spaces in <...> destinations (attribute-breakout XSS).
+      return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${text}</a>`
     },
     checkbox({ checked }: Tokens.Checkbox) {
       return checked ? '&#x2611; ' : '&#x2610; '

--- a/packages/assessment-core/src/utils/taskUtils.ts
+++ b/packages/assessment-core/src/utils/taskUtils.ts
@@ -1,6 +1,7 @@
 import { Task } from '../models/dpia'
 import { useAnswerStore } from '../stores/answers'
 import { useTaskStore } from '../stores/tasks'
+import { escapeHtml } from './escapeHtml'
 
 export function createConclusionTask(
   taskName: string,
@@ -37,6 +38,7 @@ export function renderInstanceLabel(instanceId: string, template: string): strin
 
     const value = answerStore.getAnswer(originInstance)
     if (value == null) return ''
-    return String(value)
+    // Legend renders this via v-html (schema definition markup), so escape the user value.
+    return escapeHtml(String(value))
   })
 }

--- a/packages/assessment-core/test/escapeHtml.test.ts
+++ b/packages/assessment-core/test/escapeHtml.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { escapeHtml } from '../src/utils/escapeHtml'
+
+describe('escapeHtml', () => {
+  it('escapes &, <, >, " and \'', () => {
+    expect(escapeHtml(`<tag attr="x" data='y'> & </tag>`)).toBe(
+      '&lt;tag attr=&quot;x&quot; data=&#39;y&#39;&gt; &amp; &lt;/tag&gt;',
+    )
+  })
+
+  it('escapes & first so existing entities are not double-decoded', () => {
+    expect(escapeHtml('a & b < c')).toBe('a &amp; b &lt; c')
+  })
+
+  it('neutralizes an attribute-breakout payload', () => {
+    const out = escapeHtml('"><img src=x onerror=alert(1)>')
+    expect(out).not.toContain('"><')
+    expect(out).not.toMatch(/<img/i)
+  })
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeHtml('Gewone tekst 123')).toBe('Gewone tekst 123')
+  })
+})

--- a/packages/assessment-core/test/markdown.test.ts
+++ b/packages/assessment-core/test/markdown.test.ts
@@ -102,6 +102,26 @@ describe('renderMarkdownToHtml', () => {
     expect(html).toContain('&#x2610;')
     expect(html).toContain('&#x2611;')
   })
+
+  it('escapes a double-quote breakout in the link href', () => {
+    const html = renderMarkdownToHtml('[click](https://example.com#"><img src=x onerror=alert(1)>)')
+    expect(html).not.toContain('"><')
+    expect(html).not.toMatch(/<img/i)
+    expect(html).toContain('&quot;')
+  })
+
+  it('escapes quotes/spaces in a pointy-bracket link destination', () => {
+    // marked's <...> link syntax preserves literal quotes and spaces in the href
+    const html = renderMarkdownToHtml('[click](<https://a" onmouseover="alert(1)>)')
+    expect(html).not.toMatch(/href="https:\/\/a" onmouseover/)
+    expect(html).not.toContain('onmouseover="alert(1)"')
+    expect(html).toContain('click')
+  })
+
+  it('keeps legitimate ampersands in a link href as an entity', () => {
+    const html = renderMarkdownToHtml('[ok](https://e.com/p?a=1&b=2)')
+    expect(html).toContain('href="https://e.com/p?a=1&amp;b=2"')
+  })
 })
 
 describe('markdownToPdfContent', () => {

--- a/packages/assessment-core/test/renderInstanceLabel.test.ts
+++ b/packages/assessment-core/test/renderInstanceLabel.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useTaskStore } from '../src/stores/tasks'
+import { useAnswerStore } from '../src/stores/answers'
+import { useTaskDependencies } from '../src/composables/useTaskDependencies'
+import { rebuildRepeatableInstances } from '../src/utils/applyState'
+import { renderInstanceLabel } from '../src/utils/taskUtils'
+import { FormType, type Task } from '../src/models/dpia'
+
+// 3.1 (source, free-text 3.1.1) maps one-to-one to 5.1, whose label derives from the 3.1.1 answer.
+const tree: Task[] = [
+  {
+    id: '3',
+    task: 'Gegevensverwerkingen',
+    type: ['task_group'],
+    tasks: [
+      {
+        id: '3.1',
+        task: 'Gegevensverwerking',
+        type: ['task_group'],
+        repeatable: true,
+        tasks: [{ id: '3.1.1', task: 'Naam', type: ['text_input'] }],
+      },
+    ],
+  },
+  {
+    id: '5',
+    task: 'Verwerkingsdoeleinden',
+    type: ['task_group'],
+    tasks: [
+      {
+        id: '5.1',
+        task: 'Gegevensverwerking',
+        type: ['task_group'],
+        repeatable: true,
+        dependencies: [
+          {
+            type: 'instance_mapping',
+            source: { id: '3.1.1' },
+            mapping_type: 'one_to_one',
+            action: 'sync_instances',
+          },
+        ],
+        tasks: [{ id: '5.1.1', task: 'Doel', type: ['open_text'] }],
+      },
+    ],
+  },
+]
+
+describe('renderInstanceLabel', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    const taskStore = useTaskStore()
+    const answerStore = useAnswerStore()
+    taskStore.setActiveNamespace(FormType.DPIA)
+    answerStore.setActiveNamespace(FormType.DPIA)
+  })
+
+  it('HTML-escapes the user answer substituted into an instance label', () => {
+    const taskStore = useTaskStore()
+    const answerStore = useAnswerStore()
+    taskStore.init(tree, true)
+    answerStore.answers[FormType.DPIA] = {
+      '3.1.1[0]': { value: '<img src=x onerror=alert(1)>', lastEditedAt: '2024-01-01' },
+    }
+    rebuildRepeatableInstances(taskStore, answerStore)
+    useTaskDependencies().syncInstances.value()
+
+    const label = renderInstanceLabel('5.1[0]', 'Verwerking {3.1.1}')
+
+    expect(label).toContain('Verwerking ')
+    expect(label).not.toContain('<img')
+    expect(label).toContain('&lt;img')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,11 +34,11 @@ importers:
         specifier: ^5.2.5
         version: 5.2.5
       drizzle-orm:
-        specifier: ^0.44.2
-        version: 0.44.7(postgres@3.4.8)
+        specifier: ^0.45.2
+        version: 0.45.2(postgres@3.4.8)
       fastify:
-        specifier: ^5.3.3
-        version: 5.8.2
+        specifier: ^5.8.5
+        version: 5.8.5
       jose:
         specifier: ^6.0.11
         version: 6.2.1
@@ -66,7 +66,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/boekhouding-frontend:
     dependencies:
@@ -103,7 +103,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.7.3))
+        version: 6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.30(typescript@5.7.3))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.4
         version: 4.1.8(vitest@4.1.8)
@@ -124,10 +124,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       vue-tsc:
         specifier: ^2.2.10
         version: 2.2.12(typescript@5.7.3)
@@ -167,7 +167,7 @@ importers:
         version: 24.12.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.7.3))
+        version: 6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.30(typescript@5.7.3))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.4
         version: 4.1.8(vitest@4.1.8)
@@ -206,16 +206,16 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-singlefile:
         specifier: ^2.3.0
-        version: 2.3.0(rollup@4.59.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.3.0(rollup@4.59.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       vite-plugin-vue-devtools:
         specifier: ^8.0.3
-        version: 8.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.7.3))
+        version: 8.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.30(typescript@5.7.3))
       vitest:
         specifier: ^4.1.4
-        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       vue-tsc:
         specifier: ^2.2.10
         version: 2.2.12(typescript@5.7.3)
@@ -258,7 +258,7 @@ importers:
         version: 0.2.13
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.7.3))
+        version: 6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.30(typescript@5.7.3))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.4
         version: 4.1.8(vitest@4.1.8)
@@ -282,7 +282,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -1016,8 +1016,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.0.0':
-    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
+  '@fastify/static@9.1.3':
+    resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
 
   '@fastify/swagger-ui@5.2.5':
     resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
@@ -1623,14 +1623,14 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1787,8 +1787,8 @@ packages:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
-  drizzle-orm@0.44.7:
-    resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -2064,14 +2064,14 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
-  fastify@5.8.2:
-    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2449,8 +2449,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2620,8 +2620,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.8:
@@ -3156,8 +3156,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -3694,7 +3694,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -3737,7 +3737,7 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@9.0.0':
+  '@fastify/static@9.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/send': 4.1.0
@@ -3748,11 +3748,11 @@ snapshots:
 
   '@fastify/swagger-ui@5.2.5':
     dependencies:
-      '@fastify/static': 9.0.0
+      '@fastify/static': 9.1.3
       fastify-plugin: 5.1.0
       openapi-types: 12.1.3
       rfdc: 1.4.1
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   '@fastify/swagger@9.7.0':
     dependencies:
@@ -3760,7 +3760,7 @@ snapshots:
       json-schema-resolver: 3.0.0
       openapi-types: 12.1.3
       rfdc: 1.4.1
-      yaml: 2.8.2
+      yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4065,10 +4065,10 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.7.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.30(typescript@5.7.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.30(typescript@5.7.3)
 
   '@vitest/coverage-istanbul@4.1.8(vitest@4.1.8)':
@@ -4083,7 +4083,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -4096,13 +4096,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -4191,7 +4191,7 @@ snapshots:
       '@vue/shared': 3.5.30
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.8
+      postcss: 8.5.15
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.30':
@@ -4336,7 +4336,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4383,16 +4383,16 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4529,7 +4529,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(postgres@3.4.8):
+  drizzle-orm@0.45.2(postgres@3.4.8):
     optionalDependencies:
       postgres: 3.4.8
 
@@ -4790,7 +4790,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -4800,11 +4800,11 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastify-plugin@5.1.0: {}
 
-  fastify@5.8.2:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -5071,7 +5071,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -5153,15 +5153,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.15
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.1
 
   minipass@7.1.3: {}
 
@@ -5175,7 +5175,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   nanoid@5.1.6: {}
 
@@ -5342,9 +5342,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.8:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5629,17 +5629,17 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       birpc: 2.9.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
-  vite-hot-client@2.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-hot-client@2.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  vite-plugin-inspect@11.3.3(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -5649,32 +5649,32 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-singlefile@2.3.0(rollup@4.59.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-singlefile@2.3.0(rollup@4.59.0)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       micromatch: 4.0.8
       rollup: 4.59.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  vite-plugin-vue-devtools@8.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.7.3)):
+  vite-plugin-vue-devtools@8.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.30(typescript@5.7.3)):
     dependencies:
       '@vue/devtools-core': 8.1.0(vue@3.5.30(typescript@5.7.3))
       '@vue/devtools-kit': 8.1.0
       '@vue/devtools-shared': 8.1.0
       sirv: 3.0.2
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
-      vite-plugin-vue-inspector: 5.4.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-inspect: 11.3.3(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+      vite-plugin-vue-inspector: 5.4.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.4.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-vue-inspector@5.4.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -5685,16 +5685,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.30
       kolorist: 1.8.0
       magic-string: 0.30.21
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.8
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -5702,12 +5702,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.8(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.8)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -5724,7 +5724,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
@@ -5829,6 +5829,6 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
## fix(security): stored XSS + ontbrekende CSP, kwetsbare deps en backend-hardening

Adresseert de security-audit op `experimenteel/samenwerken` (bevindingen geverifieerd tegen de actuele code; deels ernstiger dan de audit aangaf). De **auth-takeover (F5)** zit in een aparte PR (`fix/auth-account-linking`). Gerebased op de huidige `experimenteel/samenwerken` (monorepo + IAMA + 100%-coverage-gate).

### 1. Stored XSS in `assessment-core` (HIGH)
- **Markdown link-href** (`markdown.ts`) werd ongeëscaped geïnterpoleerd → attribute-breakout XSS (o.a. via marked's `<...>`-linkvorm met quotes). Nu via een nieuwe `escapeHtml`-util geëscaped.
- **`v-html`-sinks die rauwe gebruikersantwoorden renderden** zijn omgezet naar veilige weergave:
  - checkbox source-options (`FormField.vue`) en pre-scan-antwoorden (`PreScanPreview.vue`) → tekst-interpolatie `{{ }}`.
  - instance-label legend (`TaskGroup.vue` via `renderInstanceLabel`) houdt `v-html` (rendert bewust schema-definitie-HTML), maar de gesubstitueerde gebruikerswaarde wordt nu geëscaped.
- Config-afgeleide sinks (labels/descriptions/schema-opties, incl. het nieuwe `multiselect_scrollable` dat al `{{ }}` gebruikt) en de diff-views in boekhouding-frontend (`VersionHistory`/`ConflictResolutionDialog`, die al via `formatValue`/`formatConflictValue` escapen) zijn **bewust ongemoeid** gelaten.

### 2. Ontbrekende CSP op de hoofd-SPA (HIGH — door de audit gemist)
`nginx` erft `add_header` niet wanneer een `location` eigen headers zet. `location /` (Cache-Control op index.html) en de static-asset-locatie lieten daardoor **alle** server-niveau security-headers vervallen — de collaboratieve app werd **zonder CSP/HSTS/clickjacking-bescherming** geserveerd. De volledige header-set (incl. strikte `script-src 'self'` CSP) is nu in beide locaties herhaald. Geverifieerd met `nginx -t`.

### 3. Kwetsbare runtime-dependencies (HIGH/MEDIUM)
Gebumpt en met `pnpm audit` geverifieerd (prod nu **schoon**): `drizzle-orm`→0.45.2 (CVE-2026-39356), `fastify`→5.8.5 (CVE-2026-33806 + 5.8.3-fix), `fast-uri`→3.1.2 (CVE-2026-6321/6322), `@fastify/static`→9.1.3, `yaml`→2.9.0, `brace-expansion` → patched, `postcss`→≥8.5.10. Nieuwe CI-stap `pnpm audit --prod --audit-level high` voorkomt regressie.

### 4. Backend-hardening
- **F6**: backend-container draait nu als unprivileged `USER 1000` i.p.v. root.
- **F7**: Swagger UI (`/api/docs`) + `/api/openapi.json` achter `config.exposeApiDocs` (default uit in productie; opt-in via `EXPOSE_API_DOCS=true`).
- **F9**: configureerbare `trustProxy` (env `TRUST_PROXY`, proxy-CIDR; nooit `true`) zodat `req.ip` achter de ZAD-ingress de echte client is.

## Breaking changes
**Geen.** Aandachtspunt: het herstellen van de CSP op de hoofd-SPA is een aanscherping — verifieer dat de SPA laadt onder `script-src 'self'`.

## Deployment-env
- `EXPOSE_API_DOCS=true` waar interne API-docs bereikbaar moeten blijven (default uit in prod)
- `TRUST_PROXY=<ZAD-ingress-CIDR>` voor correcte per-IP rate-limiting

## Verificatie
- 100%-coverage-gate groen in **alle** workspaces: assessment-core (1166), boekhouding-backend (348), standalone-form (40), boekhouding-frontend (787).
- backend/frontend/standalone type-checks ✓ · `nginx -t` ✓ · `pnpm audit --prod` schoon ✓.

## Bewust uitgesteld (follow-up, niet-blokkerend)
- **F10** standalone-CSP `unsafe-inline` (vereist build-time script-hash; de F1-fix neutraliseert de XSS al).
- **F8** opake `state`-validatie (laag; XSS-output is aan de renderkant gedicht).
