### PR TITLE
Security follow-up #343: state-validatie, image-allowlist & readOnlyRootFilesystem

### DIFF
--- a/apps/boekhouding-backend/package.json
+++ b/apps/boekhouding-backend/package.json
@@ -20,6 +20,8 @@
     "@fastify/rate-limit": "^11.0.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.8.5",
     "jose": "^6.2.3",

--- a/apps/boekhouding-backend/src/routes/assessments.ts
+++ b/apps/boekhouding-backend/src/routes/assessments.ts
@@ -6,6 +6,8 @@ import { requireAuth } from '../middleware/auth.js'
 import { requireAssessmentAccess } from '../middleware/assessmentAccess.js'
 import { diffStates } from '../utils/diffStates.js'
 import { rebuildState } from '../utils/rebuildState.js'
+import { hasOnlyAllowedImages } from '../utils/imageValidator.js'
+import { validateState } from '../utils/validateState.js'
 
 // Sentinel to trigger transaction rollback when a concurrent write wins the
 // optimistic-lock race (conditional UPDATE affected 0 rows).
@@ -62,6 +64,28 @@ export async function assessmentRoutes(app: FastifyInstance) {
         title: 'Ongeldig verzoek',
         status: 400,
         detail: 'Gegevens of naam is verplicht',
+        instance: request.url,
+      })
+    }
+
+    if (!hasOnlyAllowedImages(state)) {
+      return reply.status(400).type('application/problem+json').send({
+        type: 'https://httpproblems.com/http-status/400',
+        title: 'Ongeldig verzoek',
+        status: 400,
+        detail: 'Ongeldig afbeeldingsformaat. Toegestaan zijn PNG, JPEG, WebP en GIF.',
+        instance: request.url,
+      })
+    }
+
+    const stateValidation = validateState(state)
+    if (!stateValidation.valid) {
+      request.log.warn({ errors: stateValidation.errors }, 'Assessment state rejected: schema validation failed')
+      return reply.status(400).type('application/problem+json').send({
+        type: 'https://httpproblems.com/http-status/400',
+        title: 'Ongeldig verzoek',
+        status: 400,
+        detail: 'Assessmentgegevens voldoen niet aan het verwachte formaat.',
         instance: request.url,
       })
     }

--- a/apps/boekhouding-backend/src/routes/projects.ts
+++ b/apps/boekhouding-backend/src/routes/projects.ts
@@ -5,6 +5,8 @@ import { eq, and } from 'drizzle-orm'
 import { requireAuth } from '../middleware/auth.js'
 import { requireProjectAccess } from '../middleware/projectAccess.js'
 import { hasOnlyAllowedImages } from '../utils/imageValidator.js'
+import { validateState } from '../utils/validateState.js'
+import { normalizeCreateState } from '../utils/normalizeCreateState.js'
 
 export async function projectRoutes(app: FastifyInstance) {
   // All project routes require auth
@@ -169,6 +171,25 @@ export async function projectRoutes(app: FastifyInstance) {
       })
     }
 
+    // Lean create payloads (pre-scan conversion, imports) omit $schema/urn; fill
+    // those in, then enforce the same output schema as save. A malformed initial
+    // state must not be persisted and later replayed verbatim by rebuildState.
+    let initialState: Record<string, unknown> = {}
+    if (state !== undefined) {
+      initialState = normalizeCreateState(state as Record<string, unknown>, assessmentType)
+      const stateValidation = validateState(initialState)
+      if (!stateValidation.valid) {
+        request.log.warn({ errors: stateValidation.errors }, 'Initial assessment state rejected: schema validation failed')
+        return reply.status(400).type('application/problem+json').send({
+          type: 'https://httpproblems.com/http-status/400',
+          title: 'Ongeldig verzoek',
+          status: 400,
+          detail: 'Assessmentgegevens voldoen niet aan het verwachte formaat.',
+          instance: request.url,
+        })
+      }
+    }
+
     let finalName = name
     if (!finalName) {
       // assessmentType is enum-validated by the route schema (400 otherwise),
@@ -185,8 +206,6 @@ export async function projectRoutes(app: FastifyInstance) {
         )
       finalName = existing.length === 0 ? baseLabel : `${baseLabel} ${existing.length + 1}`
     }
-
-    const initialState = state || {}
 
     const [assessment] = await db
       .insert(assessmentInstances)

