### PR TITLE
ci: per-PR preview-deployments + DRY build via reusable workflow

### DIFF
--- a/.github/workflows/_build-images.yaml
+++ b/.github/workflows/_build-images.yaml
@@ -1,0 +1,133 @@
+name: Build images (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      frontend-image:
+        required: true
+        type: string
+      backend-image:
+        required: true
+        type: string
+      tag-prefix:
+        required: false
+        type: string
+        default: ''
+      tag-latest:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      frontend-image:
+        value: ${{ jobs.build-frontend.outputs.image }}
+      backend-image:
+        value: ${{ jobs.build-backend.outputs.image }}
+
+jobs:
+  generate-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
+      - name: Generate JSON from YAML definitions
+        run: |
+          mkdir -p sources/generated
+          uv run --frozen --no-dev python script/run_all.py \
+            --schema schemas/assessment-definition.v2.schema.json \
+            --source sources/prescan.yaml \
+            --begrippen-yaml sources/begrippenkader_dpia.yaml \
+            --output-json sources/generated/PreScanDPIA.json \
+            --output-md docs/questions/questions_prescan_DPIA.md
+          uv run --frozen --no-dev python script/run_all.py \
+            --schema schemas/assessment-definition.v2.schema.json \
+            --source sources/dpia.yaml \
+            --begrippen-yaml sources/begrippenkader_dpia.yaml \
+            --output-json sources/generated/DPIA.json \
+            --output-md docs/questions/questions_DPIA.md
+          uv run --frozen --no-dev python script/run_all.py \
+            --schema schemas/assessment-definition.v2.schema.json \
+            --source sources/iama.yaml \
+            --begrippen-yaml sources/begrippenkader_iama.yaml \
+            --output-json sources/generated/IAMA.json \
+            --definitions-once-per-page
+      - uses: actions/upload-artifact@v4
+        with:
+          name: generated-sources
+          path: sources/generated/
+          retention-days: 1
+
+  build-backend:
+    needs: generate-sources
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image-ref.outputs.image }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-sources
+          path: sources/generated/
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.backend-image }}
+          tags: |
+            type=sha,prefix=${{ inputs.tag-prefix }}
+            type=raw,value=latest,enable=${{ inputs.tag-latest }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: containers/backend/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - id: image-ref
+        run: echo "image=${{ inputs.backend-image }}:${{ inputs.tag-prefix }}${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+  build-frontend:
+    needs: generate-sources
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image-ref.outputs.image }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-sources
+          path: sources/generated/
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.frontend-image }}
+          tags: |
+            type=sha,prefix=${{ inputs.tag-prefix }}
+            type=raw,value=latest,enable=${{ inputs.tag-latest }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: containers/frontend/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - id: image-ref
+        run: echo "image=${{ inputs.frontend-image }}:${{ inputs.tag-prefix }}${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -6,150 +6,28 @@ on:
       - experimenteel/samenwerken
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
 env:
-  REGISTRY: ghcr.io
-  FRONTEND_IMAGE: ghcr.io/minbzk/par-dpia-form/dev/frontend
-  BACKEND_IMAGE: ghcr.io/minbzk/par-dpia-form/dev/backend
   PROJECT_ID: asses-k2n
   DEPLOYMENT_NAME: productie
 
 jobs:
-  generate-sources:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          python-version: '3.14'
-          enable-cache: true
-
-      - name: Generate JSON from YAML definitions
-        run: |
-          mkdir -p sources/generated
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/prescan.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/PreScanDPIA.json \
-            --output-md docs/questions/questions_prescan_DPIA.md
-
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/dpia.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/DPIA.json \
-            --output-md docs/questions/questions_DPIA.md
-
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/iama.yaml \
-            --begrippen-yaml sources/begrippenkader_iama.yaml \
-            --output-json sources/generated/IAMA.json \
-            --definitions-once-per-page
-
-      - name: Upload generated sources
-        uses: actions/upload-artifact@v4
-        with:
-          name: generated-sources
-          path: sources/generated/
-          retention-days: 1
-
-  build-backend:
-    needs: generate-sources
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.image-ref.outputs.image }}
+  build:
     permissions:
       contents: read
       packages: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Download generated sources
