### PR TITLE
Python-tooling: ruff + uv + dependabot + pre-commit (#321)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      uv-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -108,15 +108,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: '3.12'
-      - name: Install Python dependencies
-        run: pip install pyyaml
+          python-version: '3.14'
+          enable-cache: true
       - name: Sync Algoritmekader definitions
         run: |
-          python script/convert_definitions_from_algoritmekader.py --output sources/begrippenkader_iama.yaml
+          uv run --frozen --no-dev python script/convert_definitions_from_algoritmekader.py --output sources/begrippenkader_iama.yaml
       - name: Check for changes
         id: git-check
         run: |

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -19,30 +19,30 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-
-      - name: Install Python dependencies
-        run: pip install pyyaml jsonschema
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
 
       - name: Generate JSON from YAML definitions
         run: |
           mkdir -p sources/generated
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/prescan.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/PreScanDPIA.json \
             --output-md docs/questions/questions_prescan_DPIA.md
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/dpia.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/DPIA.json \
             --output-md docs/questions/questions_DPIA.md
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/iama.yaml \
             --begrippen-yaml sources/begrippenkader_iama.yaml \

--- a/.github/workflows/build-standalone.yaml
+++ b/.github/workflows/build-standalone.yaml
@@ -18,31 +18,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-
-      - name: Install Python dependencies
-        run: pip install pyyaml jsonschema
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
 
       - name: Generate JSON from YAML definitions
         run: |
           mkdir -p sources/generated
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/prescan.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/PreScanDPIA.json \
             --output-md docs/questions/questions_prescan_DPIA.md
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/dpia.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/DPIA.json \
             --output-md docs/questions/questions_DPIA.md
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/iama.yaml \
             --begrippen-yaml sources/begrippenkader_iama.yaml \

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -1,0 +1,40 @@
+name: Pre-commit autoupdate
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          commit-message: "chore: pre-commit autoupdate"
+          branch: chore/pre-commit-autoupdate
+          delete-branch: true
+          base: experimenteel/samenwerken
+          title: "chore: pre-commit autoupdate"
+          body: |
+            Wekelijkse automatische update van de pre-commit hook-versies via
+            `pre-commit autoupdate`.

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release-and-deploy.yaml
+++ b/.github/workflows/release-and-deploy.yaml
@@ -28,31 +28,31 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-
-      - name: Install Python dependencies
-        run: pip install pyyaml jsonschema
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
 
       - name: Generate JSON from YAML definitions
         run: |
           mkdir -p sources/generated
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/prescan.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/PreScanDPIA.json \
             --output-md docs/questions/questions_prescan_DPIA.md
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/dpia.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/DPIA.json \
             --output-md docs/questions/questions_DPIA.md
 
-          python script/run_all.py \
+          uv run --frozen --no-dev python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/iama.yaml \
             --begrippen-yaml sources/begrippenkader_iama.yaml \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,21 +44,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
+
       - name: Generate assessment JSON sources
         run: |
-          pip install pyyaml jsonschema pytest
           mkdir -p sources/generated
-          python script/run_all.py \
+          uv run --frozen python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/prescan.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/PreScanDPIA.json
-          python script/run_all.py \
+          uv run --frozen python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/dpia.yaml \
             --begrippen-yaml sources/begrippenkader_dpia.yaml \
             --output-json sources/generated/DPIA.json
-          python script/run_all.py \
+          uv run --frozen python script/run_all.py \
             --schema schemas/assessment-definition.v2.schema.json \
             --source sources/iama.yaml \
             --begrippen-yaml sources/begrippenkader_iama.yaml \
@@ -66,7 +71,7 @@ jobs:
             --definitions-once-per-page
 
       - name: Run Python pipeline tests
-        run: pytest script/tests -q
+        run: uv run --frozen pytest script/tests -q
 
       - name: Type check backend
         run: cd apps/boekhouding-backend && npx tsc --noEmit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -11,10 +11,14 @@ repos:
     -   id: check-added-large-files
     -   id: check-merge-conflict
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.15.16
     hooks:
         - id: ruff
         - id: ruff-format
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+        - id: gitleaks
 
 ci:
   autofix_prs: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "par-form-scripts"
+version = "0" # placeholder: required by PEP 621, never built or published
+description = "Build-time Python pipeline for the assessment sources (script/)."
+requires-python = ">=3.14"
+dependencies = [
+    "pyyaml>=6.0.3",
+    "jsonschema>=4.26.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]
+
+[tool.uv]
+package = false
+
+[tool.ruff]
+line-length = 100
+target-version = "py314"
+# .claude holds Claude tooling, not project code, and isn't in ruff's defaults.
+extend-exclude = [".claude"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "S", "SIM", "C4", "RUF", "PTH", "PT", "A", "T20", "LOG", "G"]
+
+[tool.ruff.lint.per-file-ignores]
+"script/tests/**" = ["S101"]  # asserts are expected in tests

--- a/script/convert_definitions_from_algoritmekader.py
+++ b/script/convert_definitions_from_algoritmekader.py
@@ -6,28 +6,38 @@ and converts the markdown abbreviation definitions (*[term]: definition) into a
 YAML file compatible with the definition_enricher.py pipeline.
 
 Usage:
-    python script/convert_definitions_from_algoritmekader.py --output sources/begrippenkader-iama.yaml
-    python script/convert_definitions_from_algoritmekader.py --input begrippenlijst.md --output sources/begrippenkader-iama.yaml
+    python script/convert_definitions_from_algoritmekader.py \
+        --output sources/begrippenkader-iama.yaml
+    python script/convert_definitions_from_algoritmekader.py \
+        --input begrippenlijst.md --output sources/begrippenkader-iama.yaml
 """
 
 import argparse
+import logging
 import re
 import sys
 import urllib.request
 from copy import deepcopy
+from pathlib import Path
 
 import yaml
 
-BEGRIPPENLIJST_URL = "https://raw.githubusercontent.com/MinBZK/Algoritmekader/main/includes/begrippenlijst.md"
+logger = logging.getLogger(__name__)
+
+BEGRIPPENLIJST_URL = (
+    "https://raw.githubusercontent.com/MinBZK/Algoritmekader/main/includes/begrippenlijst.md"
+)
 
 
 def download_begrippenlijst(url: str) -> str:
     """Download the begrippenlijst markdown from the Algoritmekader repository."""
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-HTTPS URL: {url}")
     try:
-        with urllib.request.urlopen(url) as response:
+        with urllib.request.urlopen(url) as response:  # noqa: S310 (scheme checked above)
             return response.read().decode("utf-8")
     except Exception as e:
-        print(f"Error downloading begrippenlijst from {url}: {e}")
+        logger.error("Error downloading begrippenlijst from %s: %s", url, e)
         sys.exit(1)
 
 
@@ -49,7 +59,7 @@ def parse_markdown_definitions(content: str) -> dict[str, str]:
 def read_yaml_definitions(file_path: str) -> list[dict[str, str]]:
     """Read existing YAML definitions file."""
     try:
-        with open(file_path, encoding="utf-8") as f:
+        with Path(file_path).open(encoding="utf-8") as f:
             data = yaml.safe_load(f)
             if data and "definitions" in data:
                 return data["definitions"]
@@ -74,13 +84,13 @@ def upsert_definitions(
         if term in new_defs:
             if item["definition"] != new_defs[term]:
                 result[i]["definition"] = new_defs[term]
-                print(f"Updated definition for: {term}")
+                logger.info("Updated definition for: %s", term)
             updated_terms.add(term)
 
     for term, definition in new_defs.items():
         if term not in updated_terms:
             result.append({"term": term, "definition": definition})
-            print(f"Added new definition for: {term}")
+            logger.info("Added new definition for: %s", term)
 
     return result
 
@@ -88,7 +98,7 @@ def upsert_definitions(
 def write_yaml_definitions(definitions: list[dict[str, str]], output_path: str):
     """Write definitions to YAML file."""
     output_data = {"definitions": definitions}
-    with open(output_path, "w", encoding="utf-8") as f:
+    with Path(output_path).open("w", encoding="utf-8") as f:
         yaml.dump(output_data, f, allow_unicode=True, sort_keys=False, indent=2)
 
 
@@ -109,30 +119,29 @@ def main():
 
     if args.input:
         try:
-            with open(args.input, encoding="utf-8") as f:
+            with Path(args.input).open(encoding="utf-8") as f:
                 markdown_content = f.read()
         except FileNotFoundError:
-            print(f"Error: Input file '{args.input}' not found")
+            logger.error("Error: Input file '%s' not found", args.input)
             sys.exit(1)
     else:
-        print(f"Downloading begrippenlijst from {BEGRIPPENLIJST_URL}...")
+        logger.info("Downloading begrippenlijst from %s...", BEGRIPPENLIJST_URL)
         markdown_content = download_begrippenlijst(BEGRIPPENLIJST_URL)
 
     new_definitions = parse_markdown_definitions(markdown_content)
-    print(f"Parsed {len(new_definitions)} definitions from markdown")
+    logger.info("Parsed %s definitions from markdown", len(new_definitions))
 
     existing_definitions = read_yaml_definitions(args.output)
     if existing_definitions:
-        print(
-            f"Found {len(existing_definitions)} existing definitions in {args.output}"
-        )
+        logger.info("Found %s existing definitions in %s", len(existing_definitions), args.output)
 
     updated_definitions = upsert_definitions(existing_definitions, new_definitions)
 
     write_yaml_definitions(updated_definitions, args.output)
 
-    print(f"\nTotal definitions in output: {len(updated_definitions)}")
+    logger.info("\nTotal definitions in output: %s", len(updated_definitions))
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     main()

--- a/script/definition_enricher.py
+++ b/script/definition_enricher.py
@@ -1,18 +1,36 @@
 #!/usr/bin/env python3
-import yaml
-import json
-import re
+"""Convert assessment YAML files to JSON and inject term definitions.
+
+Injects terms from the begrippenkader as HTML tags for definitions.
+
+Term matching priority:
+1. Main terms (longest first)
+2. Alternative spellings (longest first)
+3. Alternative terms (longest first)
+
+Matching is case-insensitive, but the original casing in the text is preserved.
+Terms already inside an existing ``<span class="aiv-definition">`` tag are skipped
+to avoid nested definition spans.
+"""
+
 import argparse
+import json
+import logging
+import re
 from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def load_yaml(file_path):
     """Load YAML file and return its content as a dictionary."""
     try:
-        with open(file_path, "r", encoding="utf-8") as file:
+        with Path(file_path).open(encoding="utf-8") as file:
             return yaml.safe_load(file)
     except Exception as e:
-        print(f"Fout bij het inlezen van {file_path}: {str(e)}")
+        logger.error("Fout bij het inlezen van %s: %s", file_path, e)
         raise
 
 
@@ -193,14 +211,15 @@ def inject_terms(text, term_map, already_matched_terms=None):
         for pos in range(start, end):
             matched_positions.add(pos)
 
-    # Mark positions inside any HTML tag (<...>) so terms in attributes (e.g. href URLs) are not enriched
+    # Mark positions inside any HTML tag (<...>) so terms in attributes
+    # (e.g. href URLs) are not enriched.
     for match in re.finditer(r"<[^>]+>", text, re.DOTALL):
         start, end = match.span()
         for pos in range(start, end):
             matched_positions.add(pos)
 
     # Process each term list in order
-    for term_list_index, term_list in enumerate(all_term_lists):
+    for _term_list_index, term_list in enumerate(all_term_lists):
         if not term_list:
             continue
 
@@ -254,7 +273,10 @@ def inject_terms(text, term_map, already_matched_terms=None):
                     continue
 
                 # Create the HTML with the original matched text
-                term_html = f'<span class="aiv-definition">{matched_text}<span class="aiv-definition-text">{term_data["definition"]}'
+                term_html = (
+                    f'<span class="aiv-definition">{matched_text}'
+                    f'<span class="aiv-definition-text">{term_data["definition"]}'
+                )
 
                 # Add toelichting if available
                 toelichting = term_data.get("toelichting", "")
@@ -266,30 +288,28 @@ def inject_terms(text, term_map, already_matched_terms=None):
                 if voorbeelden:
                     if isinstance(voorbeelden, list):
                         voorbeelden_text = "; ".join(voorbeelden)
-                        term_html += (
-                            f"\n<br><strong>Voorbeeld(en)</strong>: {voorbeelden_text}"
-                        )
+                        term_html += f"\n<br><strong>Voorbeeld(en)</strong>: {voorbeelden_text}"
                     elif isinstance(voorbeelden, str):
-                        term_html += (
-                            f"\n<br><strong>Voorbeeld(en)</strong>: {voorbeelden}"
-                        )
+                        term_html += f"\n<br><strong>Voorbeeld(en)</strong>: {voorbeelden}"
 
                 # Add alternative term information
-                if term_data.get("is_alternatief_term", False) and term_data.get(
-                    "hoofdterm"
-                ):
-                    term_html += f"\n<br><i>Dit is een alternatieve term van {term_data.get('hoofdterm')}</i>"
+                if term_data.get("is_alternatief_term", False) and term_data.get("hoofdterm"):
+                    term_html += (
+                        f"\n<br><i>Dit is een alternatieve term van "
+                        f"{term_data.get('hoofdterm')}</i>"
+                    )
 
-                if term_data.get("is_alternatief_spelling", False) and term_data.get(
-                    "hoofdterm"
-                ):
-                    term_html += f"\n<br><i>Dit is een alternatieve spelling van {term_data.get('hoofdterm')}</i>"
+                if term_data.get("is_alternatief_spelling", False) and term_data.get("hoofdterm"):
+                    term_html += (
+                        f"\n<br><i>Dit is een alternatieve spelling van "
+                        f"{term_data.get('hoofdterm')}</i>"
+                    )
 
                 # Add plural form information - NEW CODE
-                if term_data.get("is_meervoudsvorm", False) and term_data.get(
-                    "hoofdterm"
-                ):
-                    term_html += f"\n<br><i>Dit is een meervoudsvorm van {term_data.get('hoofdterm')}</i>"
+                if term_data.get("is_meervoudsvorm", False) and term_data.get("hoofdterm"):
+                    term_html += (
+                        f"\n<br><i>Dit is een meervoudsvorm van {term_data.get('hoofdterm')}</i>"
+                    )
 
                 term_html += "</span></span>"
 
@@ -359,18 +379,14 @@ def process_dpia(dpia_data, term_map, once_per_page=False):
             result[key] = inject_terms(value, term_map)
         elif key == "tasks" and isinstance(value, list):
             # Process tasks with level 0
-            result[key] = process_tasks(
-                value, term_map, level=0, once_per_page=once_per_page
-            )
+            result[key] = process_tasks(value, term_map, level=0, once_per_page=once_per_page)
         else:
             result[key] = value
 
     return result
 
 
-def process_tasks(
-    tasks, term_map, level=0, already_matched_terms=None, once_per_page=False
-):
+def process_tasks(tasks, term_map, level=0, already_matched_terms=None, once_per_page=False):
     """
     Process tasks recursively based on their level:
     - At level 0 (top level): Only process description
@@ -402,10 +418,7 @@ def process_tasks(
 
         # At the top level each task (deel) starts fresh: a set enables
         # once-per-page enrichment, None enriches every occurrence.
-        if level == 0:
-            page_matched = set() if once_per_page else None
-        else:
-            page_matched = already_matched_terms
+        page_matched = (set() if once_per_page else None) if level == 0 else already_matched_terms
 
         # For top level (level 0), only process description
         if level == 0:
@@ -416,9 +429,7 @@ def process_tasks(
         # For deeper levels, process both task and description
         else:
             if "task" in task_copy and isinstance(task_copy["task"], str):
-                task_copy["task"] = inject_terms(
-                    task_copy["task"], term_map, page_matched
-                )
+                task_copy["task"] = inject_terms(task_copy["task"], term_map, page_matched)
             if "description" in task_copy and isinstance(task_copy["description"], str):
                 task_copy["description"] = inject_terms(
                     task_copy["description"], term_map, page_matched
@@ -430,17 +441,11 @@ def process_tasks(
         if isinstance(task_type, str):
             is_option_task = task_type in ["checkbox_option", "radio_option"]
         elif isinstance(task_type, list):
-            is_option_task = any(
-                t in ["checkbox_option", "radio_option"] for t in task_type
-            )
+            is_option_task = any(t in ["checkbox_option", "radio_option"] for t in task_type)
         else:
             is_option_task = False
 
-        if (
-            is_option_task
-            and "options" in task_copy
-            and isinstance(task_copy["options"], list)
-        ):
+        if is_option_task and "options" in task_copy and isinstance(task_copy["options"], list):
             options_copy = []
             for option in task_copy["options"]:
                 option_copy = option.copy()
@@ -464,8 +469,7 @@ def process_tasks(
                 if (
                     isinstance(dependency_copy, dict)
                     and dependency_copy.get("type") == "conditional"
-                    and dependency_copy.get("condition", {}).get("operator")
-                    == "contains"
+                    and dependency_copy.get("condition", {}).get("operator") == "contains"
                 ):
                     # Include the value in the processing if it exists
                     condition = dependency_copy.get("condition", {}).copy()
@@ -504,9 +508,7 @@ class DefinitionEnricher:
         """
         self.script_dir = script_dir if script_dir else Path(__file__).parent
 
-    def enrich_and_export(
-        self, source_path, begrippen_yaml_path, output_path, once_per_page=False
-    ):
+    def enrich_and_export(self, source_path, begrippen_yaml_path, output_path, once_per_page=False):
         """
         Enrich a DPIA YAML file with definitions and export as JSON.
 
@@ -525,16 +527,16 @@ class DefinitionEnricher:
         output_dir = Path(output_path).parent
         if not output_dir.exists():
             output_dir.mkdir(parents=True, exist_ok=True)
-            print(f"Output directory created: {output_dir}")
+            logger.info("Output directory created: %s", output_dir)
 
         # Load the YAML files
-        print(f"Reading input YAML from: {source_path}")
+        logger.info("Reading input YAML from: %s", source_path)
         dpia_data = load_yaml(source_path)
 
-        print(f"Reading begrippenkader from: {begrippen_yaml_path}")
+        logger.info("Reading begrippenkader from: %s", begrippen_yaml_path)
         begrippenkader_data = load_yaml(begrippen_yaml_path)
 
-        print("YAML files successfully loaded.")
+        logger.info("YAML files successfully loaded.")
 
         # Create a map of terms to their definitions
         term_map = create_term_map(begrippenkader_data)
@@ -555,22 +557,22 @@ class DefinitionEnricher:
         # Determine if it's a DPIA or PreScan based on the filename
         file_type = "PrescanDPIA" if "prescan" in str(source_path).lower() else "DPIA"
         mode = "once-per-page" if once_per_page else "every occurrence"
-        print(f"Processing {file_type} data (definition mode: {mode})...")
+        logger.info("Processing %s data (definition mode: %s)...", file_type, mode)
 
         # Process the DPIA data and inject terms
         processed_dpia = process_dpia(dpia_data, term_map, once_per_page)
 
-        print(f"{file_type} data processed and terms injected.")
+        logger.info("%s data processed and terms injected.", file_type)
 
         # Convert to JSON
         json_output = json.dumps(processed_dpia, indent=2, ensure_ascii=False)
 
         # Write the output to a file
-        print(f"Writing output to: {output_path}")
-        with open(output_path, "w", encoding="utf-8") as file:
+        logger.info("Writing output to: %s", output_path)
+        with Path(output_path).open("w", encoding="utf-8") as file:
             file.write(json_output)
 
-        print(f"Successfully enriched and exported to: {output_path}")
+        logger.info("Successfully enriched and exported to: %s", output_path)
 
         return processed_dpia
 
@@ -608,33 +610,12 @@ def main():
         )
 
     except Exception as e:
-        print(f"Er is een fout opgetreden: {str(e)}")
+        logger.error("Er is een fout opgetreden: %s", e)
         import traceback
 
         traceback.print_exc()
 
 
 if __name__ == "__main__":
-    print("DPIA/PreScan YAML naar JSON Converter met Begrippenkader")
-    print("=======================================================")
-    print("Dit script zet YAML bestanden om naar JSON en injecteert termen")
-    print("uit het begrippenkader met HTML-tags voor definities.")
-    print("")
-    print("Prioriteit van term-matching:")
-    print("1. Hoofdtermen (langste eerst)")
-    print("2. Alternatieve spellingen (langste eerst)")
-    print("3. Alternatieve termen (langste eerst)")
-    print("")
-    print("Alle matching gebeurt hoofdletter-ongevoelig, maar de oorspronkelijke")
-    print("hoofdletters in de tekst blijven behouden.")
-    print("")
-    print('Termen binnen bestaande <span class="aiv-definition"> tags worden')
-    print("overgeslagen om te voorkomen dat er geneste definitie-spans ontstaan.")
-    print("")
-    print("Gebruik:")
-    print("  --source [PATH]          Pad naar bron YAML bestand")
-    print("  --definitions [PATH]     Pad naar begrippenkader_dpia.yaml")
-    print("  --output [PATH]          Pad naar output JSON bestand")
-    print("")
-
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     main()

--- a/script/generate_licenses.py
+++ b/script/generate_licenses.py
@@ -6,7 +6,11 @@ Usage:
 """
 
 import json
+import logging
 import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 HEADER = """\
 MinBZK Assessments
@@ -49,17 +53,20 @@ def main() -> None:
         lines.append(f"└── license files: {pkg['license']}")
         lines.append("")
 
-    license_types = sorted(set(p["license"] for p in all_packages))
+    license_types = sorted({p["license"] for p in all_packages})
     lines.append(f"LICENSES: {', '.join(license_types)}")
 
     output = "\n".join(lines) + "\n"
-    with open("LICENSES.txt", "w") as f:
+    with Path("LICENSES.txt").open("w") as f:
         f.write(output)
 
-    print(
-        f"LICENSES.txt gegenereerd: {len(all_packages)} packages, {len(license_types)} licentietypes"
+    logger.info(
+        "LICENSES.txt gegenereerd: %s packages, %s licentietypes",
+        len(all_packages),
+        len(license_types),
     )
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     main()

--- a/script/generate_md_table_tasks.py
+++ b/script/generate_md_table_tasks.py
@@ -1,7 +1,11 @@
-import yaml
-import os
 import argparse
+import logging
 import sys
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def extract_task_info(task, parent_path=""):
@@ -36,7 +40,7 @@ def extract_task_info(task, parent_path=""):
 
     # Extract options if available
     options = []
-    if "options" in task and task["options"]:
+    if task.get("options"):
         for option in task["options"]:
             if "label" in option and "value" in option:
                 options.append(f"{option['value']}")
@@ -82,7 +86,7 @@ def extract_task_info(task, parent_path=""):
     )
 
     # Process subtasks recursively
-    if "tasks" in task and task["tasks"]:
+    if task.get("tasks"):
         for subtask in task["tasks"]:
             result.extend(extract_task_info(subtask, current_path))
 
@@ -100,7 +104,7 @@ def process_yaml_file(file_path):
         List of dictionaries containing task information
     """
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with Path(file_path).open(encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         all_tasks = []
@@ -109,12 +113,12 @@ def process_yaml_file(file_path):
             for task in data["tasks"]:
                 all_tasks.extend(extract_task_info(task))
 
-        return all_tasks, data.get("name", os.path.basename(file_path))
+        return all_tasks, data.get("name", Path(file_path).name)
     except yaml.YAMLError as e:
-        print(f"Error parsing YAML file: {e}")
+        logger.error("Error parsing YAML file: %s", e)
         sys.exit(1)
     except Exception as e:
-        print(f"Error processing file: {e}")
+        logger.error("Error processing file: %s", e)
         sys.exit(1)
 
 
@@ -161,7 +165,10 @@ def generate_markdown_table(tasks, file_name):
         description = description.replace("|", "\\|")
         task_text = task_text.replace("|", "\\|")
 
-        md += f"| {task['id']} | {task_text} | {description} | {task['type']} | {task['options']} | {task['related']} |\n"
+        md += (
+            f"| {task['id']} | {task_text} | {description} "
+            f"| {task['type']} | {task['options']} | {task['related']} |\n"
+        )
 
     return md
 
@@ -198,7 +205,7 @@ def main():
     if args.output:
         output_file = args.output
     else:
-        base_name = os.path.splitext(os.path.basename(yaml_file))[0]
+        base_name = Path(yaml_file).stem
         output_file = f"tasks_{base_name}.md"
 
     # Ensure output file has .md extension
@@ -206,12 +213,12 @@ def main():
         output_file += ".md"
 
     # Create output directory if it doesn't exist
-    output_dir = os.path.dirname(output_file)
-    if output_dir and not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    output_dir = Path(output_file).parent
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
 
-    if not os.path.exists(yaml_file):
-        print(f"Error: Source file not found: {yaml_file}")
+    if not Path(yaml_file).exists():
+        logger.error("Error: Source file not found: %s", yaml_file)
         sys.exit(1)
 
     tasks, file_name = process_yaml_file(yaml_file)
@@ -219,15 +226,16 @@ def main():
 
     # Write the result to a Markdown file
     try:
-        with open(output_file, "w", encoding="utf-8") as f:
+        with Path(output_file).open("w", encoding="utf-8") as f:
             f.write(md_content)
 
-        print(f"Successfully processed {yaml_file}")
-        print(f"Markdown file generated: {output_file}")
+        logger.info("Successfully processed %s", yaml_file)
+        logger.info("Markdown file generated: %s", output_file)
     except Exception as e:
-        print(f"Error writing output file: {e}")
+        logger.error("Error writing output file: %s", e)
         sys.exit(1)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     main()

--- a/script/run_all.py
+++ b/script/run_all.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 import argparse
+import logging
 import sys
 from pathlib import Path
 
-from schema_validator import SchemaValidator
 from definition_enricher import DefinitionEnricher
-from generate_md_table_tasks import process_yaml_file, generate_markdown_table
+from generate_md_table_tasks import generate_markdown_table, process_yaml_file
+from schema_validator import SchemaValidator
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
@@ -19,12 +22,8 @@ def main() -> None:
     script_dir = Path(__file__).parent
 
     # Set up argument parser
-    parser = argparse.ArgumentParser(
-        description="YAML Validator and Definition Enricher"
-    )
-    parser.add_argument(
-        "--schema", type=Path, required=True, help="Path to the JSON schema file"
-    )
+    parser = argparse.ArgumentParser(description="YAML Validator and Definition Enricher")
+    parser.add_argument("--schema", type=Path, required=True, help="Path to the JSON schema file")
     parser.add_argument(
         "--source",
         type=Path,
@@ -49,9 +48,7 @@ def main() -> None:
         required=False,
         help="Path to the questions output Markdown file",
     )
-    parser.add_argument(
-        "--skip-validation", action="store_true", help="Skip the validation step"
-    )
+    parser.add_argument("--skip-validation", action="store_true", help="Skip the validation step")
     parser.add_argument(
         "--definitions-once-per-page",
         action="store_true",
@@ -63,26 +60,22 @@ def main() -> None:
     args = parser.parse_args()
 
     try:
-        validated_data = None
-
         # Step 1: Validate YAML against schema (unless skipped)
         if not args.skip_validation:
-            print(f"Validating {args.source} against schema {args.schema}...")
+            logger.info("Validating %s against schema %s...", args.source, args.schema)
             validator = SchemaValidator(script_dir)
-            is_valid, errors, validated_data = validator.validate_yaml(
-                args.source, args.schema
-            )
+            is_valid, errors, _validated_data = validator.validate_yaml(args.source, args.schema)
 
             if not is_valid:
-                print(f"Validation failed: {errors}")
+                logger.error("Validation failed: %s", errors)
                 sys.exit(1)
 
-            print("Validation successful")
+            logger.info("Validation successful")
         else:
-            print("Validation step skipped.")
+            logger.info("Validation step skipped.")
 
         # Step 2: Enrich with definitions
-        print(f"Enriching {args.source} with definitions from {args.begrippen_yaml}...")
+        logger.info("Enriching %s with definitions from %s...", args.source, args.begrippen_yaml)
         enricher = DefinitionEnricher(script_dir)
         enricher.enrich_and_export(
             args.source,
@@ -91,11 +84,11 @@ def main() -> None:
             once_per_page=args.definitions_once_per_page,
         )
 
-        print(f"Successfully processed data. Output saved to {args.output_json}")
+        logger.info("Successfully processed data. Output saved to %s", args.output_json)
 
         # Step 3: Generate questions MD file (if specified)
         if args.output_md:
-            print("Generating questions MD file...")
+            logger.info("Generating questions MD file...")
 
             # Process the source YAML file
             tasks, file_name = process_yaml_file(args.source)
@@ -109,17 +102,18 @@ def main() -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
             # Write the markdown content to the specified file
-            with open(args.output_md, "w", encoding="utf-8") as f:
+            with Path(args.output_md).open("w", encoding="utf-8") as f:
                 f.write(md_content)
 
-            print(f"Questions markdown file generated: {args.output_md}")
+            logger.info("Questions markdown file generated: %s", args.output_md)
 
     except Exception as e:
-        print(f"Error: {e}")
+        logger.error("Error: %s", e)
         sys.exit(1)
 
     sys.exit(0)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     main()

--- a/script/schema_validator.py
+++ b/script/schema_validator.py
@@ -44,13 +44,13 @@ class SchemaValidator:
             with schema_path.open("r", encoding="utf-8") as f:
                 schema = json.load(f)
             self.schemas[schema_path.stem] = schema
-            self.logger.info(f"Successfully loaded schema: {schema_path}")
+            self.logger.info("Successfully loaded schema: %s", schema_path)
             return schema
         except FileNotFoundError:
-            self.logger.exception(f"Schema file not found: {schema_path}")
+            self.logger.exception("Schema file not found: %s", schema_path)
             raise
         except json.JSONDecodeError:
-            self.logger.exception(f"Invalid JSON in schema file {schema_path}")
+            self.logger.exception("Invalid JSON in schema file %s", schema_path)
             raise
 
     def load_yaml(self, yaml_path: Path) -> dict[str, Any]:
@@ -58,13 +58,13 @@ class SchemaValidator:
         try:
             with yaml_path.open("r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
-            self.logger.info(f"Successfully loaded YAML: {yaml_path}")
+            self.logger.info("Successfully loaded YAML: %s", yaml_path)
             return data
         except FileNotFoundError:
-            self.logger.exception(f"YAML file not found: {yaml_path}")
+            self.logger.exception("YAML file not found: %s", yaml_path)
             raise
         except yaml.YAMLError:
-            self.logger.exception(f"Invalid YAML in file {yaml_path}")
+            self.logger.exception("Invalid YAML in file %s", yaml_path)
             raise
 
     def validate_yaml(
@@ -100,9 +100,7 @@ class SchemaValidator:
             return True, [], data
         except jsonschema.exceptions.ValidationError as e:
             error_path = " -> ".join(str(x) for x in e.path)
-            error_msg = (
-                f"Validation error in {yaml_path.name} at {error_path}: {e.message}"
-            )
+            error_msg = f"Validation error in {yaml_path.name} at {error_path}: {e.message}"
             result = {
                 "file": yaml_path.name,
                 "schema": schema_path.name,
@@ -129,12 +127,8 @@ def main() -> None:
 
     # Set up argument parser
     parser = argparse.ArgumentParser(description="YAML Schema Validator")
-    parser.add_argument(
-        "--schema", type=Path, required=True, help="Path to the JSON schema file"
-    )
-    parser.add_argument(
-        "--source", type=Path, required=True, help="Path to the source YAML file"
-    )
+    parser.add_argument("--schema", type=Path, required=True, help="Path to the JSON schema file")
+    parser.add_argument("--source", type=Path, required=True, help="Path to the source YAML file")
     parser.add_argument(
         "--output",
         type=Path,
@@ -153,17 +147,17 @@ def main() -> None:
         is_valid, errors, data = validator.validate_yaml(args.source, args.schema)
 
         if not is_valid:
-            validator.logger.error(f"Validation failed: {errors}")
+            validator.logger.error("Validation failed: %s", errors)
             sys.exit(1)
 
-        validator.logger.info(f"Successfully validated {args.source}")
+        validator.logger.info("Successfully validated %s", args.source)
 
         # Save validated data to JSON if output path is provided
         if args.output:
             args.output.parent.mkdir(parents=True, exist_ok=True)
             with args.output.open("w", encoding="utf-8") as f:
                 json.dump(data, f, indent=4)
-            validator.logger.info(f"Saved validated data to {args.output}")
+            validator.logger.info("Saved validated data to %s", args.output)
 
     except Exception:
         validator.logger.exception("Validation failed")

--- a/script/tests/test_definition_enricher.py
+++ b/script/tests/test_definition_enricher.py
@@ -21,8 +21,7 @@ def make_begrippenkader(*definitions):
     """Build a minimal begrippenkader dict from (term, definition) pairs."""
     return {
         "definitions": [
-            {"id": term.lower(), "term": term, "definition": defn}
-            for term, defn in definitions
+            {"id": term.lower(), "term": term, "definition": defn} for term, defn in definitions
         ]
     }
 
@@ -126,8 +125,7 @@ def test_inject_terms_does_not_double_wrap_existing_definition_span():
     term_map = create_term_map(make_begrippenkader(("term", "uitleg")))
 
     pre_enriched = (
-        '<span class="aiv-definition">term'
-        '<span class="aiv-definition-text">uitleg</span></span>'
+        '<span class="aiv-definition">term<span class="aiv-definition-text">uitleg</span></span>'
     )
     result = inject_terms(pre_enriched, term_map)
 
@@ -160,9 +158,7 @@ def _deel_with_repeated_term():
 def test_once_per_page_false_enriches_every_occurrence():
     term_map = create_term_map(make_begrippenkader(("persoonsgegeven", "een gegeven")))
 
-    result = process_tasks(
-        _deel_with_repeated_term(), term_map, level=0, once_per_page=False
-    )
+    result = process_tasks(_deel_with_repeated_term(), term_map, level=0, once_per_page=False)
     subtasks = result[0]["tasks"]
 
     assert "aiv-definition" in subtasks[0]["task"]
@@ -172,9 +168,7 @@ def test_once_per_page_false_enriches_every_occurrence():
 def test_once_per_page_true_enriches_only_first_occurrence_per_deel():
     term_map = create_term_map(make_begrippenkader(("persoonsgegeven", "een gegeven")))
 
-    result = process_tasks(
-        _deel_with_repeated_term(), term_map, level=0, once_per_page=True
-    )
+    result = process_tasks(_deel_with_repeated_term(), term_map, level=0, once_per_page=True)
     subtasks = result[0]["tasks"]
 
     # First occurrence enriched, second left alone (same page).

--- a/script/tests/test_schema_validation.py
+++ b/script/tests/test_schema_validation.py
@@ -7,7 +7,6 @@ against the real assessment-definition schema, using small inline YAML fixtures.
 from pathlib import Path
 
 import yaml
-
 from schema_validator import SchemaValidator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,228 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "par-form-scripts"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jsonschema", specifier = ">=4.26.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]


### PR DESCRIPTION
Pakt het resterende deel van #321 op en richt onderhoud + Python-dependency-management in. `experimenteel/samenwerken` had al pre-commit met ruff/ruff-format in CI; deze PR vult de gaten, schoont op en moderniseert de Python-pipeline onder `script/`.

## Wijzigingen

### Ruff (lint + format)
- Config naar **`pyproject.toml` `[tool.ruff]`** (i.p.v. losse `ruff.toml`), `line-length = 100`, `target-version = py314`.
- Ruleset uitgebreid met o.a. **security** (`S`/flake8-bandit), `PTH` (pathlib), `PT` (pytest-style), `A` (builtins), `T20` (print), `LOG` + `G` (logging). `.claude/` uitgesloten.
- Alle findings op `script/` opgelost.

### `script/` modernisering (gedrag byte-identiek geverifieerd)
- **`print()` → `logging`** met lazy `%`-formatting (G004-conform).
- **`os.path` → `pathlib`**.
- **S310 echt opgelost**: een `https://`-scheme-guard die andere schemes weigert (de `# noqa` betekent nu "runtime gevalideerd", geen blind vertrouwen).
- Lange regels (E501) weggewerkt; alle code/config-comments in het Engels.

### uv (Python-dependency-management)
- **`pyproject.toml` + `uv.lock`** (met hashes → reproduceerbaar/supply-chain).
- Alle workflows draaien de pipeline via **`uv run --frozen`**, met uv geïnstalleerd via de officiële **`astral-sh/setup-uv`** action (incl. cache). Geen losse, ongepinde `pip install` meer.

### CI / onderhoud
- **python-version overal `3.14`** (consistent met ruff target).
- **pre-commit** opgeschoond: `pre-commit-hooks v6.0.0`, `ruff v0.15.16`, + **gitleaks** secret-scanning.
- **`dependabot.yml`**: `github-actions` + `npm` + `uv`, gegroepeerd (lage PR-ruis).
- **Scheduled `pre-commit-autoupdate`** workflow (dependabot dekt pre-commit-hooks niet).
- Third-party actions **`astral-sh/setup-uv`** en **`peter-evans/create-pull-request`** op commit-SHA gepind (supply-chain hardening; dependabot houdt ze bij).

## ⚠️ Default-branch-gedrag
GitHub activeert `dependabot.yml` en `schedule:`-triggers **alleen vanaf de default branch**. Ruff, gitleaks, python-pins, uv en de pre-commit-CI werken **meteen** op deze branch; **dependabot + de scheduled autoupdate blijven dormant** tot `experimenteel/samenwerken` default wordt of naar main merget (`workflow_dispatch` werkt wél handmatig).

## Verificatie (lokaal, ruff 0.15.16 / uv / python 3.14)
- `ruff check .` + `ruff format --check script/` → schoon
- `uv run --frozen pytest script/tests` → 22 passed
- Pipeline-output (prescan) **byte-identiek** aan pre-refactor baseline; dpia + iama exit 0
- `pre-commit run --all-files` → alle hooks Passed (incl. gitleaks)

Closes #321