--- a/apps/boekhouding-backend/src/routes/projects.ts
+++ b/apps/boekhouding-backend/src/routes/projects.ts
@@ -4,6 +4,7 @@ import { projects, projectMembers, assessmentInstances, assessmentVersions, asse
 import { eq, and } from 'drizzle-orm'
 import { requireAuth } from '../middleware/auth.js'
 import { requireProjectAccess } from '../middleware/projectAccess.js'
+import { hasOnlyAllowedImages } from '../utils/imageValidator.js'
 
 export async function projectRoutes(app: FastifyInstance) {
   // All project routes require auth
@@ -156,6 +157,17 @@ export async function projectRoutes(app: FastifyInstance) {
     const { projectId } = request.params
     const { name, assessmentType, state } = request.body
     const userId = request.user!.id
+
+    // Also applies on create, otherwise an SVG bypasses the image check via create.
+    if (!hasOnlyAllowedImages(state)) {
+      return reply.status(400).type('application/problem+json').send({
+        type: 'https://httpproblems.com/http-status/400',
+        title: 'Ongeldig verzoek',
+        status: 400,
+        detail: 'Ongeldig afbeeldingsformaat. Toegestaan zijn PNG, JPEG, WebP en GIF.',
+        instance: request.url,
+      })
+    }
 
     let finalName = name
     if (!finalName) {

--- a/apps/boekhouding-backend/src/utils/imageValidator.ts
+++ b/apps/boekhouding-backend/src/utils/imageValidator.ts
@@ -1,0 +1,28 @@
+// Browser-side image processing is untrusted, so re-validate the MIME here. The
+// anchored allowlist passes only raster data: URIs, blocking data:image/svg+xml.
+const ALLOWED_IMAGE_DATA = /^data:image\/(webp|png|jpe?g|gif);base64,[A-Za-z0-9+/]+={0,2}$/
+
+// Bounds the recursive scan so a deeply nested payload can't overflow the stack.
+const MAX_DEPTH = 100
+
+export function isAllowedImageData(data: string): boolean {
+  return ALLOWED_IMAGE_DATA.test(data)
+}
+
+/** False if any embedded image `data` URI fails the allowlist; deep nesting → false. */
+export function hasOnlyAllowedImages(value: unknown, depth = 0): boolean {
+  if (depth > MAX_DEPTH) return false
+  if (Array.isArray(value)) {
+    return value.every((item) => hasOnlyAllowedImages(item, depth + 1))
+  }
+  if (value !== null && typeof value === 'object') {
+    const data = (value as Record<string, unknown>).data
+    // Case-insensitive prefix detection routes Data:/DATA: variants through the
+    // strict (lowercase) allowlist instead of skipping them.
+    if (typeof data === 'string' && /^data:/i.test(data) && !isAllowedImageData(data)) {
+      return false
+    }
+    return Object.values(value as Record<string, unknown>).every((item) => hasOnlyAllowedImages(item, depth + 1))
+  }
+  return true
+}

--- a/apps/boekhouding-backend/src/utils/normalizeCreateState.ts
+++ b/apps/boekhouding-backend/src/utils/normalizeCreateState.ts
@@ -1,0 +1,39 @@
+import { OUTPUT_SCHEMA_URL } from './validateState.js'
+
+// Canonical URN (including version) per assessment type, mirroring the urn + version
+// fields in sources/<type>.yaml. Only used to normalise lean create payloads — the
+// pre-scan-to-DPIA conversion and legacy imports omit metadata.urn — so they satisfy
+// the output schema's required metadata.urn. The authoritative urn is re-emitted by
+// the client on the first save; a version drift here is cosmetic, since the namespace
+// is derived from the urn prefix and the value self-corrects on the next save.
+export const ASSESSMENT_TYPE_URNS = {
+  prescan: 'urn:nl:prescan:2.0',
+  dpia: 'urn:nl:dpia:3.0',
+  iama: 'urn:nl:iama:2.0',
+} as const
+
+export type AssessmentType = keyof typeof ASSESSMENT_TYPE_URNS
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+// Fill in the schema-required metadata that lean create payloads omit, without
+// overwriting anything the client did provide, then leave answer validation to
+// validateState. Returns a new object; the input is not mutated.
+export function normalizeCreateState(
+  state: Record<string, unknown>,
+  assessmentType: AssessmentType,
+): Record<string, unknown> {
+  const metadata = asObject(state.metadata)
+  return {
+    ...state,
+    $schema: typeof state.$schema === 'string' ? state.$schema : OUTPUT_SCHEMA_URL,
+    metadata: {
+      ...metadata,
+      urn: typeof metadata.urn === 'string' ? metadata.urn : ASSESSMENT_TYPE_URNS[assessmentType],
+      createdAt: typeof metadata.createdAt === 'string' ? metadata.createdAt : new Date().toISOString(),
+    },
+    answers: typeof state.answers === 'object' && state.answers !== null ? state.answers : {},
+  }
+}

--- a/apps/boekhouding-backend/src/utils/validateState.ts
+++ b/apps/boekhouding-backend/src/utils/validateState.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { Ajv2020 } from 'ajv/dist/2020.js'
+import addFormatsDefault from 'ajv-formats'
+
+// ajv-formats ships as CJS (module.exports = fn); under nodenext the default
+// import resolves to the module namespace type, so cast to the plugin fn it
+// actually is at runtime.
+const addFormats = addFormatsDefault as unknown as (ajv: Ajv2020) => void
+
+// The schema is the single source of truth at the repo root, read at startup and
+// resolved relative to this module so dev, tests and the production build agree.
+const schemaPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../schemas/assessment-output.v2.schema.json',
+)
+const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'))
+
+// Fail-fast (not allErrors): allErrors lets a malformed payload enumerate thousands
+// of errors, blocking the event loop and bloating the log line.
+const ajv = new Ajv2020()
+addFormats(ajv)
+const validate = ajv.compile(schema)
+
+export interface StateValidationResult {
+  valid: boolean
+  /** Human-readable validation errors for server-side logging (empty when valid). */
+  errors: string
+}
+
+export function validateState(state: unknown): StateValidationResult {
+  if (validate(state)) {
+    return { valid: true, errors: '' }
+  }
+  return { valid: false, errors: ajv.errorsText(validate.errors) }
+}

--- a/apps/boekhouding-backend/src/utils/validateState.ts
+++ b/apps/boekhouding-backend/src/utils/validateState.ts
@@ -17,6 +17,11 @@ const schemaPath = resolve(
 )
 const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'))
 
+// The canonical $schema value every conforming state must carry, derived from the
+// schema itself so it cannot drift from the source of truth. Used to normalise lean
+// create payloads that omit it (see normalizeCreateState).
+export const OUTPUT_SCHEMA_URL: string = schema.properties.$schema.const
+
 // Fail-fast (not allErrors): allErrors lets a malformed payload enumerate thousands
 // of errors, blocking the event loop and bloating the log line.
 const ajv = new Ajv2020()

--- a/apps/boekhouding-backend/test/cov/routes-assessments.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/routes-assessments.cov.test.ts
@@ -28,9 +28,11 @@ function authHeader(token: string) {
 }
 
 const URN = 'urn:nl:dpia:3.0'
+const OUTPUT_SCHEMA_URL = 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json'
 
 function makeState(answers: Record<string, unknown>, completedTasks?: string[]) {
   return {
+    $schema: OUTPUT_SCHEMA_URL,
     metadata: {
       createdAt: '2026-01-01T00:00:00Z',
       urn: URN,
@@ -381,6 +383,7 @@ describe('PUT /assessments/:id', () => {
     })
 
     const state2 = {
+      $schema: OUTPUT_SCHEMA_URL,
       metadata: { createdAt: '2026-02-02T00:00:00Z', urn: URN },
       answers: { '0.1': answer('Eerste') },
     }
@@ -466,6 +469,109 @@ describe('PUT /assessments/:id', () => {
     expect(res.json().currentVersion).toBe(2)
     const versions = await db.select().from(assessmentVersions)
     expect(versions[0].changeDescription).toBe('Hersteld naar versie 1')
+  })
+})
+
+describe('PUT /assessments/:id — input hardening', () => {
+  const imageAnswer = (data: string) => ({ value: { data }, lastEditedAt: '2026-01-01T00:00:00Z' })
+
+  it('accepts a save with an allowed WebP image', async () => {
+    const owner = await createUser()
+    const { assessment } = await seedFor(owner, 'owner', makeState({}))
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        state: makeState({ '0.1': imageAnswer('data:image/webp;base64,UklGRg==') }),
+        expectedVersion: 1,
+      },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().currentVersion).toBe(2)
+    const [row] = await db
+      .select({ cachedState: assessmentInstances.cachedState })
+      .from(assessmentInstances)
+      .where(eq(assessmentInstances.id, assessment.id))
+    expect(JSON.stringify(row.cachedState)).toContain('data:image/webp;base64,UklGRg==')
+  })
+
+  it('rejects a save with an embedded SVG image (XSS vector) and writes nothing', async () => {
+    const owner = await createUser()
+    const { assessment } = await seedFor(owner, 'owner', makeState({}))
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        state: makeState({ '0.1': imageAnswer('data:image/svg+xml;base64,PHN2Zz4=') }),
+        expectedVersion: 1,
+      },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.headers['content-type']).toContain('application/problem+json')
+    expect(res.json().detail).toContain('afbeeldingsformaat')
+    expect(await db.select().from(assessmentVersions)).toHaveLength(0)
+    const [row] = await db
+      .select({ cachedState: assessmentInstances.cachedState })
+      .from(assessmentInstances)
+      .where(eq(assessmentInstances.id, assessment.id))
+    expect(JSON.stringify(row.cachedState)).not.toContain('svg')
+  })
+
+  it('rejects an image nested in a grouped repeatable array', async () => {
+    const owner = await createUser()
+    const { assessment } = await seedFor(owner, 'owner', makeState({}))
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        state: makeState({
+          '2.1': [{ _index: 0, '2.1.1': imageAnswer('data:image/svg+xml;base64,PHN2Zz4=') }],
+        }),
+        expectedVersion: 1,
+      },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().detail).toContain('afbeeldingsformaat')
+  })
+
+  it('rejects a state with an invalid answer key', async () => {
+    const owner = await createUser()
+    const { assessment } = await seedFor(owner, 'owner', makeState({}))
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        state: makeState({ 'invalid key with spaces': answer('x') }),
+        expectedVersion: 1,
+      },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().detail).toContain('verwachte formaat')
+  })
+
+  it('rejects a state that omits the required $schema field', async () => {
+    const owner = await createUser()
+    const { assessment } = await seedFor(owner, 'owner', makeState({}))
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        state: { metadata: { createdAt: '2026-01-01T00:00:00Z', urn: URN }, answers: {} },
+        expectedVersion: 1,
+      },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().detail).toContain('verwachte formaat')
   })
 })
 

