### PR TITLE
fix(security): robuuste account-koppeling — geen takeover, geen lockout (F5)

### DIFF
--- a/apps/boekhouding-backend/src/middleware/auth.ts
+++ b/apps/boekhouding-backend/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import type { FastifyRequest, FastifyReply } from 'fastify'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 import { db } from '../db/connection.js'
 import { users } from '../db/schema.js'
-import { eq } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { config } from '../config.js'
 
 export interface AuthUser {
@@ -81,30 +81,72 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
     .limit(1)
 
   if (user) {
-    // Sync email and name from Keycloak (e.g. after email change)
+    // Sync email and name from Keycloak (e.g. after an email/name change). The
+    // email is only synced when no other account already uses it: a collision
+    // would violate the unique(email) constraint and lock this user out, so the
+    // existing email is kept in that case (and logged). The name always syncs.
     if (user.email !== payload.email || user.displayName !== displayName) {
+      let email = payload.email
+      if (email !== user.email) {
+        const [clash] = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.email, email))
+          .limit(1)
+        if (clash) {
+          request.log.warn('Skipping email sync: address already linked to another account')
+          email = user.email
+        }
+      }
       const [updated] = await db
         .update(users)
-        .set({ email: payload.email, displayName })
+        .set({ email, displayName })
         .where(eq(users.oidcSub, payload.sub))
         .returning({ id: users.id, email: users.email, displayName: users.displayName })
       user = updated
     }
   } else {
-    // First login — create user record
-    const [created] = await db
-      .insert(users)
-      .values({
-        email: payload.email,
-        displayName,
-        oidcSub: payload.sub,
-      })
-      .onConflictDoUpdate({
-        target: users.email,
-        set: { oidcSub: payload.sub, displayName },
-      })
+    // First login for this subject.
+    // Claim an invite placeholder — a row created by an invite that is still
+    // without an oidcSub — but ONLY while it is unclaimed (guarded by the
+    // isNull condition, which is atomic with the update). A row that is already
+    // linked to another subject is NEVER overwritten, preventing account takeover.
+    const [claimed] = await db
+      .update(users)
+      .set({ oidcSub: payload.sub, displayName })
+      .where(and(eq(users.email, payload.email), isNull(users.oidcSub)))
       .returning({ id: users.id, email: users.email, displayName: users.displayName })
-    user = created
+
+    if (claimed) {
+      user = claimed
+    } else {
+      // No unclaimed placeholder. Insert a fresh account; if a row with this
+      // email already exists — linked to a different subject, or created by a
+      // concurrent first-login — DO NOTHING (never relink/overwrite) and refuse.
+      // onConflictDoNothing makes this race-safe: exactly one concurrent insert
+      // wins, the other gets no row back and falls through to 409 (not a 500).
+      const [created] = await db
+        .insert(users)
+        .values({
+          email: payload.email,
+          displayName,
+          oidcSub: payload.sub,
+        })
+        .onConflictDoNothing({ target: users.email })
+        .returning({ id: users.id, email: users.email, displayName: users.displayName })
+
+      if (created) {
+        user = created
+      } else {
+        return reply.status(409).type('application/problem+json').send({
+          type: 'https://httpproblems.com/http-status/409',
+          title: 'Conflict',
+          status: 409,
+          detail: 'Dit e-mailadres is al gekoppeld aan een ander account.',
+          instance: request.url,
+        })
+      }
+    }
   }
 
   request.user = {

--- a/apps/boekhouding-backend/test/cov/middleware-auth.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/middleware-auth.cov.test.ts
@@ -171,21 +171,23 @@ describe('requireAuth — displayName precedence + user provisioning', () => {
     expect(row.displayName).toBe('Nieuwe Naam')
   })
 
-  it('first login with an email already taken updates the existing row by email (onConflictDoUpdate)', async () => {
+  it('first login does NOT take over an email already claimed by another subject (409)', async () => {
     const sharedEmail = `shared-${randomUUID()}@example.com`
+    const legacySub = `legacy-${randomUUID()}`
     const [existing] = await db
       .insert(users)
-      .values({ email: sharedEmail, displayName: 'Origineel', oidcSub: `legacy-${randomUUID()}` })
+      .values({ email: sharedEmail, displayName: 'Origineel', oidcSub: legacySub })
       .returning()
 
     const newSub = randomUUID()
     const t = await token({ sub: newSub, email: sharedEmail, name: 'Gemigreerde Naam' })
     const res = await getProjects(authHeader(t))
-    expect(res.statusCode).toBe(200)
+    // Account linking must refuse: relinking a claimed row would be a takeover.
+    expect(res.statusCode).toBe(409)
 
     const [row] = await db.select().from(users).where(eq(users.email, sharedEmail))
     expect(row.id).toBe(existing.id)
-    expect(row.oidcSub).toBe(newSub)
-    expect(row.displayName).toBe('Gemigreerde Naam')
+    expect(row.oidcSub).toBe(legacySub)
+    expect(row.displayName).toBe('Origineel')
   })
 })

--- a/apps/boekhouding-backend/test/routes/accountLinking.test.ts
+++ b/apps/boekhouding-backend/test/routes/accountLinking.test.ts
@@ -1,0 +1,138 @@
+// Account-linking safety in requireAuth.
+//
+// A Keycloak login is matched to a local user by oidcSub. When no row exists for
+// the subject yet, the middleware may CLAIM an invite placeholder (a row created
+// by an invite, still without an oidcSub). It must NEVER relink a row that is
+// already claimed by a different subject — that would be silent account takeover
+// of another user's projects/data.
+//
+// These run the real Fastify app + requireAuth against a real Postgres test DB,
+// with real JWTs signed by the loopback JWKS. No auth path is bypassed.
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { eq } from 'drizzle-orm'
+import { buildApp } from '../../src/app.js'
+import { db } from '../../src/db/connection.js'
+import { users } from '../../src/db/schema.js'
+import { getJwks } from '../helpers/testContext.js'
+import { truncateAll } from '../helpers/testDb.js'
+import { createUser } from '../helpers/fixtures.js'
+
+let app: FastifyInstance
+const jwks = getJwks()
+
+function authHeader(token: string) {
+  return { authorization: `Bearer ${token}` }
+}
+
+async function login(token: string) {
+  return app.inject({ method: 'GET', url: '/api/v1/projects', headers: authHeader(token) })
+}
+
+beforeAll(async () => {
+  app = await buildApp({ logger: false })
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+})
+
+beforeEach(async () => {
+  await truncateAll(process.env.DATABASE_SERVER_FULL!)
+})
+
+describe('requireAuth account linking', () => {
+  it('does NOT relink an email already claimed by a different subject (no takeover)', async () => {
+    const victim = await createUser({ email: 'victim@example.com' })
+
+    // Attacker presents a valid token: different subject, same email.
+    const token = await jwks.signToken({ sub: 'attacker-sub-999', email: 'victim@example.com' })
+    const res = await login(token)
+
+    expect(res.statusCode).toBe(409)
+
+    // The victim's row must be untouched (still linked to the original subject).
+    const [row] = await db.select().from(users).where(eq(users.email, 'victim@example.com'))
+    expect(row.oidcSub).toBe(victim.oidcSub)
+  })
+
+  it('claims an unclaimed invite placeholder on first login', async () => {
+    const [placeholder] = await db
+      .insert(users)
+      .values({ email: 'invitee@example.com', displayName: 'invitee@example.com' })
+      .returning()
+    expect(placeholder.oidcSub).toBeNull()
+
+    const token = await jwks.signToken({ sub: 'new-sub-1', email: 'invitee@example.com', name: 'Invitee' })
+    const res = await login(token)
+
+    expect(res.statusCode).toBe(200)
+    const [row] = await db.select().from(users).where(eq(users.id, placeholder.id))
+    expect(row.oidcSub).toBe('new-sub-1')
+  })
+
+  it('creates a fresh account for a new subject + email', async () => {
+    const token = await jwks.signToken({ sub: 'fresh-sub', email: 'fresh@example.com', name: 'Fresh' })
+    const res = await login(token)
+
+    expect(res.statusCode).toBe(200)
+    const [row] = await db.select().from(users).where(eq(users.email, 'fresh@example.com'))
+    expect(row?.oidcSub).toBe('fresh-sub')
+  })
+
+  it('handles concurrent first-logins for the same email without a 500 (one wins, one 409)', async () => {
+    // Two different subjects log in simultaneously with the same email. The
+    // unique(email) constraint + onConflictDoNothing guarantee exactly one
+    // account is created (200) and the other is refused with 409 — never a 500.
+    const tokenA = await jwks.signToken({ sub: 'race-a', email: 'race@example.com' })
+    const tokenB = await jwks.signToken({ sub: 'race-b', email: 'race@example.com' })
+
+    const [a, b] = await Promise.all([login(tokenA), login(tokenB)])
+
+    expect([a.statusCode, b.statusCode].sort()).toEqual([200, 409])
+    // Exactly one row exists, owned by whichever subject won the race.
+    const rows = await db.select().from(users).where(eq(users.email, 'race@example.com'))
+    expect(rows).toHaveLength(1)
+    expect(['race-a', 'race-b']).toContain(rows[0].oidcSub)
+  })
+
+  it('still syncs email/name for an already-linked subject', async () => {
+    const user = await createUser({ email: 'old@example.com', displayName: 'Old Name' })
+    const token = await jwks.signToken({ sub: user.oidcSub, email: 'new@example.com', name: 'New Name' })
+    const res = await login(token)
+
+    expect(res.statusCode).toBe(200)
+    const [row] = await db.select().from(users).where(eq(users.oidcSub, user.oidcSub))
+    expect(row.email).toBe('new@example.com')
+    expect(row.displayName).toBe('New Name')
+  })
+
+  it('syncs only the display name when the email is unchanged', async () => {
+    const user = await createUser({ email: 'stable@example.com', displayName: 'Oude Naam' })
+    const token = await jwks.signToken({ sub: user.oidcSub, email: 'stable@example.com', name: 'Nieuwe Naam' })
+    const res = await login(token)
+
+    expect(res.statusCode).toBe(200)
+    const [row] = await db.select().from(users).where(eq(users.oidcSub, user.oidcSub))
+    expect(row.email).toBe('stable@example.com')
+    expect(row.displayName).toBe('Nieuwe Naam')
+  })
+
+  it('keeps an existing user logged in (no 500/lockout) when their new email collides with another account', async () => {
+    const a = await createUser({ email: 'a@example.com', displayName: 'A' })
+    await createUser({ email: 'b@example.com', displayName: 'B' })
+
+    // A's token now presents B's already-taken email — syncing it would violate
+    // the unique(email) constraint. A must stay logged in, keeping the old email.
+    const token = await jwks.signToken({ sub: a.oidcSub, email: 'b@example.com', name: 'A Hernoemd' })
+    const res = await login(token)
+
+    expect(res.statusCode).toBe(200)
+    const [rowA] = await db.select().from(users).where(eq(users.oidcSub, a.oidcSub))
+    expect(rowA.email).toBe('a@example.com')      // kept old email (collision avoided)
+    expect(rowA.displayName).toBe('A Hernoemd')   // display name still synced
+    const [rowB] = await db.select().from(users).where(eq(users.email, 'b@example.com'))
+    expect(rowB.displayName).toBe('B')            // other account untouched
+  })
+})

--- a/docs/account-koppeling.md
+++ b/docs/account-koppeling.md
@@ -1,0 +1,76 @@
+# Account-koppeling en identiteit
+
+Hoe een Keycloak-login wordt gekoppeld aan een lokale gebruiker in de
+boekhouding-backend (`apps/boekhouding-backend/src/middleware/auth.ts`).
+
+## Identiteit = Keycloak `sub`
+
+Een lokale `users`-rij wordt geïdentificeerd door het Keycloak-subject
+(`oidc_sub`). Dat is de stabiele, unieke identifier per Keycloak-account.
+E-mail is **veranderbare metadata** — niet de identiteit — maar is in het
+huidige datamodel wél `unique`, omdat de uitnodig-functie op e-mail leunt
+(zie hieronder).
+
+Bij elke login:
+
+1. Zoek de gebruiker op `oidc_sub`. Gevonden → ingelogd (e-mail/naam worden
+   gesynct). **Bestaande gebruikers worden dus altijd op `sub` herkend en
+   raken hun projecten nooit kwijt door deze logica.**
+2. Niet gevonden (eerste login voor dit subject) → zie "Eerste login".
+
+## Uitnodigen per e-mail (waarom e-mail uniek is)
+
+Een eigenaar kan een collega per **e-mailadres** aan een project toevoegen
+vóórdat die ooit heeft ingelogd. Daarvoor maakt `routes/members.ts` een
+**placeholder-rij** aan: een `users`-rij met het e-mailadres en `oidc_sub =
+NULL`. Bij de eerste login van die persoon wordt de placeholder geclaimd
+(de `oidc_sub` wordt ingevuld).
+
+## Veiligheidsregels bij eerste login
+
+- **Claim alleen een onbeheerde placeholder.** De placeholder wordt geclaimd
+  via `UPDATE ... WHERE email = ? AND oidc_sub IS NULL` (atomair). Een rij die
+  al aan een ander subject is gekoppeld wordt **nooit** overschreven.
+- **Geen account-takeover.** Bestaat er al een *gekoppeld* account met dit
+  e-mailadres, dan wordt niet herkoppeld maar **409** geretourneerd. Zo kan een
+  token met een ander subject maar hetzelfde e-mailadres niet stilzwijgend
+  andermans account (incl. projecten/DPIA-data) overnemen.
+- **Geen lockout bij e-mail-sync.** Wijzigt het e-mailadres van een bestaande
+  gebruiker in Keycloak naar één die een andere rij al heeft, dan wordt het
+  e-mailadres **niet** gesynct (de oude waarde blijft staan, er wordt gelogd) —
+  de gebruiker blijft inloggen i.p.v. een unique-constraint-fout te krijgen.
+
+## E-mailverificatie (`email_verified`)
+
+Keycloak levert de standaard OIDC-claim `email_verified` in het token. We
+**dwingen die bewust niet af**:
+
+- SSO Rijk levert in de praktijk al een geverifieerd e-mailadres.
+- Onvoorwaardelijk afdwingen zou gebruikers buitensluiten bij IdP's die de
+  claim weglaten.
+- Daarom is er geen ongebruikte config/gate voor in de code (eerder wel
+  overwogen, weer verwijderd om geen dode code mee te dragen).
+
+**Heroverweeg** dit als er een auth-pad bijkomt náást SSO Rijk (lokale
+Keycloak-accounts, self-registration, een tweede broker) waar e-mail niet
+gegarandeerd uniek/geverifieerd is — of bij een toekomstige invitations-flow
+(zie #335), waar het claimen van een uitnodiging idealiter `email_verified` vereist.
+
+> De bron-IdP (bijv. "komt van SSO Rijk") is **niet** uit de standaardclaims af
+> te leiden. Dat zou een Keycloak protocol-mapper vergen die bijv. een `idp`-
+> claim toevoegt.
+
+## Bekende randgevallen
+
+- **`sub`-wijziging** (realm-migratie, account opnieuw aangemaakt, her-
+  federatie): zelfde persoon, zelfde e-mail, nieuw subject → wordt niet op
+  `sub` gevonden en de e-mail matcht een gekoppelde rij → **409**. Vereist
+  admin-interventie (de `oidc_sub` van de bestaande rij bijwerken). Komt bij
+  stabiele SSO-Rijk-accounts niet voor in normaal bedrijf.
+- **E-mailhergebruik** (adres van een vertrekkende collega later aan iemand
+  anders toegewezen): de nieuwe persoon (nieuw `sub`) erft **niet** het oude
+  account → 409 of, bij een niet-botsend e-mailadres, een vers account.
+
+> Een meer account-gebaseerde invite-flow (eerst lookup naar bestaande accounts;
+> uitnodigingen los van de gebruikersidentiteit), die deze randgevallen wegneemt,
+> staat als verbeterrichting in #335.


### PR DESCRIPTION
## fix(security): robuuste account-koppeling — geen takeover, geen lockout (F5)

Adresseert bevinding **F5** uit de security-audit, apart gehouden van de overige hardening (`fix/security-hardening`) omdat dit gedragswijzigingen in de auth-flow betreft. Gerebased op de huidige `experimenteel/samenwerken` (100%-coverage-gate).

## Het probleem
`requireAuth` koppelde een Keycloak-login aan een lokale user via `insert(...).onConflictDoUpdate({ target: users.email, set: { oidcSub } })`. Bij **elke** e-mailbotsing werd de `oidcSub` van de bestaande rij overschreven — een token met een **ander subject maar hetzelfde e-mailadres** nam zo stilzwijgend het account (incl. projectlidmaatschappen + DPIA-data) over.

## De fix
- **Identiteit verankerd op `oidc_sub`.** Een invite-placeholder (`oidc_sub IS NULL`) wordt alleen geclaimd zolang die onbeheerd is (atomair `UPDATE ... WHERE email = ? AND oidc_sub IS NULL`). Een reeds gekoppeld account wordt **nooit** overschreven → **409**.
- Nieuwe accounts via `INSERT ... ON CONFLICT (email) DO NOTHING` → ook een gelijktijdige first-login-race geeft deterministisch 409, nooit een 500.
- **Geen lockout bij e-mail-sync.** Wijzigt het e-mailadres van een bestaande gebruiker in Keycloak naar één die een andere rij al heeft, dan wordt de e-mail niet gesynct (oude waarde blijft, wordt gelogd) i.p.v. een unique-violation/500. Bestaande gebruikers (gevonden op `sub`) raken dus nooit buitengesloten.
- **`email_verified` wordt bewust niet afgedwongen** (SSO Rijk levert dit al; afdwingen riskeert lockout bij IdP's die de claim weglaten). Geen ongebruikte config/gate in de code. Afweging + toekomstrichting (identiteit puur op `sub` + aparte `invitations`-tabel, à la MinBZK/amt) staan in **`docs/account-koppeling.md`**.

## Relatie tot bestaande gebruikers
De lookup gaat op `oidc_sub`; dat pad is ongewijzigd. **Bij deploy raakt geen enkele huidige gebruiker zijn toegang kwijt** — de fix wijzigt alleen het pad "eerste login voor een nieuw subject". Enige randgeval: een `sub`-wijziging (realm-migratie / account opnieuw aangemaakt) van een bestaande gebruiker geeft 409 en vergt admin-interventie; dat komt bij stabiele SSO-Rijk-accounts niet voor in normaal bedrijf (zie doc).

## ⚠️ Breaking change
E-mail/subject-botsingen die voorheen stil "lukten" (door overname) geven nu **409**. De legitieme uitnodigingsflow verandert niet.

## Tests
Account-linking integratietests (echte Postgres + echte JWT's): takeover-weigering, placeholder-claim, nieuw account, concurrent first-login race (200+409, nooit 500), e-mail/naam-sync, **e-mail-sync-botsing zonder lockout**, name-only-sync. De bestaande cov-test die de oude overschrijf-flow als 200 assertte is bijgewerkt naar 409. **Backend 352 tests + 100%-coverage-gate groen.**

## Relatie tot `fix/security-hardening`
Onafhankelijk (beide vanaf `experimenteel/samenwerken`); kunnen in willekeurige volgorde mergen. Lichte overlap in `config.ts` → mogelijk triviaal conflict bij de tweede merge.
