### PR TITLE
fix: betaversie-balk tekst centreren (#330)

### DIFF
--- a/packages/assessment-core/src/components/AppBanner.vue
+++ b/packages/assessment-core/src/components/AppBanner.vue
@@ -15,14 +15,14 @@ withDefaults(defineProps<{
 </script>
 
 <template>
-  <div class="rvo-alert rvo-alert--warning rvo-alert--padding-sm" style="display: flex; align-items: center; gap: 0.5rem; flex-wrap: nowrap;">
+  <div class="rvo-alert rvo-alert--warning rvo-alert--padding-sm" style="display: flex; align-items: center; justify-content: center; gap: 0.5rem; flex-wrap: nowrap;">
     <span
       class="utrecht-icon rvo-icon rvo-icon-waarschuwing rvo-icon--xl rvo-status-icon-waarschuwing"
       role="img"
       aria-label="Waarschuwing"
       style="flex-shrink: 0;"
     ></span>
-    <div class="rvo-alert-text">
+    <div class="rvo-alert-text" style="text-align: center;">
       <a class="rvo-link" :href="linkUrl">{{ linkLabel }}</a>
       {{ message }}
     </div>


### PR DESCRIPTION
## Wat
De tekst in de betaversie-balk stond linksuitgelijnd; deze staat nu horizontaal (en verticaal) gecentreerd.

## Hoe
In `AppBanner.vue`:
- `justify-content: center` toegevoegd aan de `rvo-alert`-balk (horizontaal centreren van icoon + tekst).
- `text-align: center` toegevoegd aan het `.rvo-alert-text`-blok (centreren bij meerdere regels). Verticaal centreren liep al via de bestaande `align-items: center`.

## Test
- Lokaal visueel geverifieerd in zowel `standalone-form` als `boekhouding-frontend`: balk-tekst staat gecentreerd.
- `@overheid-assessment/core`: 1158 tests groen, 100% coverage behouden (style-only wijziging, geen nieuwe branches).

Closes #330