### PR TITLE
Hernoem Assessment Boekhouding naar Invulhulpen + RVO logo-tagline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Assessment Boekhouding
+# Invulhulpen voor pre-scan, DPIA en IAMA
 
 Pre-scan-, DPIA- en IAMA-assessment-applicatie voor de overheid, gebouwd op het RVO component library.
 
@@ -70,7 +70,7 @@ De tsconfigs in `apps/*` en `packages/*` erven gedeelde instellingen via `extend
 - Database: PostgreSQL 17 via Drizzle ORM
 - Auth: Keycloak JWT-verificatie via `jose` met audience-validatie (geen cookies/sessies)
 - Migraties: `pnpm db:generate` → `pnpm db:migrate`
-- Realm: `assessment-boekhouding`, client: `boekhouding-frontend`
+- Realm: `invulhulpen`, client: `boekhouding-frontend`
 - API-routes onder `/api/v1/` (NL GOV API Design Rules: major versie in URI-pad)
 - Foutresponses: `application/problem+json` (RFC 9457)
 - Security: `@fastify/helmet` (security headers), `@fastify/rate-limit`, `API-Version` response header

--- a/.claude/skills/run-dev-stack/SKILL.md
+++ b/.claude/skills/run-dev-stack/SKILL.md
@@ -17,7 +17,7 @@ postgres + keycloak + backend + frontend + standalone. Runs on **podman**
 | frontend (boekhouding) | http://localhost:5174 | Vite dev, live-reload via `src/` mount |
 | standalone (zelfstandig invullen) | http://localhost:5175 | Vite dev, live-reload via `src/` mount |
 | backend API | http://localhost:3000/api | health: `/api/health` |
-| keycloak | http://localhost:8080 | realm `assessment-boekhouding`; admin `admin`/`admin` |
+| keycloak | http://localhost:8080 | realm `invulhulpen`; admin `admin`/`admin` |
 | postgres | localhost:5432 | `parassessment`/`parassessment`; shared by backend **and** keycloak |
 
 **App logins** (frontend → "Inloggen"): `sam@example.com` / `welkom123`,
@@ -80,7 +80,7 @@ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3000/api/health   # 20
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5174/              # 200
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5175/              # 200
 curl -s -o /dev/null -w '%{http_code}\n' \
-  http://localhost:8080/realms/assessment-boekhouding/.well-known/openid-configuration  # 200
+  http://localhost:8080/realms/invulhulpen/.well-known/openid-configuration  # 200
 ```
 
 Then load http://localhost:5174 in a browser and confirm the landing page

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Webapplicatie voor het uitvoeren van Pre-scan-, DPIA- en IAMA-assessments, volge
 ## Kenmerken
 
 - Pre-scan, DPIA en IAMA invullen in de browser als losstaande applicatie
-- Samenwerken aan Pre-scans, DPIA's en IAMA's via de Assessment Boekhouding:
+- Samenwerken aan Pre-scans, DPIA's en IAMA's via Invulhulpen:
   - Samenwerken aan assessments met meerdere gebruikers
   - Projectbeheer met rollen (eigenaar, bewerker, kijker)
   - Voortgang opslaan en later hervatten