-        uses: actions/download-artifact@v4
-        with:
-          name: generated-sources
-          path: sources/generated/
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.BACKEND_IMAGE }}
-          tags: |
-            type=sha,prefix=
-            type=raw,value=latest
-
-      - name: Build and push backend
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: containers/backend/Containerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Set image reference
-        id: image-ref
-        run: echo "image=${{ env.BACKEND_IMAGE }}:${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-
-  build-frontend:
-    needs: generate-sources
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.image-ref.outputs.image }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Download generated sources
-        uses: actions/download-artifact@v4
-        with:
-          name: generated-sources
-          path: sources/generated/
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FRONTEND_IMAGE }}
-          tags: |
-            type=sha,prefix=
-            type=raw,value=latest
-
-      - name: Build and push frontend
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: containers/frontend/Containerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Set image reference
-        id: image-ref
-        run: echo "image=${{ env.FRONTEND_IMAGE }}:${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/_build-images.yaml
+    with:
+      frontend-image: ghcr.io/minbzk/par-dpia-form/dev/frontend
+      backend-image: ghcr.io/minbzk/par-dpia-form/dev/backend
+      tag-latest: true
 
   deploy:
-    needs: [build-frontend, build-backend]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -164,6 +42,6 @@ jobs:
           wait-for-ready: 'true'
           components: >-
             [
-              {"name": "frontend", "image": "${{ needs.build-frontend.outputs.image }}"},
-              {"name": "api", "image": "${{ needs.build-backend.outputs.image }}"}
+              {"name": "frontend", "image": "${{ needs.build.outputs.frontend-image }}"},
+              {"name": "api", "image": "${{ needs.build.outputs.backend-image }}"}
             ]

--- a/.github/workflows/preview-deployment.yaml
+++ b/.github/workflows/preview-deployment.yaml
@@ -1,0 +1,85 @@
+name: Preview deployment
+
+on:
+  pull_request:
+    branches: [experimenteel/samenwerken]
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  deployments: write
+
+env:
+  PROJECT_ID: asses-k2n
+  DEPLOYMENT_CLONE_FROM: acceptatie
+
+jobs:
+  build:
+    if: github.event.action != 'closed' && github.event.pull_request.user.type != 'Bot'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/_build-images.yaml
+    with:
+      frontend-image: ghcr.io/minbzk/par-dpia-form/preview/frontend
+      backend-image: ghcr.io/minbzk/par-dpia-form/preview/backend
+      tag-prefix: pr-${{ github.event.pull_request.number }}-
+
+  deploy-preview:
+    needs: build
+    if: github.event.action != 'closed' && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    environment:
+      name: pr-${{ github.event.pull_request.number }}
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - id: deploy
+        uses: RijksICTGilde/zad-actions/deploy@v4
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: ${{ env.PROJECT_ID }}
+          deployment-name: pr-${{ github.event.pull_request.number }}
+          clone-from: ${{ env.DEPLOYMENT_CLONE_FROM }}
+          comment-on-pr: 'true'
+          wait-for-ready: 'true'
+          health-endpoint: /api/health
+          components: >-
+            [
+              {"name": "frontend", "image": "${{ needs.build.outputs.frontend-image }}"},
+              {"name": "api", "image": "${{ needs.build.outputs.backend-image }}"}
+            ]
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: RijksICTGilde/zad-actions/cleanup@v4
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: ${{ env.PROJECT_ID }}
+          deployment-name: pr-${{ github.event.pull_request.number }}
+          delete-github-deployments: 'true'
+          delete-pr-comment: 'true'
+      - name: Delete this PR's preview container images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TAG: pr-${{ github.event.pull_request.number }}
+        run: |
+          for pkg in preview/frontend preview/backend; do
+            enc="par-dpia-form%2F${pkg/\//%2F}"
+            gh api --paginate "/orgs/minbzk/packages/container/${enc}/versions" \
+              --jq ".[] | select(.metadata.container.tags[] | startswith(\"${PR_TAG}-\")) | .id" \
+              | while read -r id; do
+                  gh api -X DELETE "/orgs/minbzk/packages/container/${enc}/versions/${id}" || true
+                done
+          done

