### PR TITLE
chore(ci): vervang peter-evans-actions door git + gh in CI/CD (#320)

### DIFF
--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -9,16 +9,22 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.4
+        uses: lycheeverse/lychee-action@4dcb8bee2a0a4531cba1a1f392c54e8375d6dd81 # v1.5.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -44,20 +50,28 @@ jobs:
           # Fail if any link is broken
           fail: true
 
-      # Only create an issue when broken links are found AND running on schedule/manual
-      - name: Create Issue (Only on schedule or manual run)
+      - name: Update or create the broken-links issue (schedule/manual only)
         if: ${{ failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-        uses: peter-evans/create-issue-from-file@v4
-        with:
-          title: Broken links detected
-          content-filepath: ./lychee/out.md
-          labels: broken-links
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list --label broken-links --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file ./lychee/out.md
+          else
+            # gh issue create needs the label to exist; ensure it idempotently.
+            gh label create broken-links --color ededed --description "Automatically detected broken links" 2>/dev/null || true
+            gh issue create --title "Broken links detected" --body-file ./lychee/out.md --label broken-links
+          fi
 
   sync-yaml:
     runs-on: ubuntu-latest
     # Allow this job to continue even if the check-links job fails
     needs: check-links
     if: always()
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -71,9 +85,9 @@ jobs:
         run: |
           git add sources/begrippenkader_dpia.yaml
           if ! git diff --staged --quiet; then
-            echo "changes=true" >> $GITHUB_ENV
+            echo "changes=true" >> "$GITHUB_ENV"
           else
-            echo "changes=false" >> $GITHUB_ENV
+            echo "changes=false" >> "$GITHUB_ENV"
           fi
       - name: Commit directly (when in PR)
         if: env.changes == 'true' && github.event_name == 'pull_request'
@@ -82,27 +96,39 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git commit -m "Auto-sync YAML file from external source"
           git push
-      - name: Create Pull Request (when scheduled or manual)
+      - name: Create pull request (when scheduled or manual)
         if: env.changes == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        uses: peter-evans/create-pull-request@v5
-        with:
-          base: main
-          commit-message: "Auto-sync YAML file from external source"
-          title: "Auto-sync YAML file from external source"
-          body: |
-            Automated sync of `begrippenkader_dpia.yaml` from external source.
-
-            Source: https://modellen.jenvgegevens.nl/dpia/begrippenkader-dpia.yaml
-
-            This PR was created automatically by the sync-yaml workflow.
-          branch: auto-sync-yaml-${{ github.run_number }}
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="auto-sync-yaml-${{ github.run_number }}"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git switch -c "$branch"
+          git commit -m "Auto-sync YAML file from external source"
+          git push --set-upstream origin "$branch"
+          # Single quotes keep the backticks literal markdown (no substitution).
+          # shellcheck disable=SC2016
+          body=$(printf '%s\n' \
+            'Automated sync of `begrippenkader_dpia.yaml` from external source.' \
+            '' \
+            'Source: https://modellen.jenvgegevens.nl/dpia/begrippenkader-dpia.yaml' \
+            '' \
+            'This PR was created automatically by the sync-yaml workflow.')
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "Auto-sync YAML file from external source" \
+            --body "$body"
 
   sync-begrippenkader-iama:
     runs-on: ubuntu-latest
     # Allow this job to continue even if the check-links job fails
     needs: check-links
     if: always()
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -121,9 +147,9 @@ jobs:
         run: |
           git add sources/begrippenkader_iama.yaml
           if ! git diff --staged --quiet; then
-            echo "changes=true" >> $GITHUB_ENV
+            echo "changes=true" >> "$GITHUB_ENV"
           else
-            echo "changes=false" >> $GITHUB_ENV
+            echo "changes=false" >> "$GITHUB_ENV"
           fi
       - name: Commit directly (when in PR)
         if: env.changes == 'true' && github.event_name == 'pull_request'
@@ -132,18 +158,25 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git commit -m "Auto-sync begrippenkader_iama.yaml from Algoritmekader"
           git push
-      - name: Create Pull Request (when scheduled or manual)
+      - name: Create pull request (when scheduled or manual)
         if: env.changes == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        uses: peter-evans/create-pull-request@v5
-        with:
-          base: main
-          commit-message: "Auto-sync begrippenkader_iama.yaml from Algoritmekader"
-          title: "Auto-sync begrippenkader_iama.yaml from Algoritmekader"
-          body: |
-            Automated sync of IAMA definitions from the Algoritmekader begrippenlijst.
-
-            Source: https://github.com/MinBZK/Algoritmekader/blob/main/includes/begrippenlijst.md
-
-            This PR was created automatically by the sync workflow.
-          branch: auto-sync-begrippenkader-iama-${{ github.run_number }}
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="auto-sync-begrippenkader-iama-${{ github.run_number }}"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git switch -c "$branch"
+          git commit -m "Auto-sync begrippenkader_iama.yaml from Algoritmekader"
+          git push --set-upstream origin "$branch"
+          body=$(printf '%s\n' \
+            'Automated sync of IAMA definitions from the Algoritmekader begrippenlijst.' \
+            '' \
+            'Source: https://github.com/MinBZK/Algoritmekader/blob/main/includes/begrippenlijst.md' \
+            '' \
+            'This PR was created automatically by the sync workflow.')
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "Auto-sync begrippenkader_iama.yaml from Algoritmekader" \
+            --body "$body"

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -27,14 +27,29 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          commit-message: "chore: pre-commit autoupdate"
-          branch: chore/pre-commit-autoupdate
-          delete-branch: true
-          base: experimenteel/samenwerken
-          title: "chore: pre-commit autoupdate"
-          body: |
-            Wekelijkse automatische update van de pre-commit hook-versies via
-            `pre-commit autoupdate`.
+      - name: Create or update pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "No pre-commit updates."
+            exit 0
+          fi
+          branch="chore/pre-commit-autoupdate"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          # Reuse a single rolling branch; force-push updates an already-open PR in place.
+          git switch -C "$branch"
+          git commit -am "chore: pre-commit autoupdate"
+          git push --force --set-upstream origin "$branch"
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')" ]; then
+            # shellcheck disable=SC2016
+            body=$(printf '%s\n' \
+              'Wekelijkse automatische update van de pre-commit hook-versies via' \
+              '`pre-commit autoupdate`.')
+            gh pr create \
+              --base experimenteel/samenwerken \
+              --head "$branch" \
+              --title "chore: pre-commit autoupdate" \
+              --body "$body"
+          fi


### PR DESCRIPTION
## Wat & waarom

Lost #320 op en breidt het uit tot **alle** CI/CD: de `peter-evans/*`-actions hadden **schrijfrechten** op de workflow-context. Vervangen door transparante, eigen stappen met `git` + de `gh` CLI → kleinere supply-chain-aanvalsoppervlakte, geen externe maintainer met write-toegang. De betrokken workflows zijn meteen mee-gehard ("full hardening").

## Wijzigingen

### `broken-link-and-begrippenkader-sync.yaml`
| # | Wijziging | Standaard |
|---|-----------|-----------|
| 1 | `create-issue-from-file@v4` → `gh`. **Verbetering:** zoekt eerst een bestaande **open** `broken-links`-issue en werkt die bij (`gh issue edit`); maakt alleen een nieuwe aan als er geen open issue is. Voorheen maakte de action elke run een nieuwe issue → de repo had al 8+ dubbele "Broken links detected"-issues. | NeRDS 6, OWASP ASVS §15.2 |
| 2 | `create-pull-request@v5` (2×) → `git switch/commit/push` + `gh pr create` | idem |
| 3 | Least-privilege `permissions:` (top-level `contents: read`; per job alleen wat nodig is) — was er voorheen **niet** | OpenSSF *Token-Permissions*, BIO |
| 4 | `actions/checkout@v2` → `@v5` (v2 = EOL Node 12/16) | NeRDS 6 "up-to-date" |
| 5 | `lychee-action@v1.5.4` (muteerbare tag) → SHA-pin `4dcb8be` (geverifieerd: tag resolvet exact naar dit commit) | OpenSSF *Pinned-Dependencies* |

De `schedule` (dagelijks 09:00) en `workflow_dispatch` blijven ongewijzigd.

### `pre-commit-autoupdate.yaml`
- `create-pull-request@v8.1.1` (SHA-pinned) → `git` + `gh pr create`. Behoudt het exacte gedrag: skip als er niets te updaten valt, één **rollende** branch `chore/pre-commit-autoupdate` (force-push werkt een reeds-open PR bij), nieuwe PR alleen als er geen open PR is. `base: experimenteel/samenwerken` ongewijzigd.

> **Scope van de pinning (geen over-claim):** dit pint alleen de third-party non-GitHub-action die hier geraakt wordt (`lychee`) op SHA, conform de repo-conventie (third-party → SHA, eerste-partij `actions/*` → major-tag). De workflow/repo is hiermee dus **niet** "volledig Scorecard-Pinned-Dependencies"; andere workflows dragen nog muteerbare third-party tags (out of scope). **Dependabot** dekt `github-actions` al (`.github/dependabot.yml`), dus de SHA-pins krijgen automatisch update-PR's — de "up-to-date"-helft van NeRDS r6 blijft geborgd.

## Nederlandse standaarden

- **NeRDS richtlijn 6 — Maak veilige systemen** (BIO-baseline; dependency-hygiëne; software up-to-date).
- **developer.overheid.nl leidraad — Beveilig systemen en data** + OWASP ASVS 5.0 §15.2 "Security Architecture and Dependencies".
- **OpenSSF Scorecard** als operationalisatie: deze PR verbetert *Token-Permissions* en *Pinned-Dependencies* (zie scope-noot).

## Hoe getest

GitHub draait deze workflows niet op een PR naar `experimenteel/samenwerken` (de sync-workflow self-triggert alleen op `schedule`/`workflow_dispatch` en PR's naar `main`). Daarom is de shell-logica lokaal getest met een **high-fidelity harness** die de échte `run:`-blokken uit de YAML extraheert (na `${{ }}`-substitutie) en uitvoert tegen een tijdelijke git-repo + bare remote met een mock-`gh`. **9/9 scenario's groen:**

- ✅ `Check for changes` detecteert wel/niet-gewijzigde bron
- ✅ PR-pad beide sync-jobs: branch → commit → push → `gh pr create` met juiste args; markdown-backticks blijven letterlijk
- ✅ broken-links: **open issue bestaat** → `gh issue edit` (geen nieuwe, geen label-clobber); **geen open issue** → label geborgd + `gh issue create`
- ✅ pre-commit-autoupdate: wijziging + geen open PR → PR aangemaakt; wijziging + open PR → alleen force-push, geen dubbele PR; geen wijziging → vroege exit, geen `gh`-calls

Daarnaast: `actionlint 1.7.12` + `shellcheck 0.11.0` slagen op beide bestanden (exit 0). Adversarieel multi-agent review (security / NL-standaarden / correctheid / syntax + completeness-critic): **0 blokkerende findings**.

## Bewuste keuzes / aandachtspunten

- **`delete-branch: true` vervalt** (`gh` heeft geen equivalent) → leunt op repo-instelling *"Automatically delete head branches"*. Sync-branches zijn uniek per run (`github.run_number`); de pre-commit-branch is bewust een rollende branch.
- **`gh pr create` met default `GITHUB_TOKEN`** vereist de repo/org-instelling *"Allow GitHub Actions to create and approve pull requests"* — exact dezelfde eis als `peter-evans` had, dus **geen regressie**.
- **`pre-commit-autoupdate`**: scheduled runs draaien vanaf de default branch (`main`) terwijl de PR-base `experimenteel/samenwerken` is — dit is **pre-existing peter-evans-gedrag**, hier 1:1 behouden (niet "gefixt", want dat zou de checkout-stap raken; out of scope).

## Scope-keuzes

Bewust beperkt tot de twee workflows die `peter-evans` gebruikten. Mogelijke follow-up: een repo-brede `actionlint`-gate in CI (er staan nog pre-existing shellcheck-meldingen in `release-and-deploy.yaml`).

Closes #320
