### PR TITLE
feat(standalone): cache-keuze op landing (#322) + offline HTML-download

### DIFF
--- a/apps/standalone-form/src/App.vue
+++ b/apps/standalone-form/src/App.vue
@@ -29,7 +29,18 @@ const schemaStore = useSchemaStore()
 
 const currentView = ref<ViewState>(ViewState.Landing)
 
+// Which assessments have saved progress in localStorage. Recomputed whenever
+// the landing page is shown, since localStorage is not reactive.
+const cachedTypes = ref<FormType[]>([])
+const refreshCachedTypes = () => {
+  cachedTypes.value = [FormType.PRE_SCAN, FormType.DPIA, FormType.IAMA].filter((type) =>
+    persistence.hasSavedState(type),
+  )
+}
+refreshCachedTypes()
+
 const navigateTo = (view: ViewState) => {
+  if (view === ViewState.Landing) refreshCachedTypes()
   currentView.value = view
 }
 
@@ -54,18 +65,41 @@ const navigationFunctions: NavigationFunctions = {
     navigateTo(ViewState.IAMA)
   },
 }
+
+// "Nieuwe starten": discard the saved session, then open a fresh form.
+const goByType: Record<FormType, () => void> = {
+  [FormType.PRE_SCAN]: () => navigationFunctions.goToPreScanDPIA(),
+  [FormType.DPIA]: () => navigationFunctions.goToDPIA(),
+  [FormType.IAMA]: () => navigationFunctions.goToIAMA!(),
+}
+const startFresh = (type: FormType) => {
+  persistence.clearSavedState(type)
+  goByType[type]()
+}
+
+// Resuming (saved state present) jumps straight into the form; a fresh start
+// shows the intro/upload page. clearSavedState() runs before navigation, so
+// this reflects the right intent at mount time.
+const isResume = (type: FormType) => persistence.hasSavedState(type)
 </script>
 
 <template>
   <!-- Landing page -->
-  <LandingView v-if="currentView === ViewState.Landing" :navigation="navigationFunctions" />
+  <LandingView
+    v-if="currentView === ViewState.Landing"
+    :navigation="navigationFunctions"
+    :cached-types="cachedTypes"
+    @start-fresh="startFresh"
+  />
 
   <!-- DPIA Form -->
   <Form
     v-if="currentView === ViewState.DPIA"
     :navigation="navigationFunctions"
     :namespace="FormType.DPIA"
-     :validData="schemaStore.getSchema(FormType.DPIA)"
+    :validData="schemaStore.getSchema(FormType.DPIA)"
+    :autoStart="isResume(FormType.DPIA)"
+    bannerTitle="Invulhulpen"
   />
 
   <!-- Pre Scan DPIA Form -->