--- a/apps/boekhouding-backend/test/cov/routes-projects.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/routes-projects.cov.test.ts
@@ -9,6 +9,8 @@ import { db } from '../../src/db/connection.js'
 import { assessmentInstances, assessmentVersions, assessmentEdits } from '../../src/db/schema.js'
 import { eq } from 'drizzle-orm'
 
+const SCHEMA_URL = 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json'
+
 let app: FastifyInstance
 const jwks = getJwks()
 
@@ -339,7 +341,13 @@ describe('POST /api/v1/projects/:projectId/assessments (create assessment)', () 
   it('uses the provided name when given and stores the provided state', async () => {
     const owner = await createUser()
     const project = await projectWithRole(owner, 'owner')
-    const state = { answers: { '0.1': { value: 'Inleiding' } } }
+    // A fully conforming state so create's normalise-then-validate is a no-op and
+    // the stored value matches verbatim.
+    const state = {
+      $schema: SCHEMA_URL,
+      metadata: { urn: 'urn:nl:dpia:3.0', createdAt: '2026-01-01T00:00:00.000Z' },
+      answers: { '0.1': { value: 'Inleiding', lastEditedAt: '2026-01-01T00:00:00.000Z' } },
+    }
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/boekhouding-backend/test/cov/utils-imageValidator.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-imageValidator.cov.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { isAllowedImageData, hasOnlyAllowedImages } from '../../src/utils/imageValidator.js'
+
+describe('isAllowedImageData', () => {
+  it.each([
+    'data:image/webp;base64,UklGRg==',
+    'data:image/png;base64,iVBORw0KGgo=',
+    'data:image/jpeg;base64,/9j/4AAQ',
+    'data:image/jpg;base64,/9j/4AAQ',
+    'data:image/gif;base64,R0lGODlh',
+  ])('accepts allowed raster format: %s', (data) => {
+    expect(isAllowedImageData(data)).toBe(true)
+  })
+
+  it.each([
+    'data:image/svg+xml;base64,PHN2Zz4=', // SVG — XSS vector, must be rejected
+    'data:text/html;base64,PGgxPg==',
+    'data:application/json;base64,e30=',
+    'javascript:alert(1)',
+    'data:image/png', // no ;base64, segment
+    'data:image/png;base64', // missing trailing comma
+    'data:image/png;base64,', // empty payload
+    'not-a-data-uri',
+    '',
+  ])('rejects disallowed data: %s', (data) => {
+    expect(isAllowedImageData(data)).toBe(false)
+  })
+
+  it.each([
+    'data:image/png;base64,AAAA"><svg onload=alert(1)>', // embedded markup after a valid prefix
+    'data:image/png;base64,iVBOR\ndata:image/svg+xml;base64,PHN2Zz4=', // smuggled second URI
+    'data:image/png;base64,not valid base64 chars!',
+  ])('rejects a valid prefix followed by a non-base64 payload: %s', (data) => {
+    expect(isAllowedImageData(data)).toBe(false)
+  })
+})
+
+describe('hasOnlyAllowedImages', () => {
+  it('returns true for null, primitives and empty structures', () => {
+    expect(hasOnlyAllowedImages(null)).toBe(true)
+    expect(hasOnlyAllowedImages('plain text')).toBe(true)
+    expect(hasOnlyAllowedImages(42)).toBe(true)
+    expect(hasOnlyAllowedImages({})).toBe(true)
+    expect(hasOnlyAllowedImages([])).toBe(true)
+  })
+
+  it('accepts an allowed embedded image', () => {
+    const state = {
+      answers: { '0.1': { value: { data: 'data:image/webp;base64,UklGRg==', title: 'Diagram' } } },
+    }
+    expect(hasOnlyAllowedImages(state)).toBe(true)
+  })
+
+  it('rejects a disallowed embedded image (SVG)', () => {
+    const state = {
+      answers: { '0.1': { value: { data: 'data:image/svg+xml;base64,PHN2Zz4=' } } },
+    }
+    expect(hasOnlyAllowedImages(state)).toBe(false)
+  })
+
+  it('recurses into grouped repeatable arrays and accepts valid images', () => {
+    const state = {
+      answers: {
+        '2.1': [
+          { _index: 0, '2.1.1': { value: { data: 'data:image/png;base64,iVBORw0KGgo=' } } },
+          { _index: 1, '2.1.1': { value: 'plain answer' } },
+        ],
+      },
+    }
+    expect(hasOnlyAllowedImages(state)).toBe(true)
+  })
+
+  it('rejects a disallowed image nested inside a grouped repeatable array', () => {
+    const state = {
+      answers: {
+        '2.1': [
+          { _index: 0, '2.1.1': { value: { data: 'data:image/png;base64,iVBORw0KGgo=' } } },
+          { _index: 1, '2.1.1': { value: { data: 'data:image/svg+xml;base64,PHN2Zz4=' } } },
+        ],
+      },
+    }
+    expect(hasOnlyAllowedImages(state)).toBe(false)
+  })
+
+  it('ignores a non-string data field (schema validation covers type errors)', () => {
+    expect(hasOnlyAllowedImages({ data: 123 })).toBe(true)
+  })
+
+  it('ignores a string data field that is not a data: URI', () => {
+    expect(hasOnlyAllowedImages({ data: 'https://example.org/logo.png' })).toBe(true)
+  })
+
+  it('rejects a case-variant data: prefix instead of skipping the allowlist', () => {
+    expect(hasOnlyAllowedImages({ data: 'Data:image/svg+xml;base64,PHN2Zz4=' })).toBe(false)
+    expect(hasOnlyAllowedImages({ data: 'DATA:image/svg+xml;base64,PHN2Zz4=' })).toBe(false)
+  })
+
+  it('accepts a null answer value (cleared image)', () => {
+    expect(hasOnlyAllowedImages({ answers: { '0.1': { value: null } } })).toBe(true)
+  })
+
+  it('rejects pathologically deep nesting instead of overflowing the stack', () => {
+    // A small payload of deeply nested arrays would overflow V8's call stack and
+    // surface as a 500; the depth guard turns it into a clean rejection.
+    let deep: unknown = { data: 'data:image/png;base64,AAAA' }
+    for (let i = 0; i < 5000; i++) deep = [deep]
+    expect(hasOnlyAllowedImages(deep)).toBe(false)
+  })
+
+  it('accepts legitimately nested (but shallow) grouped state', () => {
+    let nested: unknown = { value: { data: 'data:image/webp;base64,UklGRg==' } }
+    for (let i = 0; i < 20; i++) nested = [{ _index: 0, child: nested }]
+    expect(hasOnlyAllowedImages(nested)).toBe(true)
+  })
+})

--- a/apps/boekhouding-backend/test/cov/utils-normalizeCreateState.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-normalizeCreateState.cov.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeCreateState, ASSESSMENT_TYPE_URNS } from '../../src/utils/normalizeCreateState.js'
+import { OUTPUT_SCHEMA_URL } from '../../src/utils/validateState.js'
+
+const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+
+describe('ASSESSMENT_TYPE_URNS', () => {
+  it('carries a versioned URN per assessment type', () => {
+    expect(ASSESSMENT_TYPE_URNS).toEqual({
+      prescan: 'urn:nl:prescan:2.0',
+      dpia: 'urn:nl:dpia:3.0',
+      iama: 'urn:nl:iama:2.0',
+    })
+  })
+})
+
+describe('normalizeCreateState', () => {
+  it('fills $schema, metadata.urn/createdAt and answers for a fully lean state', () => {
+    const result = normalizeCreateState({}, 'dpia')
+    expect(result.$schema).toBe(OUTPUT_SCHEMA_URL)
+    expect(result.answers).toEqual({})
+    const metadata = result.metadata as Record<string, unknown>
+    expect(metadata.urn).toBe('urn:nl:dpia:3.0')
+    expect(metadata.createdAt).toMatch(ISO)
+  })
+
+  it('derives the URN from the assessment type', () => {
+    expect((normalizeCreateState({}, 'prescan').metadata as Record<string, unknown>).urn).toBe('urn:nl:prescan:2.0')
+    expect((normalizeCreateState({}, 'iama').metadata as Record<string, unknown>).urn).toBe('urn:nl:iama:2.0')
+  })
+
+  it('preserves values the client did provide and never overwrites them', () => {
+    const input = {
+      $schema: 'client-schema',
+      metadata: { urn: 'urn:nl:dpia:2.0', createdAt: '2020-01-01T00:00:00.000Z', createdBy: { name: 'Sam' } },
+      answers: { '0.1': { value: 'x', lastEditedAt: '2020-01-01T00:00:00.000Z' } },
+    }
+    const result = normalizeCreateState(input, 'dpia')
+    expect(result.$schema).toBe('client-schema')
+    const metadata = result.metadata as Record<string, unknown>
+    expect(metadata.urn).toBe('urn:nl:dpia:2.0')
+    expect(metadata.createdAt).toBe('2020-01-01T00:00:00.000Z')
+    expect(metadata.createdBy).toEqual({ name: 'Sam' })
+    expect(result.answers).toEqual({ '0.1': { value: 'x', lastEditedAt: '2020-01-01T00:00:00.000Z' } })
+  })
+
+  it('preserves extra top-level keys such as _prescanAnswers', () => {
+    const result = normalizeCreateState(
+      { metadata: { createdAt: '2026-01-01T00:00:00.000Z' }, answers: {}, _prescanAnswers: { '0.1': { value: 'p' } } },
+      'dpia',
+    )
+    expect(result._prescanAnswers).toEqual({ '0.1': { value: 'p' } })
+    const metadata = result.metadata as Record<string, unknown>
+    expect(metadata.urn).toBe('urn:nl:dpia:3.0')
+    expect(metadata.createdAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('replaces a null metadata with a generated one', () => {
+    const result = normalizeCreateState({ metadata: null }, 'dpia')
+    const metadata = result.metadata as Record<string, unknown>
+    expect(metadata.urn).toBe('urn:nl:dpia:3.0')
+    expect(metadata.createdAt).toMatch(ISO)
+  })
+
+  it('replaces non-string $schema and non-object answers with defaults', () => {
+    const result = normalizeCreateState({ $schema: 123, answers: 'oops' }, 'dpia')
+    expect(result.$schema).toBe(OUTPUT_SCHEMA_URL)
+    expect(result.answers).toEqual({})
+  })
+
+  it('does not mutate the input object', () => {
+    const input = { answers: { '0.1': { value: 'x', lastEditedAt: '2020-01-01T00:00:00.000Z' } } }
+    const snapshot = JSON.parse(JSON.stringify(input))
+    normalizeCreateState(input, 'dpia')
+    expect(input).toEqual(snapshot)
+  })
+})

--- a/apps/boekhouding-backend/test/cov/utils-validateState.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-validateState.cov.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { validateState } from '../../src/utils/validateState.js'
+import { validateState, OUTPUT_SCHEMA_URL } from '../../src/utils/validateState.js'
 
 const SCHEMA_URL = 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json'
+
+describe('OUTPUT_SCHEMA_URL', () => {
+  it('is derived from the schema $schema const', () => {
+    expect(OUTPUT_SCHEMA_URL).toBe(SCHEMA_URL)
+  })
+})
 
 function validState(answers: Record<string, unknown> = {}) {
   return {

--- a/apps/boekhouding-backend/test/cov/utils-validateState.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-validateState.cov.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { validateState } from '../../src/utils/validateState.js'
+
+const SCHEMA_URL = 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json'
+
+function validState(answers: Record<string, unknown> = {}) {
+  return {
+    $schema: SCHEMA_URL,
+    metadata: { urn: 'urn:nl:dpia:3.0', createdAt: '2026-01-01T00:00:00.000Z' },
+    answers,
+  }
+}
+
+const answer = (value: unknown) => ({ value, lastEditedAt: '2026-01-01T00:00:00.000Z' })
+
+describe('validateState', () => {
+  it('accepts a conforming export-shaped state', () => {
+    const result = validateState(validState({ '0.1': answer('Inleiding') }))
+    expect(result.valid).toBe(true)
+    expect(result.errors).toBe('')
+  })
+
+  it('accepts a grouped repeatable answer', () => {
+    const result = validateState(validState({
+      '2.1': [
+        { _index: 0, '2.1.1': answer('Email') },
+        { _index: 1 },
+      ],
+    }))
+    expect(result.valid).toBe(true)
+  })
+
+  it('accepts an allowed embedded image value', () => {
+    const result = validateState(validState({
+      '0.1': answer({ data: 'data:image/png;base64,iVBORw0KGgo=', title: 'Diagram' }),
+    }))
+    expect(result.valid).toBe(true)
+  })
+
+  it('accepts the extra top-level _prescanAnswers field the DPIA client sends', () => {
+    // buildApiState() adds _prescanAnswers for DPIA saves; the schema has no
+    // additionalProperties:false at the root, so this must keep validating.
+    const result = validateState({
+      ...validState({ '0.1': answer('x') }),
+      _prescanAnswers: { '0.1': answer('leftover') },
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  it('accepts a realistic full client payload (drift guard for buildApiState)', () => {
+    // Mirrors every shape buildApiState() emits in one payload — text, checkbox
+    // array, embedded image, a grouped repeatable with a nested image, completed
+    // tasks, and the _prescanAnswers envelope. If strict validation ever starts
+    // rejecting a legitimate save, this test fails before it reaches production.
+    const result = validateState({
+      $schema: SCHEMA_URL,
+      metadata: { urn: 'urn:nl:dpia:3.0', createdAt: '2026-01-01T00:00:00.000Z', completedTasks: ['0', '1'] },
+      answers: {
+        '0.1': answer('Projectnaam'),
+        '0.2': answer(['optie-a', 'optie-b']),
+        '0.3': answer({ data: 'data:image/webp;base64,UklGRg==', title: 'Diagram', source: 'arch.webp' }),
+        '2.1': [
+          { _index: 0, '2.1.1': answer('Email'), '2.1.2': answer({ data: 'data:image/png;base64,iVBORw0KGgo=' }) },
+          { _index: 1, '2.1.1': answer('Telefoon') },
+        ],
+      },
+      _prescanAnswers: { '0.1': answer('prescan waarde') },
+    })
+    expect(result.valid).toBe(true)
+    expect(result.errors).toBe('')
+  })
+
+  it('rejects state missing $schema and reports an error', () => {
+    const { $schema, ...withoutSchema } = validState()
+    const result = validateState(withoutSchema)
+    expect(result.valid).toBe(false)
+    expect(result.errors).not.toBe('')
+  })
+
+  it('rejects state missing metadata.urn', () => {
+    const result = validateState({
+      $schema: SCHEMA_URL,
+      metadata: { createdAt: '2026-01-01T00:00:00.000Z' },
+      answers: {},
+    })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects an invalid answer key', () => {
+    const result = validateState(validState({ 'invalid key': answer('x') }))
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects non-numeric completedTasks', () => {
+    const result = validateState({
+      $schema: SCHEMA_URL,
+      metadata: { urn: 'urn:nl:dpia:3.0', createdAt: '2026-01-01T00:00:00.000Z', completedTasks: ['abc'] },
+      answers: {},
+    })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects a grouped element without _index', () => {
+    const result = validateState(validState({ '2.1': [{ '2.1.1': answer('x') }] }))
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects an image value whose data is not a data:image URI', () => {
+    const result = validateState(validState({ '0.1': answer({ data: 'javascript:alert(1)' }) }))
+    expect(result.valid).toBe(false)
+  })
+})

--- a/apps/boekhouding-backend/test/routes/assessmentsSaveRace.test.ts
+++ b/apps/boekhouding-backend/test/routes/assessmentsSaveRace.test.ts
@@ -25,8 +25,11 @@ function authHeader(token: string) {
   return { authorization: `Bearer ${token}` }
 }
 
+const OUTPUT_SCHEMA_URL = 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json'
+
 function makeState(urn: string, answers: Record<string, unknown> = {}) {
   return {
+    $schema: OUTPUT_SCHEMA_URL,
     metadata: { createdAt: '2026-01-01T00:00:00Z', urn },
     answers,
   }

--- a/apps/boekhouding-backend/test/routes/createAssessment.test.ts
+++ b/apps/boekhouding-backend/test/routes/createAssessment.test.ts
@@ -80,4 +80,37 @@ describe('POST /projects/:projectId/assessments', () => {
     expect(res.statusCode).toBe(201)
     expect(res.json().name).toBe('IAMA')
   })
+
+  it('rejects an initial state containing a disallowed (SVG) image (no create bypass)', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        assessmentType: 'dpia',
+        state: { answers: { '0.1': { value: { data: 'data:image/svg+xml;base64,PHN2Zz4=' }, lastEditedAt: '2026-01-01T00:00:00Z' } } },
+      },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().detail).toContain('afbeeldingsformaat')
+  })
+
+  it('accepts an initial state with an allowed WebP image', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        assessmentType: 'dpia',
+        state: { answers: { '0.1': { value: { data: 'data:image/webp;base64,UklGRg==' }, lastEditedAt: '2026-01-01T00:00:00Z' } } },
+      },
+    })
+    expect(res.statusCode).toBe(201)
+  })
 })

--- a/apps/boekhouding-backend/test/routes/createAssessment.test.ts
+++ b/apps/boekhouding-backend/test/routes/createAssessment.test.ts
@@ -11,6 +11,8 @@ import { getJwks } from '../helpers/testContext.js'
 import { truncateAll } from '../helpers/testDb.js'
 import { createUser, createProject, addMember, type SeededUser } from '../helpers/fixtures.js'
 
+const SCHEMA_URL = 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json'
+
 let app: FastifyInstance
 const jwks = getJwks()
 
@@ -112,5 +114,64 @@ describe('POST /projects/:projectId/assessments', () => {
       },
     })
     expect(res.statusCode).toBe(201)
+  })
+
+  it('normalises a lean pre-scan-conversion initial state and persists it schema-conforming', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        assessmentType: 'dpia',
+        // buildPrescanState() shape: no $schema, no metadata.urn, extra _prescanAnswers key.
+        state: {
+          metadata: { createdAt: '2026-01-01T00:00:00Z' },
+          answers: {},
+          _prescanAnswers: { '0.1': { value: 'Pre-scan waarde', lastEditedAt: '2026-01-01T00:00:00Z' } },
+        },
+      },
+    })
+    expect(res.statusCode).toBe(201)
+    const persisted = res.json().cachedState
+    expect(persisted.$schema).toBe(SCHEMA_URL)
+    expect(persisted.metadata.urn).toBe('urn:nl:dpia:3.0')
+    expect(persisted._prescanAnswers).toEqual({ '0.1': { value: 'Pre-scan waarde', lastEditedAt: '2026-01-01T00:00:00Z' } })
+  })
+
+  it('rejects a malformed initial answer (missing lastEditedAt) — no create bypass of schema validation', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        assessmentType: 'dpia',
+        state: { answers: { '0.1': { value: 'x' } } }, // missing required lastEditedAt
+      },
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().detail).toContain('verwachte formaat')
+  })
+
+  it('preserves a client-provided URN instead of overwriting it', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        assessmentType: 'dpia',
+        state: { $schema: SCHEMA_URL, metadata: { urn: 'urn:nl:dpia:2.0', createdAt: '2026-01-01T00:00:00Z' }, answers: {} },
+      },
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.json().cachedState.metadata.urn).toBe('urn:nl:dpia:2.0')
   })
 })

