### PR TITLE
fix(backend): clone-bestendige (idempotente) migraties voor preview-DB's

### DIFF
--- a/apps/boekhouding-backend/drizzle/0001_eminent_jamie_braddock.sql
+++ b/apps/boekhouding-backend/drizzle/0001_eminent_jamie_braddock.sql
@@ -1,6 +1,6 @@
 DO $$ BEGIN CREATE TYPE "project_role" AS ENUM('owner', 'editor', 'commenter', 'viewer'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
 ALTER TYPE "project_role" ADD VALUE IF NOT EXISTS 'commenter' BEFORE 'viewer';--> statement-breakpoint
-CREATE TABLE "comments" (
+CREATE TABLE IF NOT EXISTS "comments" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"assessment_instance_id" uuid NOT NULL,
 	"field_id" text NOT NULL,
@@ -13,6 +13,6 @@ CREATE TABLE "comments" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "comments" ADD CONSTRAINT "comments_assessment_instance_id_assessment_instances_id_fk" FOREIGN KEY ("assessment_instance_id") REFERENCES "assessment_instances"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "comments" ADD CONSTRAINT "comments_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "comments" ADD CONSTRAINT "comments_resolved_by_users_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;
+DO $$ BEGIN ALTER TABLE "comments" ADD CONSTRAINT "comments_assessment_instance_id_assessment_instances_id_fk" FOREIGN KEY ("assessment_instance_id") REFERENCES "assessment_instances"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "comments" ADD CONSTRAINT "comments_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "comments" ADD CONSTRAINT "comments_resolved_by_users_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/boekhouding-backend/drizzle/0002_certain_thunderbolts.sql
+++ b/apps/boekhouding-backend/drizzle/0002_certain_thunderbolts.sql
@@ -1,4 +1,4 @@
-CREATE INDEX "assessment_edits_version_idx" ON "assessment_edits" USING btree ("assessment_version_id");--> statement-breakpoint
-CREATE INDEX "assessment_instances_project_idx" ON "assessment_instances" USING btree ("project_id");--> statement-breakpoint
-CREATE INDEX "comments_assessment_updated_idx" ON "comments" USING btree ("assessment_instance_id","updated_at");--> statement-breakpoint
-CREATE INDEX "comments_parent_idx" ON "comments" USING btree ("parent_id");
+CREATE INDEX IF NOT EXISTS "assessment_edits_version_idx" ON "assessment_edits" USING btree ("assessment_version_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "assessment_instances_project_idx" ON "assessment_instances" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "comments_assessment_updated_idx" ON "comments" USING btree ("assessment_instance_id","updated_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "comments_parent_idx" ON "comments" USING btree ("parent_id");


### PR DESCRIPTION
## Probleem
Een PR-preview krijgt z'n eigen ZAD-database, maar `clone-from: acceptatie` vult die met een **schema-scoped `pg_dump -n <app_schema>`** van acceptatie. Drizzle's migratie-tracking (`__drizzle_migrations`) leeft in een **apart `drizzle`-schema** dat die clone **niet** meekopieert. De preview-DB heeft dus wél alle tabellen maar **geen tracking-rijen** → `migrate`-on-boot denkt "niets toegepast" en speelt alles opnieuw af. Migraties `0001` (`CREATE TABLE "comments"` + FK's) en `0002` (indexes) waren niet zelfstandig idempotent → `relation "comments" already exists` → de api-pod crasht bij boot.

## Fix
Zelfde idempotente patroon als `0000` al gebruikt:
- `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`
- `ADD CONSTRAINT` → `DO $$ BEGIN … EXCEPTION WHEN duplicate_object THEN NULL; END $$;`
- `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS`

Re-run = no-op — net zoals `sqlx` (regelrecht) en Django (wies) van nature doen; daarom werken hún clone-based previews wél.

## Verificatie
Clone-scenario gereproduceerd op een wegwerp-Postgres (migrate → `DROP SCHEMA drizzle CASCADE` → migrate opnieuw):
- **zonder fix:** tweede migrate faalt (`relation "comments" already exists`, exit 1)
- **met fix:** tweede migrate slaagt (exit 0; "already exists, skipping" als NOTICE)

Verandert niets aan het resulterende schema; verse DB's en bestaande productie/acceptatie (tracking al gevuld) zijn niet geraakt.

Refs #337, #339.