@@ -74,6 +108,8 @@ const navigationFunctions: NavigationFunctions = {
     :navigation="navigationFunctions"
     :namespace="FormType.PRE_SCAN"
     :validData="schemaStore.getSchema(FormType.PRE_SCAN)"
+    :autoStart="isResume(FormType.PRE_SCAN)"
+    bannerTitle="Invulhulpen"
   />
 
   <!-- IAMA Form -->
@@ -82,5 +118,7 @@ const navigationFunctions: NavigationFunctions = {
     :navigation="navigationFunctions"
     :namespace="FormType.IAMA"
     :validData="schemaStore.getSchema(FormType.IAMA)"
+    :autoStart="isResume(FormType.IAMA)"
+    bannerTitle="Invulhulpen"
   />
 </template>

--- a/apps/standalone-form/src/LocalPersistence.ts
+++ b/apps/standalone-form/src/LocalPersistence.ts
@@ -7,10 +7,25 @@ import {
   OUTPUT_SCHEMA_URL,
   type PersistenceProvider,
   type AssessmentState,
+  type GroupedAnswerValue,
   migrateStateV1toV2,
   applyStateToStores,
   groupAnswers,
 } from '@overheid-assessment/core'
+
+/** Loosely-typed shape of state read from storage: it may be a current flat
+ *  state, or an older namespaced/taskState format handled during migration. */
+interface LoadedState {
+  metadata?: { urn?: string; createdAt?: string; completedTasks?: string[] }
+  answers?: Record<string, GroupedAnswerValue | Record<string, GroupedAnswerValue>>
+  taskState?: Record<string, { completedRootTaskIds?: string[] }>
+}
+
+/** Persistence provider with standalone-only extras for the landing page. */
+export interface LocalPersistence extends PersistenceProvider {
+  /** Whether a non-empty saved state exists for the given assessment type. */
+  hasSavedState(namespace: FormType): boolean
+}
 
 function getStorageKey(namespace: string): string {
   return `app_state_${namespace}`
@@ -20,7 +35,7 @@ function getUiStorageKey(namespace: string): string {
   return `ui_state_${namespace}`
 }
 
-export function createLocalPersistence(): PersistenceProvider {
+export function createLocalPersistence(): LocalPersistence {
   const answerStore = useAnswerStore()
   const taskStore = useTaskStore()
 
@@ -67,24 +82,24 @@ export function createLocalPersistence(): PersistenceProvider {
       try { urnLookup[FormType.DPIA] = schemaStore.getUrn(FormType.DPIA) } catch { /* */ }
       try { urnLookup[FormType.PRE_SCAN] = schemaStore.getUrn(FormType.PRE_SCAN) } catch { /* */ }
 
-      const raw = JSON.parse(stateData)
-      const migrated = migrateStateV1toV2(raw as any, urnLookup)
+      const raw = JSON.parse(stateData) as AssessmentState
+      const migrated = migrateStateV1toV2(raw, urnLookup) as LoadedState
 
-      const answers = (migrated as any).answers || {}
-      const metadata = migrated.metadata || {} as any
+      const answers = migrated.answers || {}
+      const metadata = migrated.metadata || {}
 
       // Old format: answers wrapped in namespace key
       const isNamespaced = answers[FormType.DPIA] || answers[FormType.PRE_SCAN]
 
-      let resolvedAnswers: Record<string, any>
+      let resolvedAnswers: Record<string, GroupedAnswerValue>
       let completedTasks: string[]
 
       if (isNamespaced) {
-        resolvedAnswers = answers[ns] || {}
-        completedTasks = (migrated as any).taskState?.[ns]?.completedRootTaskIds
+        resolvedAnswers = (answers[ns] as Record<string, GroupedAnswerValue>) || {}
+        completedTasks = migrated.taskState?.[ns]?.completedRootTaskIds
           || metadata.completedTasks || []
       } else {
-        resolvedAnswers = answers
+        resolvedAnswers = answers as Record<string, GroupedAnswerValue>
         completedTasks = metadata.completedTasks || []
       }
 
@@ -108,6 +123,20 @@ export function createLocalPersistence(): PersistenceProvider {
 
   function applyAppState(state: AssessmentState): void {
     applyStateToStores(state, taskStore, answerStore)
+  }
+
+  function hasSavedState(namespace: FormType): boolean {
+    try {
+      const data = localStorage.getItem(getStorageKey(namespace))
+      if (!data) return false
+      const parsed = JSON.parse(data) as { answers?: Record<string, unknown> }
+      const answers = parsed.answers ?? {}
+      // Old caches namespace their answers; current format stores them flat.
+      const scoped = (answers[namespace] as Record<string, unknown> | undefined) ?? answers
+      return Object.keys(scoped).length > 0
+    } catch {
+      return false
+    }
   }
 
   function clearSavedState(namespace?: FormType): void {
@@ -155,6 +184,7 @@ export function createLocalPersistence(): PersistenceProvider {
     saveAppState,
     loadAppState,
     applyAppState,
+    hasSavedState,
     clearSavedState,
     setupWatchers,
     restoreUiState,

--- a/apps/standalone-form/src/components/LandingView.vue
+++ b/apps/standalone-form/src/components/LandingView.vue
@@ -1,40 +1,126 @@
 <script setup lang="ts">
-import { AppBanner, UiButton, ExportPdfInfo, type NavigationFunctions } from '@overheid-assessment/core'
+import { computed, ref } from 'vue'
+import { AppBanner, UiButton, ExportPdfInfo, FormType, type NavigationFunctions } from '@overheid-assessment/core'
 
-defineProps<{
+const props = defineProps<{
   navigation: NavigationFunctions
+  cachedTypes: FormType[]
 }>()
+
+const emit = defineEmits<{
+  startFresh: [type: FormType]
+}>()
+
+interface AssessmentCard {
+  type: FormType
+  title: string
+  description: string
+  startLabel: string
+  freshLabel: string
+  start: () => void
+}
+
+const cards: AssessmentCard[] = [
+  {
+    type: FormType.PRE_SCAN,
+    title: 'Pre-scan',
+    description: 'Toets of een DPIA, DTIA, IAMA of KIA nodig is.',
+    startLabel: 'Start pre-scan',
+    freshLabel: 'Start nieuwe pre-scan',
+    start: () => props.navigation.goToPreScanDPIA(),
+  },
+  {
+    type: FormType.DPIA,
+    title: 'DPIA',
+    description: 'Vul stap voor stap het rijksmodel DPIA in.',
+    startLabel: 'Start DPIA',
+    freshLabel: 'Start nieuwe DPIA',
+    start: () => props.navigation.goToDPIA(),
+  },
+  {
+    type: FormType.IAMA,
+    title: 'IAMA',
+    description: 'Vul stap voor stap het Impact Assessment Mensenrechten en Algoritmes in.',
+    startLabel: 'Start IAMA',
+    freshLabel: 'Start nieuwe IAMA',
+    start: () => props.navigation.goToIAMA?.(),
+  },
+]
+
+function hasCache(type: FormType): boolean {
+  return props.cachedTypes.includes(type)
+}
+
+// "Start nieuwe X" confirmation
+const freshTarget = ref<FormType | null>(null)
+const freshTargetCard = computed(() => cards.find((card) => card.type === freshTarget.value))
+function askFresh(type: FormType) {
+  freshTarget.value = type
+}
+function cancelFresh() {
+  freshTarget.value = null
+}
+function confirmFresh() {
+  emit('startFresh', freshTarget.value as FormType)
+  freshTarget.value = null
+}
+
+// Download the running single-file build as a standalone HTML file.
+// Only meaningful on the hosted, built app: not in dev (no single-file bundle
+// exists) and not in an already-downloaded offline copy opened from disk.
+const canDownloadOfflineCopy = computed(
+  () => import.meta.env.PROD && window.location.protocol !== 'file:',
+)
+const downloading = ref(false)
+const downloadFailed = ref(false)
+async function downloadOfflineApp() {
+  downloading.value = true
+  downloadFailed.value = false
+  try {
+    const response = await fetch(window.location.href, { cache: 'no-store' })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const html = await response.text()
+    const url = URL.createObjectURL(new Blob([html], { type: 'text/html;charset=utf-8' }))
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'invulhulp-pre-scan-dpia-iama.html'
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  } catch {
+    downloadFailed.value = true
+  } finally {
+    downloading.value = false
+  }
+}
 </script>
 
 <template>
-  <AppBanner />
+  <AppBanner title="Invulhulpen" />
   <div class="rvo-layout-column rvo-layout-gap--3xl rvo-margin-block-start--xl">
     <div class="rvo-max-width-layout rvo-max-width-layout--md rvo-max-width-layout-inline-padding--md">
       <h1 class="utrecht-heading-1">Invulhulp voor pre-scan, DPIA en IAMA</h1>
       <div class="rvo-layout-grid-container rvo-margin-inline-end--md">
         <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--two">
-          <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card__full-card-link rvo-card--full-colour--grijs-100">
+          <div
+            v-for="card in cards"
+            :key="card.type"
+            class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card__full-card-link rvo-card--full-colour--grijs-100"
+          >
             <div class="rvo-card__content card-content-flex">
-              <h2 class="utrecht-heading-2 rvo-margin--none">Pre-scan</h2>
-              <p class="rvo-padding-block-end--sm">Toets of een DPIA, DTIA, IAMA of KIA nodig is.</p>
-              <UiButton variant="primary" label="Start pre-scan" class="card-button"
-                @click="navigation.goToPreScanDPIA" />
-            </div>
-          </div>
-          <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card__full-card-link rvo-card--full-colour--grijs-100">
-            <div class="rvo-card__content card-content-flex">
-              <h2 class="utrecht-heading-2 rvo-margin--none">DPIA</h2>
-              <p class="rvo-padding-block-end--sm">Vul stap voor stap het rijksmodel DPIA in.</p>
-              <UiButton variant="primary" label="Start DPIA" class="card-button"
-                @click="navigation.goToDPIA" />
-            </div>
-          </div>
-          <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card__full-card-link rvo-card--full-colour--grijs-100">
-            <div class="rvo-card__content card-content-flex">
-              <h2 class="utrecht-heading-2 rvo-margin--none">IAMA</h2>
-              <p class="rvo-padding-block-end--sm">Vul stap voor stap het Impact Assessment Mensenrechten en Algoritmes in.</p>
-              <UiButton variant="primary" label="Start IAMA" class="card-button"
-                @click="navigation.goToIAMA?.()" />
+              <h2 class="utrecht-heading-2 rvo-margin--none">{{ card.title }}</h2>
+              <p class="rvo-padding-block-end--sm">{{ card.description }}</p>
+              <template v-if="hasCache(card.type)">
+                <div class="card-actions">
+                  <UiButton variant="primary" label="Verder gaan" class="card-button"
+                    @click="card.start()" />
+                  <UiButton variant="tertiary" :label="card.freshLabel" class="card-button-fresh"
+                    @click="askFresh(card.type)" />
+                </div>
+              </template>
+              <UiButton v-else variant="primary" :label="card.startLabel" class="card-button"
+                @click="card.start()" />
             </div>
           </div>
         </div>
@@ -114,6 +200,69 @@ defineProps<{
         <ExportPdfInfo />
       </div>
 
+      <div v-if="canDownloadOfflineCopy" class="rvo-margin-block-start--xl rvo-margin-block-end--xl">
+        <h2 class="utrecht-heading-2">Offline gebruiken</h2>
+        <p>
+          Je kunt deze invulhulp als één HTML-bestand downloaden en lokaal openen, ook zonder internet.
+          Het bestand bevat de volledige invulhulp. Je gegevens blijven op je eigen computer.
+        </p>
+        <UiButton variant="secondary" label="Download invulhulp als HTML-bestand" :disabled="downloading"
+          @click="downloadOfflineApp" />
+        <p v-if="downloadFailed" role="alert" class="rvo-margin-block-start--sm">
+          Het downloaden is niet gelukt. Probeer het opnieuw.
+        </p>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- "Start nieuwe X" confirmation -->
+  <div v-if="freshTarget" class="fresh-confirm-overlay" @click.self="cancelFresh">
+    <div class="fresh-confirm" role="dialog" aria-modal="true" aria-labelledby="fresh-confirm-title">
+      <h2 id="fresh-confirm-title" class="utrecht-heading-2">Nieuwe {{ freshTargetCard?.title }} starten?</h2>
+      <p class="utrecht-paragraph">
+        Je hebt een opgeslagen versie van de {{ freshTargetCard?.title }}. Als je een nieuwe start, wordt
+        die opgeslagen versie definitief gewist. Dit kan niet ongedaan worden gemaakt.
+      </p>
+      <div class="fresh-confirm__actions">
+        <UiButton variant="tertiary" label="Annuleren" @click="cancelFresh" />
+        <UiButton variant="warning" :label="`Ja, start nieuwe ${freshTargetCard?.title}`" @click="confirmFresh" />
+      </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+}
+
+.fresh-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.fresh-confirm {
+  background: #fff;
+  max-width: 32rem;
+  width: 100%;
+  padding: 1.5rem;
+  border-radius: 4px;
+}
+
+.fresh-confirm__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-block-start: 1rem;
+}
+</style>

--- a/apps/standalone-form/test/cov/App.cov.test.ts
+++ b/apps/standalone-form/test/cov/App.cov.test.ts
@@ -11,13 +11,18 @@ import App from '../../src/App.vue'
 
 const LandingStub = {
   name: 'LandingView',
-  props: ['navigation'],
+  props: ['navigation', 'cachedTypes'],
+  emits: ['startFresh'],
   template: '<div class="landing-stub" />',
+}
+
+function storageKey(ns: string): string {
+  return `app_state_${ns}`
 }
 
 const FormStub = {
   name: 'Form',
-  props: ['navigation', 'namespace', 'validData'],
+  props: ['navigation', 'namespace', 'validData', 'autoStart', 'bannerTitle'],
   template: '<div class="form-stub" :data-namespace="namespace" />',
 }
 
@@ -38,6 +43,7 @@ describe('App.vue', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia())
+    localStorage.clear()
     taskStore = useTaskStore()
     answerStore = useAnswerStore()
   })
@@ -73,6 +79,8 @@ describe('App.vue', () => {
     expect(form.exists()).toBe(true)
     expect(form.props('namespace')).toBe(FormType.DPIA)
     expect(form.props('validData')).toBeNull()
+    // The "Invulhulpen" title is shown next to the logo on form pages too.
+    expect(form.props('bannerTitle')).toBe('Invulhulpen')
   })
 
   it('navigates to the Pre-Scan DPIA form via goToPreScanDPIA and configures the stores', async () => {
@@ -129,5 +137,88 @@ describe('App.vue', () => {
     expect(taskStore.activeNamespace).toBe(FormType.DPIA)
     expect(wrapper.findComponent(LandingStub).exists()).toBe(true)
     expect(wrapper.findComponent(FormStub).exists()).toBe(false)
+  })
+})
+
+describe('App.vue — cached sessions (#322)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  function seedCache(ns: FormType): void {
+    localStorage.setItem(storageKey(ns), JSON.stringify({ answers: { '0.1': { value: 'X' } } }))
+  }
+
+  it('passes no cachedTypes to LandingView when localStorage is empty', () => {
+    const wrapper = mountApp()
+    const cached = wrapper.findComponent(LandingStub).props('cachedTypes') as FormType[]
+    expect(cached).toEqual([])
+  })
+
+  it('detects cached assessments from localStorage on mount', () => {
+    seedCache(FormType.DPIA)
+    seedCache(FormType.IAMA)
+
+    const wrapper = mountApp()
+    const cached = wrapper.findComponent(LandingStub).props('cachedTypes') as FormType[]
+    expect(cached).toEqual([FormType.DPIA, FormType.IAMA])
+  })
+
+  it('refreshes cachedTypes when returning to the landing page', async () => {
+    const wrapper = mountApp()
+    const nav = wrapper.findComponent(LandingStub).props('navigation') as NavigationFunctions
+
+    nav.goToDPIA()
+    await wrapper.vm.$nextTick()
+
+    // Saved progress appears while the form is open.
+    seedCache(FormType.DPIA)
+
+    nav.goToLanding()
+    await wrapper.vm.$nextTick()
+
+    const cached = wrapper.findComponent(LandingStub).props('cachedTypes') as FormType[]
+    expect(cached).toEqual([FormType.DPIA])
+  })
+
+  it.each([
+    [FormType.PRE_SCAN],
+    [FormType.DPIA],
+    [FormType.IAMA],
+  ])('startFresh(%s) clears the saved state and opens a fresh form (no autoStart)', async (type) => {
+    seedCache(type)
+    const wrapper = mountApp()
+
+    wrapper.findComponent(LandingStub).vm.$emit('startFresh', type)
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem(storageKey(type))).toBeNull()
+    const taskStore = useTaskStore()
+    expect(taskStore.activeNamespace).toBe(type)
+    const form = wrapper.findComponent(FormStub)
+    expect(form.exists()).toBe(true)
+    // Fresh start shows the intro/upload page, so the form is not auto-started.
+    expect(form.props('autoStart')).toBe(false)
+    expect(wrapper.findComponent(LandingStub).exists()).toBe(false)
+  })
+
+  it.each([
+    [FormType.PRE_SCAN, 'goToPreScanDPIA'],
+    [FormType.DPIA, 'goToDPIA'],
+    [FormType.IAMA, 'goToIAMA'],
+  ] as const)('resuming %s (cache present) auto-starts the form', async (type, navFn) => {
+    seedCache(type)
+    const wrapper = mountApp()
+    const nav = wrapper.findComponent(LandingStub).props('navigation') as NavigationFunctions
+
+    // "Verder gaan" simply navigates; saved state is still present.
+    nav[navFn]!()
+    await wrapper.vm.$nextTick()
+
+    const form = wrapper.findComponent(FormStub)
+    expect(form.exists()).toBe(true)
+    expect(form.props('namespace')).toBe(type)
+    expect(form.props('autoStart')).toBe(true)
   })
 })

--- a/apps/standalone-form/test/cov/LocalPersistence.cov.test.ts
+++ b/apps/standalone-form/test/cov/LocalPersistence.cov.test.ts
@@ -270,6 +270,49 @@ describe('createLocalPersistence — loadAppState', () => {
   })
 })
 
+describe('createLocalPersistence — hasSavedState', () => {
+  it('returns false when nothing is stored for the namespace', () => {
+    const provider = createLocalPersistence()
+    expect(provider.hasSavedState(FormType.DPIA)).toBe(false)
+  })
+
+  it('returns true for a flat state with at least one answer', () => {
+    localStorage.setItem(
+      storageKey(FormType.DPIA),
+      JSON.stringify({ answers: { '0.1': { value: 'X' } } }),
+    )
+    const provider = createLocalPersistence()
+    expect(provider.hasSavedState(FormType.DPIA)).toBe(true)
+  })
+
+  it('returns false for a flat state with empty answers', () => {
+    localStorage.setItem(storageKey(FormType.DPIA), JSON.stringify({ answers: {} }))
+    const provider = createLocalPersistence()
+    expect(provider.hasSavedState(FormType.DPIA)).toBe(false)
+  })
+
+  it('returns false when the stored state has no answers field', () => {
+    localStorage.setItem(storageKey(FormType.DPIA), JSON.stringify({ metadata: { urn: DPIA_URN } }))
+    const provider = createLocalPersistence()
+    expect(provider.hasSavedState(FormType.DPIA)).toBe(false)
+  })
+
+  it('returns true for an old namespaced state with answers for that namespace', () => {
+    localStorage.setItem(
+      storageKey(FormType.DPIA),
+      JSON.stringify({ answers: { [FormType.DPIA]: { '0.1': { value: 'NS' } } } }),
+    )
+    const provider = createLocalPersistence()
+    expect(provider.hasSavedState(FormType.DPIA)).toBe(true)
+  })
+
+  it('returns false when the stored JSON is invalid', () => {
+    localStorage.setItem(storageKey(FormType.DPIA), '{ not valid json')
+    const provider = createLocalPersistence()
+    expect(provider.hasSavedState(FormType.DPIA)).toBe(false)
+  })
+})
+
 describe('createLocalPersistence — applyAppState', () => {
   it('writes completedTasks and flat answers into the stores', () => {
     const taskStore = useTaskStore()

--- a/apps/standalone-form/test/cov/components-LandingView.cov.test.ts
+++ b/apps/standalone-form/test/cov/components-LandingView.cov.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
-import type { NavigationFunctions } from '@overheid-assessment/core'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { FormType, type NavigationFunctions } from '@overheid-assessment/core'
 import LandingView from '@/components/LandingView.vue'
 
 function makeNavigation(): NavigationFunctions {
@@ -12,9 +12,24 @@ function makeNavigation(): NavigationFunctions {
   }
 }
 
+function mountLanding(
+  overrides: { navigation?: NavigationFunctions; cachedTypes?: FormType[] } = {},
+) {
+  const navigation = overrides.navigation ?? makeNavigation()
+  return mount(LandingView, {
+    props: { navigation, cachedTypes: overrides.cachedTypes ?? [] },
+  })
+}
+
+function clickButtonByText(wrapper: VueWrapper, text: string) {
+  const button = wrapper.findAll('button').find((b) => b.text() === text)
+  if (!button) throw new Error(`Button not found: ${text}`)
+  return button.trigger('click')
+}
+
 describe('LandingView rendering', () => {
   it('renders the page heading and the AppBanner', () => {
-    const wrapper = mount(LandingView, { props: { navigation: makeNavigation() } })
+    const wrapper = mountLanding()
 
     expect(wrapper.find('h1.utrecht-heading-1').text()).toBe(
       'Invulhulp voor pre-scan, DPIA en IAMA',
@@ -22,70 +37,66 @@ describe('LandingView rendering', () => {
     expect(wrapper.findComponent({ name: 'AppBanner' }).exists()).toBe(true)
   })
 
-  it('renders the two assessment cards with their Dutch descriptions', () => {
-    const wrapper = mount(LandingView, { props: { navigation: makeNavigation() } })
+  it('shows the "Invulhulpen" title next to the logo', () => {
+    const wrapper = mountLanding()
+    expect(wrapper.find('.rvo-logo__title').text()).toBe('Invulhulpen')
+  })
+
+  it('renders the assessment cards with their Dutch descriptions', () => {
+    const wrapper = mountLanding()
 
     const headings = wrapper.findAll('h2.utrecht-heading-2').map((h) => h.text())
     expect(headings).toContain('Pre-scan')
     expect(headings).toContain('DPIA')
+    expect(headings).toContain('IAMA')
 
     expect(wrapper.text()).toContain('Toets of een DPIA, DTIA, IAMA of KIA nodig is.')
     expect(wrapper.text()).toContain('Vul stap voor stap het rijksmodel DPIA in.')
   })
 
-  it('renders both start buttons with the correct Dutch labels', () => {
-    const wrapper = mount(LandingView, { props: { navigation: makeNavigation() } })
+  it('renders all three start buttons with the correct Dutch labels when no cache exists', () => {
+    const wrapper = mountLanding()
 
-    const buttonLabels = wrapper
-      .findAll('button.card-button')
-      .map((b) => b.text())
+    const buttonLabels = wrapper.findAll('button.card-button').map((b) => b.text())
     expect(buttonLabels).toEqual(['Start pre-scan', 'Start DPIA', 'Start IAMA'])
   })
 
   it('renders the "Over deze tools" informational section', () => {
-    const wrapper = mount(LandingView, { props: { navigation: makeNavigation() } })
+    const wrapper = mountLanding()
 
     expect(wrapper.text()).toContain('Over deze tools')
     expect(wrapper.text()).toContain('pre-scan, DPIA en het IAMA')
   })
 })
 
-describe('LandingView navigation interaction', () => {
+describe('LandingView navigation interaction (no cache)', () => {
   it('calls navigation.goToPreScanDPIA when the pre-scan button is clicked', async () => {
     const navigation = makeNavigation()
-    const wrapper = mount(LandingView, { props: { navigation } })
+    const wrapper = mountLanding({ navigation })
 
-    const buttons = wrapper.findAll('button.card-button')
-    await buttons[0].trigger('click')
+    await clickButtonByText(wrapper, 'Start pre-scan')
 
     expect(navigation.goToPreScanDPIA).toHaveBeenCalledTimes(1)
     expect(navigation.goToDPIA).not.toHaveBeenCalled()
-    expect(navigation.goToLanding).not.toHaveBeenCalled()
   })
 
   it('calls navigation.goToDPIA when the DPIA button is clicked', async () => {
     const navigation = makeNavigation()
-    const wrapper = mount(LandingView, { props: { navigation } })
+    const wrapper = mountLanding({ navigation })
 
-    const buttons = wrapper.findAll('button.card-button')
-    await buttons[1].trigger('click')
+    await clickButtonByText(wrapper, 'Start DPIA')
 
     expect(navigation.goToDPIA).toHaveBeenCalledTimes(1)
     expect(navigation.goToPreScanDPIA).not.toHaveBeenCalled()
-    expect(navigation.goToLanding).not.toHaveBeenCalled()
   })
 
   it('calls navigation.goToIAMA when the IAMA button is clicked', async () => {
     const navigation = makeNavigation()
-    const wrapper = mount(LandingView, { props: { navigation } })
+    const wrapper = mountLanding({ navigation })
 
-    const buttons = wrapper.findAll('button.card-button')
-    await buttons[2].trigger('click')
+    await clickButtonByText(wrapper, 'Start IAMA')
 
     expect(navigation.goToIAMA).toHaveBeenCalledTimes(1)
-    expect(navigation.goToDPIA).not.toHaveBeenCalled()
-    expect(navigation.goToPreScanDPIA).not.toHaveBeenCalled()
-    expect(navigation.goToLanding).not.toHaveBeenCalled()
   })
 
   it('does not throw when the IAMA button is clicked without a goToIAMA handler', async () => {
@@ -94,9 +105,171 @@ describe('LandingView navigation interaction', () => {
       goToDPIA: vi.fn(),
       goToPreScanDPIA: vi.fn(),
     }
-    const wrapper = mount(LandingView, { props: { navigation } })
+    const wrapper = mountLanding({ navigation })
 
-    const buttons = wrapper.findAll('button.card-button')
-    await expect(buttons[2].trigger('click')).resolves.not.toThrow()
+    await expect(clickButtonByText(wrapper, 'Start IAMA')).resolves.not.toThrow()
+  })
+})
+
+describe('LandingView cached-session choice (#322)', () => {
+  it('shows "Verder gaan" and a per-type "Start nieuwe ..." instead of "Start" for a cached assessment', () => {
+    const wrapper = mountLanding({ cachedTypes: [FormType.DPIA] })
+
+    const labels = wrapper.findAll('button').map((b) => b.text())
+    expect(labels).toContain('Verder gaan')
+    expect(labels).toContain('Start nieuwe DPIA')
+    // The cached card no longer shows its plain start button.
+    expect(labels).not.toContain('Start DPIA')
+    // Other cards remain unaffected.
+    expect(labels).toContain('Start pre-scan')
+  })
+
+  it('"Verder gaan" resumes via the matching navigation function', async () => {
+    const navigation = makeNavigation()
+    const wrapper = mountLanding({ navigation, cachedTypes: [FormType.DPIA] })
+
+    await clickButtonByText(wrapper, 'Verder gaan')
+
+    expect(navigation.goToDPIA).toHaveBeenCalledTimes(1)
+  })
+
+  it('"Start nieuwe DPIA" opens a type-specific confirmation and emits startFresh on confirm', async () => {
+    const wrapper = mountLanding({ cachedTypes: [FormType.DPIA] })
+
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+
+    await clickButtonByText(wrapper, 'Start nieuwe DPIA')
+    const dialog = wrapper.find('[role="dialog"]')
+    expect(dialog.exists()).toBe(true)
+    expect(dialog.text()).toContain('Nieuwe DPIA starten?')
+
+    await clickButtonByText(wrapper, 'Ja, start nieuwe DPIA')
+
+    expect(wrapper.emitted('startFresh')).toEqual([[FormType.DPIA]])
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+  })
+
+  it('closes the confirmation without emitting when cancelled', async () => {
+    const wrapper = mountLanding({ cachedTypes: [FormType.PRE_SCAN] })
+
+    await clickButtonByText(wrapper, 'Start nieuwe pre-scan')
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+
+    await clickButtonByText(wrapper, 'Annuleren')
+
+    expect(wrapper.emitted('startFresh')).toBeUndefined()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+  })
+
+  it('closes the confirmation when the backdrop is clicked', async () => {
+    const wrapper = mountLanding({ cachedTypes: [FormType.IAMA] })
+
+    await clickButtonByText(wrapper, 'Start nieuwe IAMA')
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+
+    await wrapper.find('.fresh-confirm-overlay').trigger('click')
+
+    expect(wrapper.emitted('startFresh')).toBeUndefined()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+  })
+})
+
+describe('LandingView offline-download visibility', () => {
+  const realLocation = window.location
+
+  function setProtocol(protocol: string): void {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { protocol, href: 'http://localhost/index.html' },
+    })
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    Object.defineProperty(window, 'location', { configurable: true, value: realLocation })
+  })
+
+  it('hides the offline-download section in dev (non-production build)', () => {
+    vi.stubEnv('PROD', false)
+    const wrapper = mountLanding()
+    expect(wrapper.text()).not.toContain('Offline gebruiken')
+  })
+
+  it('hides the offline-download section when opened as a local file', () => {
+    vi.stubEnv('PROD', true)
+    setProtocol('file:')
+    const wrapper = mountLanding()
+    expect(wrapper.text()).not.toContain('Offline gebruiken')
+  })
+
+  it('shows the offline-download section on the hosted, built app', () => {
+    vi.stubEnv('PROD', true)
+    setProtocol('https:')
+    const wrapper = mountLanding()
+    expect(wrapper.text()).toContain('Offline gebruiken')
+  })
+})
+
+describe('LandingView offline HTML download', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>
+  let revokeObjectURL: ReturnType<typeof vi.fn>
+  let clickSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // The download UI is only rendered on the hosted, built app.
+    vi.stubEnv('PROD', true)
+    createObjectURL = vi.fn(() => 'blob:fake-url')
+    revokeObjectURL = vi.fn()
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = createObjectURL
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = revokeObjectURL
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('downloads the running HTML as a standalone file on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('<html>standalone</html>'),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountLanding()
+    await clickButtonByText(wrapper, 'Download invulhulp als HTML-bestand')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith(window.location.href, { cache: 'no-store' })
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(createObjectURL.mock.calls[0][0]).toBeInstanceOf(Blob)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url')
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+  })
+
+  it('shows an error message when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+
+    const wrapper = mountLanding()
+    await clickButtonByText(wrapper, 'Download invulhulp als HTML-bestand')
+    await flushPromises()
+
+    expect(clickSpy).not.toHaveBeenCalled()
+    const alert = wrapper.find('[role="alert"]')
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toContain('Het downloaden is niet gelukt')
+  })
+
+  it('shows an error message when the fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+
+    const wrapper = mountLanding()
+    await clickButtonByText(wrapper, 'Download invulhulp als HTML-bestand')
+    await flushPromises()
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true)
   })
 })

--- a/apps/standalone-form/vite.config.ts
+++ b/apps/standalone-form/vite.config.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 
 import { defineConfig, type Plugin } from 'vite'

--- a/packages/assessment-core/src/components/ExportPdfInfo.vue
+++ b/packages/assessment-core/src/components/ExportPdfInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card__full-card-link rvo-card--full-colour-wit">
+  <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour-wit">
     <div class="rvo-layout-row rvo-layout-gap--xs" style="align-items: center;">
       <span class="utrecht-icon rvo-icon rvo-icon-info rvo-icon--xl rvo-status-icon-info" role="img" aria-label="Info"></span>
       <strong>Opslaan en delen van je werk</strong>

--- a/packages/assessment-core/src/components/Form.vue
+++ b/packages/assessment-core/src/components/Form.vue
@@ -33,11 +33,13 @@ const props = withDefaults(defineProps<{
   showNavHeader?: boolean
   showFileActions?: boolean
   autoStart?: boolean
+  bannerTitle?: string
 }>(), {
   showBanner: true,
   showNavHeader: true,
   showFileActions: true,
   autoStart: false,
+  bannerTitle: '',
 })
 
 // State
@@ -214,7 +216,7 @@ const isInformationalStep = computed(() => {
 </script>
 
 <template>
-  <Banner v-if="showBanner" />
+  <Banner v-if="showBanner" :title="bannerTitle" />
   <div v-if="isLoading" class="rvo-max-width-layout rvo-max-width-layout--lg rvo-max-width-layout-inline-padding--md">
     <p>Ophalen van taken...</p>
   </div>


### PR DESCRIPTION
## Wat

Twee verbeteringen voor de **standalone-form**, plus wat UX-finetuning.

### #322 — Cache-keuze op de landingspagina
Voorheen werd bij bestaande cache stilzwijgend de vorige sessie geladen. Nu toont een assessment-kaart met opgeslagen voortgang twee knoppen:

- **Verder gaan** — hervat de sessie en springt **direct het formulier in** (geen tussenliggend start-/uploadscherm meer).
- **Start nieuwe \<type\>** — wist de cache ná bevestiging (type-specifieke dialoog) en begint schoon.

Kaarten zonder cache tonen gewoon **Start \<type\>**.

### Offline gebruiken — download als HTML
Nieuwe knop onderaan de landing die de gehoste single-file build als **standalone HTML-bestand** downloadt (`fetch(location.href)` → blob-download). Werkt omdat de productie-build al één self-contained bestand is (`vite-plugin-singlefile` + inline favicon/fonts/JSON).

Slim verborgen: alleen zichtbaar op de **gehoste, gebouwde** app — niet in dev (geen single-file bundle) en niet in de **offline-kopie zelf** (`file://`), zodat er geen circulaire download-knop in het gedownloade bestand staat.

### Overige UX
- **"Invulhulpen"** naast het logo op de landing én de formulier-pagina's (nieuwe optionele `bannerTitle`-prop op `Form`; boekhouding blijft ongewijzigd).
- **ExportPdfInfo**: `rvo-card__full-card-link` verwijderd — die gaf een ongewenste hover-randkleur op een niet-klikbaar infoblok.
- Ongebruikte import uit `vite.config.ts` verwijderd.

## Verificatie
- Type-check schoon; lint volledig schoon.
- **100% testdekking** behouden in zowel `standalone-form` als `assessment-core`.
- Productie-build geverifieerd: één bestand (~7,5 MB), 0 console-errors, rendert volledig standalone vanaf schijf.

Closes #322