--- a/apps/boekhouding-backend/drizzle/0001_eminent_jamie_braddock.sql
+++ b/apps/boekhouding-backend/drizzle/0001_eminent_jamie_braddock.sql
@@ -1,6 +1,6 @@
 DO $$ BEGIN CREATE TYPE "project_role" AS ENUM('owner', 'editor', 'commenter', 'viewer'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
 ALTER TYPE "project_role" ADD VALUE IF NOT EXISTS 'commenter' BEFORE 'viewer';--> statement-breakpoint
-CREATE TABLE "comments" (
+CREATE TABLE IF NOT EXISTS "comments" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"assessment_instance_id" uuid NOT NULL,
 	"field_id" text NOT NULL,
@@ -13,6 +13,6 @@ CREATE TABLE "comments" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "comments" ADD CONSTRAINT "comments_assessment_instance_id_assessment_instances_id_fk" FOREIGN KEY ("assessment_instance_id") REFERENCES "assessment_instances"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "comments" ADD CONSTRAINT "comments_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "comments" ADD CONSTRAINT "comments_resolved_by_users_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;
+DO $$ BEGIN ALTER TABLE "comments" ADD CONSTRAINT "comments_assessment_instance_id_assessment_instances_id_fk" FOREIGN KEY ("assessment_instance_id") REFERENCES "assessment_instances"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "comments" ADD CONSTRAINT "comments_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "comments" ADD CONSTRAINT "comments_resolved_by_users_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/boekhouding-backend/drizzle/0002_certain_thunderbolts.sql
+++ b/apps/boekhouding-backend/drizzle/0002_certain_thunderbolts.sql
@@ -1,4 +1,4 @@
-CREATE INDEX "assessment_edits_version_idx" ON "assessment_edits" USING btree ("assessment_version_id");--> statement-breakpoint
-CREATE INDEX "assessment_instances_project_idx" ON "assessment_instances" USING btree ("project_id");--> statement-breakpoint
-CREATE INDEX "comments_assessment_updated_idx" ON "comments" USING btree ("assessment_instance_id","updated_at");--> statement-breakpoint
-CREATE INDEX "comments_parent_idx" ON "comments" USING btree ("parent_id");
+CREATE INDEX IF NOT EXISTS "assessment_edits_version_idx" ON "assessment_edits" USING btree ("assessment_version_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "assessment_instances_project_idx" ON "assessment_instances" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "comments_assessment_updated_idx" ON "comments" USING btree ("assessment_instance_id","updated_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "comments_parent_idx" ON "comments" USING btree ("parent_id");


### PR DESCRIPTION
## Wat
Per-PR review-omgeving via ZAD + een DRY-refactor van de build naar een **reusable workflow**, plus een **clone-bestendige migratie-fix** zodat de preview-backend ook echt boot.

## Workflows
- **`_build-images.yaml`** (reusable, `workflow_call`): sources-generatie (uv) + frontend/backend image-build. Inputs: image-pad, `tag-prefix`, `tag-latest`. Outputs: de image-refs.
- **`build-and-deploy.yaml`**: roept de reusable aan → `dev/*:<sha7>` + `latest` → `productie` (gedrag ongewijzigd).
- **`preview-deployment.yaml`**: roept dezelfde reusable aan met `tag-prefix: pr-<N>-`, deployt via `zad-actions/deploy@v4` (`clone-from: acceptatie`), cleanup bij sluiten.

Patroon volgt `RijksICTGilde/regelrecht` + `wies` (reusable build; GITHUB_TOKEN auto-beschikbaar, geen `secrets: inherit`).

## Clone-bestendige migraties (0001/0002)
Elke ZAD-deployment krijgt een **eigen** DB (`asses_k2n_pr_N`, CloudNativePG). `clone-from` vult die via een schema-scoped `pg_dump -n <app_schema>` — dat kopieert **niet** Drizzle's aparte `drizzle`-tracking-schema. Daardoor mist de preview-DB de `__drizzle_migrations`-rijen → `migrate`-on-boot speelt alles opnieuw af, en `0001/0002` waren niet idempotent → `relation "comments" already exists` → crash. Fix: zelfde patroon als `0000` (`CREATE TABLE/INDEX IF NOT EXISTS` + `DO $$ … EXCEPTION WHEN duplicate_object`). Re-run = no-op (zoals sqlx/Django bij regelrecht/wies). Geverifieerd met een clone-reproductie (oud faalt, nieuw slaagt).

## Gedrag previews
- Draait voor elke **niet-bot** PR naar `experimenteel/samenwerken` (ook drafts), **bijwerken bij elke push** (`synchronize`), **cleanup** bij `closed`.
- Config via env: `PROJECT_ID`, `DEPLOYMENT_CLONE_FROM` (= `acceptatie`).

## Veiligheid / isolatie
- `pull_request`-only → draait nooit op een push naar `experimenteel/samenwerken`. Drievoudig geïsoleerd van productie: `deployment-name: pr-<N>`, `clone-from: acceptatie`, image-pad `preview/*`. Geen untrusted input in `run`-stappen.

## Voorwaarde
De app laadt projecten pas zodra de **acceptatie-deployment** de shared-host + `/api`-routing live heeft (#337). De DB-laag (deze PR) en de routing-laag (#337) zijn losse stappen.
