### PR TITLE
invulhulpen.rijksapp.nl als hoofddomein + migratieplan

### DIFF
--- a/apps/boekhouding-backend/src/app.ts
+++ b/apps/boekhouding-backend/src/app.ts
@@ -47,7 +47,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
         version: API_VERSION,
         contact: {
           name: 'Assessment Boekhouding — MinBZK',
-          url: 'https://assessments.rijksapp.nl',
+          url: config.publicUrl,
           email: 'RIG@rijksoverheid.nl',
         },
       },

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -12,14 +12,20 @@ function parseCorsOrigin(): string | string[] {
   return raw
 }
 
+const corsOrigin = parseCorsOrigin()
+
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
   cors: {
-    origin: parseCorsOrigin(),
+    origin: corsOrigin,
     credentials: true,
   },
+  // Public-facing base URL of this deployment. ZAD injects PUBLIC_HOST per
+  // deployment (including per review branch), so this stays correct everywhere
+  // instead of hardcoding one environment. Used for OpenAPI metadata.
+  publicUrl: Array.isArray(corsOrigin) ? corsOrigin[0] : corsOrigin,
   keycloak: {
     issuer: `${oidcUrl}/realms/${oidcRealm}`,
     jwksUri: `${oidcInternalUrl}/realms/${oidcRealm}/protocol/openid-connect/certs`,

--- a/apps/boekhouding-backend/test/cov/app.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/app.cov.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import type { FastifyInstance } from 'fastify'
 import { buildApp, API_VERSION } from '../../src/app.js'
+import { config } from '../../src/config.js'
 
 let app: FastifyInstance
 
@@ -100,6 +101,7 @@ describe('static utility routes', () => {
     const doc = res.json()
     expect(doc.info.title).toBe('Assessment Boekhouding API')
     expect(doc.info.version).toBe(API_VERSION)
+    expect(doc.info.contact.url).toBe(config.publicUrl)
   })
 
   it('serves the Swagger UI at /api/docs', async () => {

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -51,6 +51,7 @@ describe('config — defaults when no env vars are set', () => {
     )
     expect(config.cors.origin).toBe('http://localhost:5174')
     expect(config.cors.credentials).toBe(true)
+    expect(config.publicUrl).toBe('http://localhost:5174')
     expect(config.keycloak.issuer).toBe('http://localhost:8080/realms/assessment-boekhouding')
     expect(config.keycloak.jwksUri).toBe(
       'http://localhost:8080/realms/assessment-boekhouding/protocol/openid-connect/certs',
@@ -123,6 +124,7 @@ describe('config — parseCorsOrigin', () => {
       'https://b.example.com',
       'https://c.example.com',
     ])
+    expect(config.publicUrl).toBe('https://a.example.com')
   })
 
   it('drops empty segments via filter(Boolean) (trailing comma / blanks)', async () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,9 +1,14 @@
-# Deployment op ZAD (assessments.rijksapp.nl)
+# Deployment op ZAD (invulhulpen.rijksapp.nl)
+
+De applicatie draait op ZAD onder het hoofddomein **invulhulpen.rijksapp.nl**.
+Het oude domein **assessments.rijksapp.nl** is een HTTP 301-redirect naar het
+nieuwe domein (een aparte `haproxy-redirect`-deployment), zodat bestaande links
+blijven werken.
 
 ## Architectuur
 
 ```
-URL: https://assessments.rijksapp.nl
+URL: https://invulhulpen.rijksapp.nl
 │
 ├── /                              → ZAD ingress → frontend (nginx:8080)
 │   ├── /                          → Vue SPA
@@ -12,7 +17,14 @@ URL: https://assessments.rijksapp.nl
 │
 └── /api                           → ZAD ingress → api (node:3000)
                                      Fastify REST API
+
+URL: https://assessments.rijksapp.nl   (legacy)
+└── *                              → 301 → https://invulhulpen.rijksapp.nl
 ```
+
+De app is host-agnostisch: de frontend roept de API same-origin/relatief aan
+(`/api/...`), Keycloak-redirects worden afgeleid van `window.location.origin` en
+de Content-Security-Policy is host-relatief.
 
 ## Containers lokaal bouwen
 
@@ -31,6 +43,24 @@ podman run --rm frontend sh -c \
 
 ZAD ondersteunt geen init containers of jobs. De backend container draait migraties automatisch bij het starten (`node dist/db/migrate.js && node dist/index.js`). Drizzle migraties zijn idempotent.
 
+## Domein en authenticatie: door ZAD beheerd
+
+Het webadres (domein) van een deployment stel je in via de ZAD Operations
+Manager: project details → deployments → deployment kiezen → blok
+*Deployment: <naam>* → **Webadres**.
+
+Op basis van dat webadres regelt ZAD de rest automatisch bij elke reconcile;
+er hoeven nergens URL's met de hand gezet te worden:
+
+- **Keycloak**: ZAD beheert per deployment een eigen client (`{project}-{deployment}`
+  + een `-public` client voor `keycloak-js`). De `redirectUris` (`https://<host>/*`)
+  en `webOrigins` worden afgeleid van het webadres en automatisch bijgewerkt
+  zodra ze afwijken. Bij een domeinwissel worden de oude entries dus vervangen.
+- **`PUBLIC_HOST`**: wordt afgeleid van het webadres en bepaalt zowel de CORS-origin
+  (`config.cors.origin`) als de OpenAPI `contact.url` (`config.publicUrl`).
+- **OIDC-variabelen** (`OIDC_URL`, `OIDC_REALM`, `OIDC_PUBLIC_CLIENT_ID`, ...) worden
+  door ZAD Keycloak geïnjecteerd.
+
 ## Environment variabelen
 
 ### Frontend (runtime via `config.json`)
@@ -46,19 +76,21 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 
 ### Backend (runtime)
 
-| Variabele              | Default                      | ZAD                           |
-|------------------------|------------------------------|-------------------------------|
-| `DATABASE_SERVER_FULL` | `postgresql://...@localhost` | Auto-inject door ZAD          |
-| `OIDC_URL`             | `http://localhost:8080`      | Auto-inject door ZAD Keycloak |
-| `OIDC_REALM`           | `assessment-boekhouding`     | Auto-inject door ZAD Keycloak |
-| `OIDC_CLIENT_ID`       | `boekhouding-frontend`       | Auto-inject door ZAD Keycloak |
-| `PUBLIC_HOST`          | —                            | Auto-inject door ZAD (→ CORS) |
-| `PORT`                 | `3000`                       | Default is correct            |
-| `HOST`                 | `0.0.0.0`                    | Default is correct            |
+| Variabele              | Default                      | ZAD                                       |
+|------------------------|------------------------------|-------------------------------------------|
+| `DATABASE_SERVER_FULL` | `postgresql://...@localhost` | Auto-inject door ZAD                      |
+| `OIDC_URL`             | `http://localhost:8080`      | Auto-inject door ZAD Keycloak             |
+| `OIDC_REALM`           | `assessment-boekhouding`     | Auto-inject door ZAD Keycloak             |
+| `OIDC_CLIENT_ID`       | `boekhouding-frontend`       | Auto-inject door ZAD Keycloak             |
+| `PUBLIC_HOST`          | —                            | Auto-inject (volgt webadres → CORS + OpenAPI `contact.url`) |
+| `PORT`                 | `3000`                       | Default is correct                        |
+| `HOST`                 | `0.0.0.0`                    | Default is correct                        |
 
 ### Niet nodig op ZAD
 
-- `CORS_ORIGIN` — `PUBLIC_HOST` wordt automatisch gebruikt als fallback
+- `CORS_ORIGIN` — `PUBLIC_HOST` wordt automatisch gebruikt als fallback. Zet dit
+  alleen handmatig (komma-gescheiden) als de app tijdelijk via meerdere hostnames
+  bereikbaar moet zijn.
 - `API_URL` — alleen voor Vite dev server proxy
 - `NODE_ENV` — optioneel, Fastify gebruikt het voor logging format
 
@@ -73,6 +105,10 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 | `release-and-deploy.yaml`| Push naar `main`           | Release naar GitHub Pages        |
 | `test.yaml`              | Push/PR naar `main`        | Type-check en tests              |
 
+De deploy-workflow zet uitsluitend de container-*images* van de componenten
+(`[{name, image}]` via `zad-actions/deploy`). Domeinen, redirects en env-vars
+worden in de ZAD Operations Manager beheerd, niet in de workflow.
+
 ### GHCR images
 
 Images staan onder `ghcr.io/minbzk/par-dpia-form/dev/`:
@@ -84,12 +120,19 @@ Images staan onder `ghcr.io/minbzk/par-dpia-form/dev/`:
 
 ## ZAD configuratie
 
-| Component  | Image                                              | Poort | Pad    | Services                          |
-|------------|----------------------------------------------------|-------|--------|-----------------------------------|
-| `frontend` | `ghcr.io/minbzk/par-dpia-form/dev/frontend:latest` | 8080  | `/`    | `publish-on-web`                  |
-| `api`      | `ghcr.io/minbzk/par-dpia-form/dev/backend:latest`  | 3000  | `/api` | `postgresql-database`, `keycloak` |
+De productie-deployment bestaat uit twee componenten:
+
+| Component  | Image                                              | Poort | Pad    | Domein                    | Services                          |
+|------------|----------------------------------------------------|-------|--------|---------------------------|-----------------------------------|
+| `frontend` | `ghcr.io/minbzk/par-dpia-form/dev/frontend:latest` | 8080  | `/`    | `invulhulpen.rijksapp.nl` | `publish-on-web`                  |
+| `api`      | `ghcr.io/minbzk/par-dpia-form/dev/backend:latest`  | 3000  | `/api` | `invulhulpen.rijksapp.nl` | `publish-on-web`, `postgresql-database`, `keycloak` |
 
 Configuratie via de ZAD Operations Manager UI.
+
+De 301-redirect van het oude domein `assessments.rijksapp.nl` is **optioneel** en
+**geen onderdeel van de productie-deployment**: het is een losse, eigen
+ZAD-deployment met één `haproxy-redirect`-component die los van productie beheerd
+en verwijderd kan worden.
 
 ## Nginx security headers
 


### PR DESCRIPTION
## Doel

De volledige collaboratieve app draaien op **invulhulpen.rijksapp.nl** als hoofddomein. `assessments.rijksapp.nl` wordt (optioneel) een 301-redirect ernaartoe.

## Wijzigingen in deze PR

- **`apps/boekhouding-backend/src/{config,app}.ts`** — OpenAPI `contact.url` is niet langer hardgecodeerd, maar afgeleid van `config.publicUrl` (uit `PUBLIC_HOST`). Klopt zo automatisch per deployment én per review-branch. Frontend en api hebben beide de `publish-on-web`-service en krijgen `PUBLIC_HOST` geïnjecteerd.
- **`docs/deployment.md`** — bijgewerkt naar invulhulpen.rijksapp.nl als hoofddomein; documenteert dat ZAD de Keycloak redirect URIs/web origins en `PUBLIC_HOST` afleidt van het webadres.
- **tests** — dekking voor `config.publicUrl` en de dynamische `contact.url`.

Geen image-, nginx-, CSP- of workflow-wijziging.

## Release / uitrol-stappen (ZAD)

> ⚠️ Volgorde: de redirect kan pas **ná** de Webadres-wissel (anders is de oude URL "in gebruik").

- [x] PR reviewen en mergen naar `experimenteel/samenwerken`
- [x] **Webadres** van de deployment aanpassen naar `invulhulpen.rijksapp.nl` (ZAD → project → deployments → deployment → blok *Deployment: <naam>* → **Webadres**) en redeploye/reconcile. ZAD synct hierbij automatisch Keycloak (redirect URIs + web origins), `PUBLIC_HOST` en daarmee CORS + de OpenAPI `contact.url`.
- [x] Verifiëren: login op invulhulpen.rijksapp.nl ✓, `/invulhulpen/` standalone ✓, `/api` ✓
- [x] (Optioneel) **redirect oud domein** opzetten — losse, eigen ZAD-deployment (apart van productie) met één `haproxy-redirect`-component:
  - image `ghcr.io/rijksictgilde/haproxy-redirect:2026.06.6` (upstream, dagelijks gepatcht)
  - env `TARGET_URL=https://invulhulpen.rijksapp.nl` (2e blok "eigen omgevingsvariabelen"; 1e is "Aliassen")
  - publiceren onder `assessments.rijksapp.nl` (pas ná de Webadres-wissel)
- [x] Collega's die nu op `assessments.rijksapp.nl` werken informeren over het nieuwe hoofddomein