@@ -133,7 +133,7 @@ Zie het [ontwerp](docs/ai-assistent/assessments-plugin-design.md) en de [verantw
 
 ## Standaarden en compliance
 
-De Assessment Boekhouding conformeert aan de volgende overheidsstandaarden:
+Invulhulpen conformeert aan de volgende overheidsstandaarden:
 
 | Standaard | Status |
 |-----------|--------|

--- a/apps/boekhouding-backend/src/app.ts
+++ b/apps/boekhouding-backend/src/app.ts
@@ -49,11 +49,11 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   if (exposeApiDocs) await app.register(swagger, {
     openapi: {
       info: {
-        title: 'Assessment Boekhouding API',
+        title: 'Invulhulpen API',
         description: 'REST API voor het beheren van assessments en projecten waarin assessments gegroepeerd kunnen worden.',
         version: API_VERSION,
         contact: {
-          name: 'Assessment Boekhouding — MinBZK',
+          name: 'Invulhulpen — MinBZK',
           url: config.publicUrl,
           email: 'RIG@rijksoverheid.nl',
         },
@@ -117,7 +117,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     routePrefix: '/api/docs',
     logo: { content: Buffer.from(''), type: 'image/svg+xml' },
     theme: {
-      title: 'Assessment Boekhouding API',
+      title: 'Invulhulpen API',
       css: [
         {
           filename: 'custom.css',

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -1,6 +1,6 @@
 const oidcUrl = process.env.OIDC_URL || 'http://localhost:8080'
 const oidcInternalUrl = process.env.OIDC_INTERNAL_URL || oidcUrl
-const oidcRealm = process.env.OIDC_REALM || 'assessment-boekhouding'
+const oidcRealm = process.env.OIDC_REALM || 'invulhulpen'
 
 // CORS_ORIGIN supports a single origin, or a comma-separated list for development
 // environments where the app is reached via multiple hostnames (localhost, myserver, etc.)

--- a/apps/boekhouding-backend/test/cov/app.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/app.cov.test.ts
@@ -101,7 +101,7 @@ describe('static utility routes', () => {
     const res = await app.inject({ method: 'GET', url: '/api/openapi.json' })
     expect(res.statusCode).toBe(200)
     const doc = res.json()
-    expect(doc.info.title).toBe('Assessment Boekhouding API')
+    expect(doc.info.title).toBe('Invulhulpen API')
     expect(doc.info.version).toBe(API_VERSION)
     expect(doc.info.contact.url).toBe(config.publicUrl)
   })

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -53,9 +53,9 @@ describe('config — defaults when no env vars are set', () => {
     expect(config.cors.origin).toBe('http://localhost:5174')
     expect(config.cors.credentials).toBe(true)
     expect(config.publicUrl).toBe('http://localhost:5174')
-    expect(config.keycloak.issuer).toBe('http://localhost:8080/realms/assessment-boekhouding')
+    expect(config.keycloak.issuer).toBe('http://localhost:8080/realms/invulhulpen')
     expect(config.keycloak.jwksUri).toBe(
-      'http://localhost:8080/realms/assessment-boekhouding/protocol/openid-connect/certs',
+      'http://localhost:8080/realms/invulhulpen/protocol/openid-connect/certs',
     )
     expect(config.keycloak.audience).toBe('boekhouding-frontend')
   })

--- a/apps/boekhouding-frontend/index.html
+++ b/apps/boekhouding-frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="node_modules/@nl-rvo/assets/images/favicon/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Assessment Boekhouding</title>
+    <title>Invulhulpen</title>
   </head>
   <body class="rvo-theme">
     <div id="app"></div>

--- a/apps/boekhouding-frontend/src/App.vue
+++ b/apps/boekhouding-frontend/src/App.vue
@@ -10,7 +10,7 @@ const homeUrl = computed(() => isAuthenticated.value ? '/projecten' : '/')
 
 <template>
   <div class="app-layout">
-    <AppBanner message="De Assessment Boekhouding en de invulhulpen zijn in ontwikkeling." title="Assessment Boekhouding" :homeUrl="homeUrl" />
+    <AppBanner message="Invulhulpen is in ontwikkeling." :homeUrl="homeUrl" />
     <router-view :key="$route.path" class="app-main" />
     <SessionExpiredDialog />
     <footer class="app-footer">
@@ -19,7 +19,7 @@ const homeUrl = computed(() => isAuthenticated.value ? '/projecten' : '/')
         <span class="app-footer__separator">|</span>
         <router-link to="/toegankelijkheid" class="app-footer__link">Toegankelijkheid</router-link>
         <span class="app-footer__separator">|</span>
-        <router-link to="/over" class="app-footer__link">Over de invulhulpen</router-link>
+        <router-link to="/over" class="app-footer__link">Over Invulhulpen</router-link>
       </nav>
     </footer>
   </div>

--- a/apps/boekhouding-frontend/src/config.ts
+++ b/apps/boekhouding-frontend/src/config.ts
@@ -15,9 +15,9 @@ export async function loadConfig(): Promise<AppConfig> {
     // Fallback for local development (Vite dev server)
     config = {
       keycloakUrl: import.meta.env.VITE_KEYCLOAK_URL || 'http://localhost:8080',
-      keycloakRealm: import.meta.env.VITE_KEYCLOAK_REALM || 'assessment-boekhouding',
+      keycloakRealm: import.meta.env.VITE_KEYCLOAK_REALM || 'invulhulpen',
       keycloakClientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID || 'boekhouding-frontend',
-      standaloneUrl: import.meta.env.VITE_STANDALONE_URL || '/invulhulpen/',
+      standaloneUrl: import.meta.env.VITE_STANDALONE_URL || '/zonder-account/',
     }
   }
   return config

--- a/apps/boekhouding-frontend/src/views/AboutAssessments.vue
+++ b/apps/boekhouding-frontend/src/views/AboutAssessments.vue
@@ -13,10 +13,10 @@ const hasHistory = computed(() => !!window.history.state?.back)
       :showBack="hasHistory"
     />
 
-    <h1 class="utrecht-heading-1">Over de invulhulpen</h1>
+    <h1 class="utrecht-heading-1">Over Invulhulpen</h1>
 
     <p>
-      De invulhulpen helpen je bij het invullen van een pre-scan, een volledige DPIA en een IAMA.
+      Invulhulpen helpt je bij het invullen van een pre-scan, een volledige DPIA en een IAMA.
       De pre-scan en DPIA zijn gebaseerd op het
       <a href="https://modellen.jenvgegevens.nl/dpia/#IntroPre-scanDPIA" target="_blank" rel="noopener noreferrer">Informatiemodellen voor de DPIA en pre-scan DPIA</a>
       en het

--- a/apps/boekhouding-frontend/src/views/AccessibilityStatement.vue
+++ b/apps/boekhouding-frontend/src/views/AccessibilityStatement.vue
@@ -23,7 +23,7 @@ const hasHistory = computed(() => !!window.history.state?.back)
 
     <h2 class="utrecht-heading-2">Nalevingsstatus</h2>
     <p>
-      De Assessment Boekhouding voldoet <strong>gedeeltelijk</strong> aan de
+      Invulhulpen voldoet <strong>gedeeltelijk</strong> aan de
       <a href="https://www.w3.org/TR/WCAG22/" target="_blank" rel="noopener noreferrer">Web Content Accessibility Guidelines (WCAG) 2.2</a>
       niveau AA. De applicatie is in actieve ontwikkeling en we werken aan volledige naleving.
     </p>

--- a/apps/boekhouding-frontend/src/views/LandingPage.vue
+++ b/apps/boekhouding-frontend/src/views/LandingPage.vue
@@ -20,7 +20,7 @@ async function goToProjects() {
 <template>
   <div class="rvo-max-width-layout rvo-max-width-layout--md rvo-max-width-layout-inline-padding--md">
     <AppHeader />
-    <h1 class="utrecht-heading-1 rvo-margin-block-start--xl">Assessment Boekhouding</h1>
+    <h1 class="utrecht-heading-1 rvo-margin-block-start--xl">Invulhulpen</h1>
 
     <div class="rvo-layout-grid-container rvo-margin-block-start--lg">
       <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--two">
@@ -45,10 +45,10 @@ async function goToProjects() {
             <h2 class="utrecht-heading-2 rvo-margin--none">Samenwerken</h2>
             <p class="rvo-padding-block-end--sm">
               <template v-if="isAuthenticated">
-                Ga naar je projecten om samen met collega's aan assessments te werken.
+                Ga naar je projecten en werk samen met je collega's aan een pre-scan, DPIA en/of IAMA.
               </template>
               <template v-else>
-                Log in om samen met collega's aan assessments te werken. Beheer projecten,
+                Log in om samen met collega's aan een pre-scan, DPIA of IAMA te werken. Beheer projecten,
                 nodig leden uit en houd de voortgang bij.
               </template>
             </p>

--- a/apps/boekhouding-frontend/src/views/PrivacyStatement.vue
+++ b/apps/boekhouding-frontend/src/views/PrivacyStatement.vue
@@ -16,14 +16,14 @@ const hasHistory = computed(() => !!window.history.state?.back)
     <h1 class="utrecht-heading-1">Privacyverklaring</h1>
 
     <p>
-      De Assessment Boekhouding is een applicatie van het Ministerie van Binnenlandse Zaken en
-      Koninkrijksrelaties (BZK) voor het uitvoeren van assessments. In deze
+      Invulhulpen is een applicatie van het Ministerie van Binnenlandse Zaken en
+      Koninkrijksrelaties (BZK), bedoeld als hulpmiddel bij het uitvoeren van een pre-scan, DPIA of IAMA. In deze
       privacyverklaring leggen we uit welke persoonsgegevens we verwerken, waarom we dat doen,
       en welke rechten je hebt.
     </p>
 
     <h2 class="utrecht-heading-2">Welke gegevens verwerken we?</h2>
-    <p>Bij het gebruik van de Assessment Boekhouding verwerken we de volgende persoonsgegevens:</p>
+    <p>Bij het gebruik van Invulhulpen verwerken we de volgende persoonsgegevens:</p>
     <ul>
       <li><strong>E-mailadres</strong> — verkregen via de inlogvoorziening (SSO Rijk / RIG Keycloak) bij authenticatie</li>
       <li><strong>Weergavenaam</strong> — verkregen via de inlogvoorziening bij authenticatie</li>

--- a/apps/boekhouding-frontend/test/cov/App.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/App.cov.test.ts
@@ -63,7 +63,7 @@ describe('App.vue', () => {
     expect(footerLinks.map((l) => l.text())).toEqual([
       'Privacyverklaring',
       'Toegankelijkheid',
-      'Over de invulhulpen',
+      'Over Invulhulpen',
     ])
     expect(footerLinks.map((l) => l.attributes('href'))).toEqual([
       '/privacy',

--- a/apps/boekhouding-frontend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/config.cov.test.ts
@@ -22,9 +22,9 @@ describe('config', () => {
     it('returns the JSON payload from /config.json', async () => {
       const payload = {
         keycloakUrl: 'https://keycloak.assessment.test',
-        keycloakRealm: 'assessment-boekhouding',
+        keycloakRealm: 'invulhulpen',
         keycloakClientId: 'boekhouding-frontend',
-        standaloneUrl: '/invulhulpen/',
+        standaloneUrl: '/zonder-account/',
       }
       const fetchMock = vi.fn().mockResolvedValue({
         json: () => Promise.resolve(payload),
@@ -72,9 +72,9 @@ describe('config', () => {
 
       expect(result).toEqual({
         keycloakUrl: 'http://localhost:8080',
-        keycloakRealm: 'assessment-boekhouding',
+        keycloakRealm: 'invulhulpen',
         keycloakClientId: 'boekhouding-frontend',
-        standaloneUrl: '/invulhulpen/',
+        standaloneUrl: '/zonder-account/',
       })
     })
   })
@@ -89,9 +89,9 @@ describe('config', () => {
     it('returns the cached config after loadConfig() has run', async () => {
       const payload = {
         keycloakUrl: 'https://keycloak.assessment.test',
-        keycloakRealm: 'assessment-boekhouding',
+        keycloakRealm: 'invulhulpen',
         keycloakClientId: 'boekhouding-frontend',
-        standaloneUrl: '/invulhulpen/',
+        standaloneUrl: '/zonder-account/',
       }
       vi.stubGlobal(
         'fetch',

--- a/apps/boekhouding-frontend/test/cov/views-AboutAssessments.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-AboutAssessments.cov.test.ts
@@ -70,7 +70,7 @@ describe('AboutAssessments', () => {
 
       const wrapper = mountAbout()
 
-      expect(wrapper.find('h1.utrecht-heading-1').text()).toBe('Over de invulhulpen')
+      expect(wrapper.find('h1.utrecht-heading-1').text()).toBe('Over Invulhulpen')
     })
 
     it('renders the key section headings explaining pre-scan, DPIA and IAMA', () => {

--- a/apps/boekhouding-frontend/test/cov/views-LandingPage.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-LandingPage.cov.test.ts
@@ -22,9 +22,9 @@ vi.mock('../../src/composables/useAuth', () => ({
 vi.mock('../../src/config', () => ({
   getConfig: () => ({
     keycloakUrl: 'http://localhost:8080',
-    keycloakRealm: 'assessment-boekhouding',
+    keycloakRealm: 'invulhulpen',
     keycloakClientId: 'boekhouding-frontend',
-    standaloneUrl: '/invulhulpen/',
+    standaloneUrl: '/zonder-account/',
   }),
 }))
 
@@ -51,13 +51,13 @@ describe('LandingPage', () => {
       const wrapper = mountPage()
       const link = wrapper.find('a.utrecht-button')
       expect(link.exists()).toBe(true)
-      expect(link.attributes('href')).toBe('/invulhulpen/')
+      expect(link.attributes('href')).toBe('/zonder-account/')
       expect(link.text()).toBe('Start zonder account')
     })
 
     it('renders the page heading', () => {
       const wrapper = mountPage()
-      expect(wrapper.find('h1').text()).toBe('Assessment Boekhouding')
+      expect(wrapper.find('h1').text()).toBe('Invulhulpen')
     })
   })
 

--- a/apps/standalone-form/src/components/LandingView.vue
+++ b/apps/standalone-form/src/components/LandingView.vue
@@ -100,7 +100,7 @@ async function downloadOfflineApp() {
   <AppBanner title="Invulhulpen" />
   <div class="rvo-layout-column rvo-layout-gap--3xl rvo-margin-block-start--xl">
     <div class="rvo-max-width-layout rvo-max-width-layout--md rvo-max-width-layout-inline-padding--md">
-      <h1 class="utrecht-heading-1">Invulhulp voor pre-scan, DPIA en IAMA</h1>
+      <h1 class="utrecht-heading-1">Invulhulpen voor pre-scan, DPIA en IAMA</h1>
       <div class="rvo-layout-grid-container rvo-margin-inline-end--md">
         <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--two">
           <div

--- a/apps/standalone-form/test/cov/components-LandingView.cov.test.ts
+++ b/apps/standalone-form/test/cov/components-LandingView.cov.test.ts
@@ -32,7 +32,7 @@ describe('LandingView rendering', () => {
     const wrapper = mountLanding()
 
     expect(wrapper.find('h1.utrecht-heading-1').text()).toBe(
-      'Invulhulp voor pre-scan, DPIA en IAMA',
+      'Invulhulpen voor pre-scan, DPIA en IAMA',
     )
     expect(wrapper.findComponent({ name: 'AppBanner' }).exists()).toBe(true)
   })

--- a/containers/compose-dev-keycloak.json
+++ b/containers/compose-dev-keycloak.json
@@ -1,6 +1,6 @@
 {
-  "realm": "assessment-boekhouding",
-  "displayName": "Assessment Boekhouding",
+  "realm": "invulhulpen",
+  "displayName": "Invulhulpen",
   "enabled": true,
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,

--- a/containers/compose.dev.yaml
+++ b/containers/compose.dev.yaml
@@ -49,7 +49,7 @@ services:
       CORS_ORIGIN: http://localhost:5174
       OIDC_URL: http://localhost:8080
       OIDC_INTERNAL_URL: http://keycloak:8080
-      OIDC_REALM: assessment-boekhouding
+      OIDC_REALM: invulhulpen
       OIDC_PUBLIC_CLIENT_ID: boekhouding-frontend
       NODE_ENV: development
       EXPOSE_API_DOCS: "true"
@@ -93,7 +93,7 @@ services:
       API_URL: http://backend:3000
       VITE_STANDALONE_URL: http://localhost:5175/
       VITE_KEYCLOAK_URL: http://localhost:8080
-      VITE_KEYCLOAK_REALM: assessment-boekhouding
+      VITE_KEYCLOAK_REALM: invulhulpen
       VITE_KEYCLOAK_CLIENT_ID: boekhouding-frontend
     volumes:
       - ../packages/assessment-core/src:/app/packages/assessment-core/src

--- a/containers/frontend/Containerfile
+++ b/containers/frontend/Containerfile
@@ -40,8 +40,8 @@ FROM nginxinc/nginx-unprivileged:stable-alpine-slim
 # Hoofd-SPA
 COPY --from=build /app/apps/boekhouding-frontend/dist /usr/share/nginx/html
 
-# Standalone invulhulp op /invulhulpen/ (index.html + favicon)
-COPY --from=build /app/apps/standalone-form/dist/ /usr/share/nginx/html/invulhulpen/
+# Standalone invulhulp op /zonder-account/ (index.html + favicon)
+COPY --from=build /app/apps/standalone-form/dist/ /usr/share/nginx/html/zonder-account/
 
 # Nginx configuratie
 COPY containers/frontend/nginx.conf /etc/nginx/nginx.conf
@@ -51,9 +51,9 @@ COPY containers/frontend/config.json.template /etc/nginx/config.json.template
 COPY --chmod=755 containers/frontend/entrypoint.sh /entrypoint.sh
 
 ENV OIDC_URL=http://localhost:8080
-ENV OIDC_REALM=assessment-boekhouding
+ENV OIDC_REALM=invulhulpen
 ENV OIDC_PUBLIC_CLIENT_ID=boekhouding-frontend
-ENV STANDALONE_URL=/invulhulpen/
+ENV STANDALONE_URL=/zonder-account/
 
 EXPOSE 8080
 ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/frontend/default.conf
+++ b/containers/frontend/default.conf
@@ -37,9 +37,9 @@ server {
 
     # Standalone invulhulp (single-file SPA via viteSingleFile)
     # viteSingleFile inlinet alle JS/CSS → vereist 'unsafe-inline' voor script-src
-    location /invulhulpen/ {
-        alias /usr/share/nginx/html/invulhulpen/;
-        try_files $uri /invulhulpen/index.html;
+    location /zonder-account/ {
+        alias /usr/share/nginx/html/zonder-account/;
+        try_files $uri /zonder-account/index.html;
 
         add_header Cache-Control "public, max-age=0, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ URL: https://invulhulpen.rijksapp.nl
 │
 ├── /                              → ZAD ingress → frontend (nginx:8080)
 │   ├── /                          → Vue SPA
-│   ├── /invulhulpen/              → standalone form
+│   ├── /zonder-account/           → standalone form
 │   └── /.well-known/security.txt  → 302 → ncsc.nl
 │
 └── /api                           → ZAD ingress → api (node:3000)
@@ -36,7 +36,7 @@ podman build -f containers/backend/Containerfile -t backend .
 
 # Verificatie
 podman run --rm frontend sh -c \
-  "ls /usr/share/nginx/html/invulhulpen/ && cat /etc/nginx/nginx.conf"
+  "ls /usr/share/nginx/html/zonder-account/ && cat /etc/nginx/nginx.conf"
 ```
 
 ## Database migraties
@@ -70,9 +70,9 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 | Variabele               | Default                  | ZAD                           |
 |-------------------------|--------------------------|-------------------------------|
 | `OIDC_URL`              | `http://localhost:8080`  | Auto-inject door ZAD Keycloak |
-| `OIDC_REALM`            | `assessment-boekhouding` | Auto-inject door ZAD Keycloak |
+| `OIDC_REALM`            | `invulhulpen` | Auto-inject door ZAD Keycloak |
 | `OIDC_PUBLIC_CLIENT_ID` | `boekhouding-frontend`   | Auto-inject door ZAD Keycloak |
-| `STANDALONE_URL`        | `/invulhulpen/`          | Default is correct            |
+| `STANDALONE_URL`        | `/zonder-account/`          | Default is correct            |
 
 ### Backend (runtime)
 
@@ -80,7 +80,7 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 |------------------------|------------------------------|-------------------------------------------|
 | `DATABASE_SERVER_FULL` | `postgresql://...@localhost` | Auto-inject door ZAD                      |
 | `OIDC_URL`             | `http://localhost:8080`      | Auto-inject door ZAD Keycloak             |
-| `OIDC_REALM`           | `assessment-boekhouding`     | Auto-inject door ZAD Keycloak             |
+| `OIDC_REALM`           | `invulhulpen`     | Auto-inject door ZAD Keycloak             |
 | `OIDC_CLIENT_ID`       | `boekhouding-frontend`       | Auto-inject door ZAD Keycloak             |
 | `PUBLIC_HOST`          | —                            | Auto-inject (volgt webadres → CORS + OpenAPI `contact.url`) |
 | `PORT`                 | `3000`                       | Default is correct                        |

--- a/docs/gegevensverwerking.md
+++ b/docs/gegevensverwerking.md
@@ -1,8 +1,8 @@
-# Gegevensverwerking Assessment Boekhouding
+# Gegevensverwerking Invulhulpen
 
 ## Status
 
-Dit document beschrijft welke persoonsgegevens de Assessment Boekhouding verwerkt. Het dient als input voor privacy-gerelateerde besluitvorming.
+Dit document beschrijft welke persoonsgegevens Invulhulpen verwerkt. Het dient als input voor privacy-gerelateerde besluitvorming.
 
 **Te bespreken met het team:**
 

--- a/packages/assessment-core/src/components/AppBanner.vue
+++ b/packages/assessment-core/src/components/AppBanner.vue
@@ -4,12 +4,14 @@ withDefaults(defineProps<{
   linkUrl?: string
   linkLabel?: string
   title?: string
+  subtitle?: string
   homeUrl?: string
 }>(), {
   message: 'De invulhulp voor pre-scan, DPIA en IAMA is in ontwikkeling.',
   linkUrl: 'https://github.com/MinBZK/par-dpia-form',
   linkLabel: 'Bètaversie',
-  title: '',
+  title: 'Invulhulpen',
+  subtitle: 'Pre-scan, DPIA en IAMA',
   homeUrl: '#',
 })
 </script>
@@ -28,7 +30,7 @@ withDefaults(defineProps<{
     </div>
   </div>
   <div class="rvo-header__logo-wrapper">
-    <a :href="homeUrl" class="rvo-header__logo-link rvo-link rvo-link--no-underline" style="display: inline-flex; align-items: center; gap: 0.75rem;">
+    <a :href="homeUrl" class="rvo-header__logo-link rvo-link rvo-link--no-underline">
       <div class="rvo-logo rvo-header__logo-img">
         <div class="rvo-logo__emblem">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -12 44 88" role="img">
@@ -46,8 +48,11 @@ withDefaults(defineProps<{
             ></path>
           </svg>
         </div>
+        <div v-if="title || subtitle" class="rvo-logo__wordmark">
+          <p v-if="title" class="rvo-logo__title">{{ title }}</p>
+          <p v-if="subtitle" class="rvo-logo__subtitle">{{ subtitle }}</p>
+        </div>
       </div>
-      <p v-if="title" class="rvo-logo__title" style="line-height: normal; color: var(--rvo-color-logoblauw, #154273); font-weight: 550; align-self: center; margin-top: 20px;">{{ title }}</p>
     </a>
   </div>
 </template>

--- a/packages/assessment-core/test/cov/components-AppBanner.cov.test.ts
+++ b/packages/assessment-core/test/cov/components-AppBanner.cov.test.ts
@@ -20,9 +20,11 @@ describe('AppBanner default props', () => {
     expect(logoLink.attributes('href')).toBe('#')
   })
 
-  it('does not render the title paragraph when title defaults to an empty string (v-if false)', () => {
+  it('renders the default wordmark (title "Invulhulpen" + subtitle "Pre-scan, DPIA en IAMA")', () => {
     const wrapper = mount(AppBanner)
-    expect(wrapper.find('.rvo-logo__title').exists()).toBe(false)
+    expect(wrapper.find('.rvo-logo__wordmark').exists()).toBe(true)
+    expect(wrapper.find('.rvo-logo__title').text()).toBe('Invulhulpen')
+    expect(wrapper.find('.rvo-logo__subtitle').text()).toBe('Pre-scan, DPIA en IAMA')
   })
 
   it('renders the warning icon and the Rijksoverheid logo svg', () => {
@@ -60,5 +62,25 @@ describe('AppBanner custom props', () => {
     expect(link.attributes('href')).toBe('https://example.test/info')
 
     expect(wrapper.find('a.rvo-header__logo-link').attributes('href')).toBe('/start')
+  })
+
+  it('hides the wordmark entirely when both title and subtitle are empty', () => {
+    const wrapper = mount(AppBanner, { props: { title: '', subtitle: '' } })
+    expect(wrapper.find('.rvo-logo__wordmark').exists()).toBe(false)
+    expect(wrapper.find('.rvo-logo__title').exists()).toBe(false)
+    expect(wrapper.find('.rvo-logo__subtitle').exists()).toBe(false)
+  })
+
+  it('renders the subtitle but no title when only a subtitle is provided', () => {
+    const wrapper = mount(AppBanner, { props: { title: '', subtitle: 'Alleen ondertitel' } })
+    expect(wrapper.find('.rvo-logo__wordmark').exists()).toBe(true)
+    expect(wrapper.find('.rvo-logo__title').exists()).toBe(false)
+    expect(wrapper.find('.rvo-logo__subtitle').text()).toBe('Alleen ondertitel')
+  })
+
+  it('renders the title but no subtitle when subtitle is empty', () => {
+    const wrapper = mount(AppBanner, { props: { title: 'Pre-scan', subtitle: '' } })
+    expect(wrapper.find('.rvo-logo__title').text()).toBe('Pre-scan')
+    expect(wrapper.find('.rvo-logo__subtitle').exists()).toBe(false)
   })
 })

--- a/tests/e2e/sync.spec.mjs
+++ b/tests/e2e/sync.spec.mjs
@@ -19,7 +19,7 @@ async function login(context, email, password) {
   await page.getByRole('button', { name: /inloggen/i }).first().click()
 
   // Nu zit je op Keycloak login
-  await page.waitForURL(/\/realms\/assessment-boekhouding\/protocol\/openid-connect\/auth/, { timeout: 15_000 })
+  await page.waitForURL(/\/realms\/invulhulpen\/protocol\/openid-connect\/auth/, { timeout: 15_000 })
 
   await page.fill('input[name="username"]', email)
   await page.fill('input[name="password"]', password)


### PR DESCRIPTION
## Wat
Hernoemt de applicatie van **Assessment Boekhouding** naar **Invulhulpen** (als merknaam), met een paar door de gebruiker gevraagde tekst- en UI-verfijningen.

## Wijzigingen
- **Rename** `Assessment Boekhouding` → `Invulhulpen` in UI (titel, banner, h1, footer, privacy/toegankelijkheid/over), backend OpenAPI, docs en config.
- **Keycloak**: realm-id én displayName → `invulhulpen` / `Invulhulpen` (config, compose, Containerfile, docs, e2e).
- **Standalone-pad**: `/invulhulpen/` → `/zonder-account/` (nginx `default.conf`, `Containerfile`, frontend-config + docs). Onderscheidt het zonder-account-formulier van de domeinnaam `invulhulpen.rijksapp.nl`.
- **Samenwerken-kaart** (LandingPage): teksten herzien naar *pre-scan, DPIA en/of IAMA* i.p.v. 'assessments'; ingelogd → "Ga naar je projecten…", uitgelogd → "Log in om samen met collega's aan een pre-scan, DPIA of IAMA te werken…".
- **Privacyverklaring**: intro herzien ("bedoeld als hulpmiddel bij het uitvoeren van een pre-scan, DPIA of IAMA").
- **Logo-tagline** (RVO-native): `AppBanner` gebruikt nu `rvo-logo__wordmark` / `rvo-logo__title` / `rvo-logo__subtitle` (geen eigen CSS) met defaults **Invulhulpen** + **Pre-scan, DPIA en IAMA**. Blijft staan naast het logo, óók in de standalone-editor (DPIA/pre-scan/IAMA).
- **Standalone h1**: "Invulhulpen voor pre-scan, DPIA en IAMA".

## Tests
Alle workspaces groen, **100% coverage** behouden: core 1155, backend 352, standalone 40, frontend 787.

## Lokaal geverifieerd
Volledige dev-stack (podman) + productie-nginx-image: rename zichtbaar, login via realm `invulhulpen`, `/zonder-account/` serveert de standalone, en de logo-tagline blijft staan bij het openen van een DPIA zonder account.

## Let op
- Productie-realm wordt door ZAD-Keycloak beheerd; die moet ook `invulhulpen` heten zodat prod met dev overeenkomt.
- Oud pad `/invulhulpen/` valt nu door naar de SPA (geen harde breuk). Een 301 → `/zonder-account/` kan eventueel toegevoegd worden.