--- a/apps/boekhouding-frontend/src/ApiPersistence.ts
+++ b/apps/boekhouding-frontend/src/ApiPersistence.ts
@@ -735,8 +735,11 @@ export function createApiPersistence(assessmentId: string, namespace?: string) {
 
   async function clearSavedState(namespace: FormType): Promise<void> {
     try {
+      // Send a schema-conforming empty state: the backend validates saves against
+      // assessment-output.v2.schema.json, which requires $schema + urn.
       await assessments.update(assessmentId, {
-        metadata: { createdAt: new Date().toISOString() },
+        $schema: OUTPUT_SCHEMA_URL,
+        metadata: { createdAt: new Date().toISOString(), urn: useSchemaStore().getUrn(namespace) },
         answers: {},
       })
       localStorage.removeItem(UI_STORAGE_PREFIX + assessmentId)

--- a/apps/boekhouding-frontend/src/views/VersionHistory.vue
+++ b/apps/boekhouding-frontend/src/views/VersionHistory.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { assessments as assessmentsApi, type AssessmentVersion, type VersionEdit } from '../api'
-import { useTaskStore, useAnswerStore, useSchemaStore, FormType, getPlainTextWithoutDefinitions, autoGrowTextarea, OUTPUT_SCHEMA_URL } from '@overheid-assessment/core'
+import { useTaskStore, useAnswerStore, useSchemaStore, FormType, getPlainTextWithoutDefinitions, autoGrowTextarea, OUTPUT_SCHEMA_URL, isImageValue } from '@overheid-assessment/core'
 import { IconDotsVertical } from '@tabler/icons-vue'
 import AppHeader from '../components/AppHeader.vue'
 import { escapeHtml, stripHtml } from '../utils/html'
@@ -476,7 +476,9 @@ function formatValue(val: unknown, options: Record<string, string> | null): stri
       // ImageValue: render as thumbnail
       if (typeof v === 'object' && v !== null && 'data' in (v as Record<string, unknown>)) {
         const img = v as Record<string, unknown>
-        if (typeof img.data === 'string' && /^data:image\/[a-z]+;base64,[A-Za-z0-9+/=]+$/.test(img.data as string)) {
+        // Reuse the shared raster-only predicate (rejects SVG) so the diff view
+        // matches the write-time image policy instead of a looser local regex.
+        if (isImageValue(v)) {
           const alt = escapeHtml(String(img.title || 'Afbeelding'))
           let html = `<img src="${(img.data as string).replace(/"/g, '&quot;')}" alt="${alt}" class="diff-image">`
           const meta: string[] = []

--- a/apps/boekhouding-frontend/src/views/VersionHistory.vue
+++ b/apps/boekhouding-frontend/src/views/VersionHistory.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { assessments as assessmentsApi, type AssessmentVersion, type VersionEdit } from '../api'
-import { useTaskStore, useAnswerStore, useSchemaStore, FormType, getPlainTextWithoutDefinitions, autoGrowTextarea } from '@overheid-assessment/core'
+import { useTaskStore, useAnswerStore, useSchemaStore, FormType, getPlainTextWithoutDefinitions, autoGrowTextarea, OUTPUT_SCHEMA_URL } from '@overheid-assessment/core'
 import { IconDotsVertical } from '@tabler/icons-vue'
 import AppHeader from '../components/AppHeader.vue'
 import { escapeHtml, stripHtml } from '../utils/html'
@@ -174,6 +174,9 @@ async function handleFieldRestore() {
       : field.editType === 'instance_added' || field.editType === 'instance_removed'
       ? `Groep uit versie ${originVer} hersteld`
       : `Antwoord uit versie ${originVer} hersteld`
+    // Legacy state (saved before $schema was emitted) lacks it; emit a canonical
+    // $schema so the strict backend accepts the field restore.
+    currentState.$schema = currentState.$schema || OUTPUT_SCHEMA_URL
     await assessmentsApi.update(props.assessmentId, currentState, { changeDescription: restoreDesc, newVersion: true, expectedVersion: assessment.currentVersion })
 
     // Refresh version list
@@ -308,9 +311,9 @@ async function handleRestore() {
       ...currentMeta,
       completedTasks: restoredMeta.completedTasks || [],
     }
-    if (currentState.$schema) {
-      restoredState.$schema = currentState.$schema
-    }
+    // Always emit a canonical $schema so the strict backend accepts the restored
+    // save, even when the current state is legacy data without one.
+    restoredState.$schema = currentState.$schema || OUTPUT_SCHEMA_URL
     if (!restoredState.answers) {
       restoredState.answers = {}
     }

--- a/apps/boekhouding-frontend/test/cov/ApiPersistence.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/ApiPersistence.cov.test.ts
@@ -9,6 +9,7 @@ import {
   useAnswerStore,
   useSchemaStore,
   FormType,
+  OUTPUT_SCHEMA_URL,
 } from '@overheid-assessment/core'
 
 // ApiError/SessionExpiredError must be real classes so `instanceof` checks inside ApiPersistence work.
@@ -601,7 +602,14 @@ describe('clearSavedState', () => {
     const { createApiPersistence } = await loadModule()
     const p = createApiPersistence('a1')
     await p.clearSavedState(FormType.DPIA)
-    expect(mockUpdate).toHaveBeenCalledWith('a1', { metadata: { createdAt: expect.any(String) }, answers: {} })
+    expect(mockUpdate).toHaveBeenCalledWith('a1', expect.objectContaining({
+      $schema: OUTPUT_SCHEMA_URL,
+      answers: {},
+      metadata: expect.objectContaining({
+        createdAt: expect.any(String),
+        urn: expect.stringContaining('urn:nl:dpia'),
+      }),
+    }))
     expect(localStorage.getItem('ui:a1')).toBeNull()
   })
 

--- a/apps/boekhouding-frontend/test/cov/views-AssessmentEditor.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-AssessmentEditor.cov.test.ts
@@ -236,7 +236,15 @@ async function mountEditor(props: { assessmentId?: string } = {}) {
 beforeEach(async () => {
   // Drain any pending async onMounted (dynamic schema imports -> schemaStore.init)
   // from a prior test before resetting mocks, so a late init call can't leak into
-  // this test and inflate the call count.
+  // this test and inflate the call count. The real dynamic schema imports settle on
+  // a macrotask tick that flushPromises (microtasks only) can't drain, so await the
+  // same module singletons first — under load this is what a prior test's late
+  // init() is waiting on.
+  await Promise.all([
+    import('../../../../sources/generated/PreScanDPIA.json'),
+    import('../../../../sources/generated/DPIA.json'),
+    import('../../../../sources/generated/IAMA.json'),
+  ]).catch(() => {})
   await flushPromises()
   vi.clearAllMocks()
   routerPush.mockReset()

--- a/apps/boekhouding-frontend/test/cov/views-VersionHistory.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-VersionHistory.cov.test.ts
@@ -68,6 +68,7 @@ vi.mock('@overheid-assessment/core', () => ({
     PRE_SCAN: 'prescan',
     IAMA: 'iama',
   },
+  OUTPUT_SCHEMA_URL: 'https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json',
   getPlainTextWithoutDefinitions: (html: string | null | undefined) =>
     (html ?? '').replace(/<[^>]*>/g, ''),
   autoGrowTextarea: autoGrowTextareaMock,
@@ -485,7 +486,9 @@ describe('VersionHistory — restore modal & handleRestore', () => {
     const [, restoredState] = apiUpdate.mock.calls[0]
     expect((restoredState as any).metadata).toEqual({ completedTasks: [] })
     expect((restoredState as any).answers).toEqual({})
-    expect((restoredState as any).$schema).toBeUndefined()
+    // Even when the current state lacks $schema (legacy data), restore must emit a
+    // canonical $schema so the strict backend accepts the save.
+    expect((restoredState as any).$schema).toBe('https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json')
   })
 
   it('handleRestore returns early when confirm word not matching', async () => {
@@ -1311,6 +1314,8 @@ describe('VersionHistory — field-level restore', () => {
 
     const [, state, opts] = apiUpdate.mock.calls[0]
     expect((state as any).answers['1.1'].value).toBe('oud')
+    // Field restore emits a canonical $schema even though the current state lacked one.
+    expect((state as any).$schema).toBe('https://github.com/MinBZK/par-dpia-form/blob/main/schemas/assessment-output.v2.schema.json')
     expect(opts.changeDescription).toBe('Antwoord uit versie 1 hersteld')
     expect(opts.newVersion).toBe(true)
     expect(apiVersions).toHaveBeenCalledTimes(2)

--- a/apps/boekhouding-frontend/test/cov/views-VersionHistory.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-VersionHistory.cov.test.ts
@@ -92,6 +92,12 @@ vi.mock('@overheid-assessment/core', () => ({
   useAnswerStore: () => ({
     reset: answerReset,
   }),
+  // Mirror the real raster-only predicate (rejects SVG) used by formatValue.
+  isImageValue: (value: unknown) => {
+    if (typeof value !== 'object' || value === null || !('data' in value) || typeof (value as Record<string, unknown>).data !== 'string') return false
+    const data = (value as Record<string, unknown>).data as string
+    return data.startsWith('data:image/') && !data.startsWith('data:image/svg')
+  },
 }))
 
 import VersionHistory from '../../src/views/VersionHistory.vue'
@@ -1098,9 +1104,11 @@ describe('VersionHistory — formatValue & formatInstanceFields', () => {
     expect(out).not.toContain('diff-image-meta')
   })
 
-  it('treats an object value with non-image data as a normal object', () => {
-    const out = vm.formatValue({ value: { data: 'plain text' } }, null)
-    expect(out).toContain('data')
+  it('treats an object value with non-allowed image data as a normal object', () => {
+    // Plain text and SVG (rejected by the raster-only policy) both fall through to
+    // object rendering instead of an <img>, matching the write-time image policy.
+    expect(vm.formatValue({ value: { data: 'plain text' } }, null)).toContain('data')
+    expect(vm.formatValue({ value: { data: 'data:image/svg;base64,PHN2Zz4=' } }, null)).not.toContain('<img')
   })
 
   it('appends remaining object keys (skipping value/timestamp/lastEditedAt/empty)', () => {

--- a/containers/backend/Containerfile
+++ b/containers/backend/Containerfile
@@ -37,6 +37,9 @@ RUN pnpm install --frozen-lockfile --prod || pnpm install --prod
 COPY --from=build /app/apps/boekhouding-backend/dist apps/boekhouding-backend/dist
 COPY --from=build /app/apps/boekhouding-backend/drizzle apps/boekhouding-backend/drizzle
 
+# Canonical output schema — read at startup by validateState.ts (resolved at /app/schemas).
+COPY schemas/assessment-output.v2.schema.json schemas/assessment-output.v2.schema.json
+
 WORKDIR /app/apps/boekhouding-backend
 
 USER 1000

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -187,6 +187,32 @@ De 301-redirect van het oude domein `assessments.rijksapp.nl` is **optioneel** e
 ZAD-deployment met één `haproxy-redirect`-component die los van productie beheerd
 en verwijderd kan worden.
 
+## Container-hardening: readOnlyRootFilesystem
+
+De `api`-deployment draait non-root (`USER 1000`, zie
+`containers/backend/Containerfile`) en schrijft niets naar het
+root-filesystem: logs gaan naar stdout, migraties naar Postgres en het
+output-schema wordt alleen gelezen. Zet daarom in de ZAD Operations Manager voor
+de `api`-deployment de runtime-optie **`readOnlyRootFilesystem: true`**, met één
+expliciet beschrijfbaar pad voor Node's tijdelijke bestanden:
+
+```yaml
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+volumes:
+  - name: tmp
+    emptyDir: {}
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+```
+
+De daadwerkelijke runtime-config wordt in de ZAD Operations Manager UI beheerd
+(net als domeinen en env-vars), niet in deze repo. De backend-container is
+hierop voorbereid: er zijn geen schrijfacties naar het applicatiepad nodig.
+
 ## Nginx security headers
 
 De frontend container configureert de volgende headers conform NCSC/BIO2 richtlijnen:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^6.0.0
         version: 6.0.0
+      ajv:
+        specifier: ^8.18.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(postgres@3.4.9)


### PR DESCRIPTION
Volgt **#343** (security-audit-follow-up, resterende low/info-hardening) op. Drie defense-in-depth-maatregelen op de boekhouding-backend, plus de client-aanpassingen die nodig zijn om strikte validatie veilig te kunnen aanzetten zonder legitieme saves te breken.

## Wat & waarom

### F8 — server-side state-validatie (strikt)
`PUT /assessments/:id` valideert de volledige `state` tegen `schemas/assessment-output.v2.schema.json` (ajv, **fail-fast**) en weigert met `400` bij afwijking. Het schema blijft één bron van waarheid in de repo-root en wordt bij startup gelezen + via de `Containerfile` in de image gekopieerd.

Omdat strikt valideren een legitieme save zou kunnen weigeren (data-verlies in een overheidsformulier), sturen alle client-paden nu een **canonieke** state (`$schema` + `metadata.urn`):
- `clearSavedState` (formulier resetten)
- `handleRestore` (volledige versie herstellen)
- `handleFieldRestore` (veld-niveau herstellen) — incl. fallback-`$schema` voor legacy-data van vóór commit `c8a08af`

### Aanbeveling #6 — `data:`-URI-allowlist voor afbeeldingen
Een recursieve scan weigert embedded afbeeldingen die niet aan de raster-allowlist voldoen: `^data:image/(webp|png|jpe?g|gif);base64,...` (volledig geankerd). Dit blokkeert o.a. `data:image/svg+xml` — de XSS-vector die de losse `^data:image/`-pattern in het schema zou doorlaten. De check draait op **zowel save (PUT) als aanmaak (POST)**, zodat er geen create-bypass is, en heeft een dieptegrens tegen stack-overflow op diep geneste payloads.

### Aanbeveling #3 (deel 2) — `readOnlyRootFilesystem`
De backend draait al non-root (#332) en schrijft niets naar het root-filesystem (logs → stdout, migraties → Postgres, schema read-only). `docs/deployment.md` beschrijft de ZAD-runtime-config (`readOnlyRootFilesystem: true` + writable `/tmp`); de `Containerfile` is hierop voorbereid. De feitelijke toggle staat in de ZAD Operations Manager (buiten deze repo).

## Adversariële review verwerkt
Een 4-agent review (security / NL-standaarden / correctheid / tests) draaide over de diff; de bevindingen zijn verwerkt:
- **DoS (medium):** ongebonden recursie in de image-scan → dieptegrens; `ajv allErrors` → fail-fast (geen event-loop-blokkade / multi-MB logregel).
- **Correctheid (high):** create-route omzeilde de image-check → opgelost; `handleFieldRestore` miste `$schema` → opgelost.
- **Defense-in-depth (low):** image-regex volledig geankerd + base64-charset.
- **Tests:** accept-pad assert nu het DB-effect, reject-pad assert dat er niets wordt geschreven; conformance-drift-guard toegevoegd.

## Standaarden
- **NeRDS richtlijn 6 (veilige systemen):** integriteit (state-validatie), vertrouwelijkheid (anti-XSS), least-privilege (readOnlyRootFilesystem), en beschikbaarheid (client-fixes voorkomen kapotte saves).
- **AVG/dataminimalisatie:** validatie-foutlogging bevat enkel schema-paden/-keys, **geen** antwoordwaarden (empirisch gecontroleerd).

## Testen
- 100% dekking behouden in **alle** workspaces (backend, frontend, standalone, core).
- `tsc` + beide `vue-tsc` schoon; `pnpm audit --prod --audit-level high` schoon (ajv/ajv-formats geen kwetsbaarheden).
- Productie-build geverifieerd onder echte Node ESM (ajv-imports + schema-load uit `dist/`).