### PR TITLE
Redesign landingspagina (Invulhulpen) + bètabalk- en versie-consistentie

### DIFF
--- a/apps/boekhouding-frontend/src/App.vue
+++ b/apps/boekhouding-frontend/src/App.vue
@@ -10,7 +10,7 @@ const homeUrl = computed(() => isAuthenticated.value ? '/projecten' : '/')
 
 <template>
   <div class="app-layout">
-    <AppBanner message="Invulhulpen is in ontwikkeling." :homeUrl="homeUrl" />
+    <AppBanner :homeUrl="homeUrl" />
     <router-view :key="$route.path" class="app-main" />
     <SessionExpiredDialog />
     <footer class="app-footer">

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -1305,3 +1305,42 @@ a.card-link:hover {
 .sync-toast-leave-to {
   opacity: 0;
 }
+
+/* ───────────────────────────────────────────────
+   Landing page
+   ─────────────────────────────────────────────── */
+
+.landing-hero {
+  margin-block-start: var(--rvo-space-xl, 2rem);
+}
+
+.landing-hero__lead {
+  max-width: 42rem;
+  margin-block-start: var(--rvo-space-md, 1rem);
+  font-size: var(--rvo-font-size-lg, 1.125rem);
+  color: var(--rvo-color-grijs-700, #4f4f4f);
+}
+
+.landing-section {
+  margin-block-start: var(--rvo-space-xl, 2rem);
+}
+
+.landing-pillars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: var(--rvo-space-lg, 1.5rem);
+}
+
+.landing-pillar {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.landing-pillar__icon {
+  flex-shrink: 0;
+  color: var(--rvo-color-donkerblauw, #01689b);
+}

--- a/apps/boekhouding-frontend/src/views/AboutAssessments.vue
+++ b/apps/boekhouding-frontend/src/views/AboutAssessments.vue
@@ -67,6 +67,12 @@ const hasHistory = computed(() => !!window.history.state?.back)
       <li>bij gegevensverwerkingen van persoonsgegevens die waarschijnlijk een hoog risico inhouden voor de rechten en vrijheden van betrokkenen.</li>
     </ol>
 
+    <h3 class="utrecht-heading-3">DPIA versie 3.0</h3>
+    <p>
+      Deze invulhulp is gebaseerd op het Rapportagemodel DPIA Rijksdienst, versie 3.0. Dit is het
+      actuele rijksbrede rapportagemodel voor de DPIA.
+    </p>
+
     <h3 class="utrecht-heading-3">Bronnen</h3>
     <ul>
       <li><a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx" target="_blank" rel="noopener noreferrer">Rapportagemodel DPIA Rijksdienst</a></li>

--- a/apps/boekhouding-frontend/src/views/LandingPage.vue
+++ b/apps/boekhouding-frontend/src/views/LandingPage.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { useAuth } from '../composables/useAuth'
+import type { Component } from 'vue'
 import { useRouter } from 'vue-router'
+import { IconBuildingBank, IconLayoutGrid, IconCopyCheck, IconListNumbers } from '@tabler/icons-vue'
+import { useAuth } from '../composables/useAuth'
 import { getConfig } from '../config'
 import AppHeader from '../components/AppHeader.vue'
 
@@ -15,52 +17,147 @@ async function goToProjects() {
     await login()
   }
 }
+
+const pillars: { icon: Component; title: string; body: string }[] = [
+  {
+    icon: IconBuildingBank,
+    title: 'Gebaseerd op rijksbrede kaders',
+    body: 'De pre-scan en DPIA volgen het Rapportagemodel DPIA Rijksdienst (versie 3.0) en de Informatiemodellen voor de DPIA en pre-scan DPIA. Het IAMA is gebaseerd op het instrument van de Universiteit Utrecht (versie 2.0).',
+  },
+  {
+    icon: IconLayoutGrid,
+    title: 'Alles op één plek',
+    body: 'Organiseer je assessments in projecten en houd verschillende versies van een DPIA of IAMA door de jaren heen bij elkaar. Zo vind je alles terug op één plek.',
+  },
+  {
+    icon: IconCopyCheck,
+    title: 'Standaardisatie',
+    body: 'De pre-scan, DPIA en IAMA volgen een gestandaardiseerd model. Dat maakt samenwerken, beoordelen en hergebruiken eenvoudiger.',
+  },
+  {
+    icon: IconListNumbers,
+    title: 'Stapsgewijs',
+    body: 'Gerichte vragen met uitleg en bronnen leiden je door het assessment, zodat je weet wat er nodig is en niets vergeet.',
+  },
+]
+
+const assessments = [
+  {
+    title: 'Pre-scan',
+    oneLiner:
+      'Bepaal met gerichte vragen of een DPIA, IAMA, DTIA of KIA nodig is voor jouw project.',
+  },
+  {
+    title: 'Data Protection Impact Assessment (DPIA)',
+    oneLiner:
+      "Breng bij verwerkingen van persoonsgegevens de privacyrisico's voor betrokkenen in beeld.",
+  },
+  {
+    title: 'Impact Assessment Mensenrechten en Algoritmes (IAMA)',
+    oneLiner:
+      'Beoordeel de impact van algoritmes op mensenrechten en publieke waarden, voorafgaand aan de ontwikkeling of inzet van een algoritme.',
+  },
+]
 </script>
 
 <template>
   <div class="rvo-max-width-layout rvo-max-width-layout--md rvo-max-width-layout-inline-padding--md">
     <AppHeader />
-    <h1 class="utrecht-heading-1 rvo-margin-block-start--xl">Invulhulpen</h1>
 
-    <div class="rvo-layout-grid-container rvo-margin-block-start--lg">
-      <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--two">
-        <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour--grijs-100">
-          <div class="rvo-card__content card-content-flex">
-            <h2 class="utrecht-heading-2 rvo-margin--none">Zelfstandig invullen</h2>
-            <p class="rvo-padding-block-end--sm">
-              Vul een pre-scan, DPIA of IAMA in zonder account. Alles blijft lokaal in je browser
-              en kan als bestand worden opgeslagen.
-            </p>
-            <a
-              :href="standaloneUrl"
-              class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
-            >
-              Start zonder account
-            </a>
+    <section class="landing-hero" aria-labelledby="landing-hero-title">
+      <h1 id="landing-hero-title" class="utrecht-heading-1 rvo-margin--none">
+        Krijg grip op pre-scans, DPIA's en IAMA's
+      </h1>
+      <p class="landing-hero__lead">
+        Begin met de pre-scan en vul daarna, afhankelijk van de uitkomst, een DPIA en/of IAMA in.
+        Werk zonder account in je browser, ook offline, of log in om samen te werken.
+      </p>
+    </section>
+
+    <section class="landing-section" aria-labelledby="landing-paths-title">
+      <h2 id="landing-paths-title" class="utrecht-heading-2">Kies hoe je werkt</h2>
+      <div class="rvo-layout-grid-container">
+        <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--two">
+          <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour--grijs-100">
+            <div class="rvo-card__content card-content-flex">
+              <h3 class="utrecht-heading-3 rvo-margin--none">Zelfstandig invullen</h3>
+              <p>
+                Vul een pre-scan, DPIA of IAMA in zonder account of inloggen. Je antwoorden blijven
+                lokaal in je browser. Je slaat je werk op als bestand, laadt het later weer in, of
+                downloadt de invulhulp om offline te gebruiken.
+              </p>
+              <a
+                :href="standaloneUrl"
+                class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+              >
+                Start zonder account
+              </a>
+            </div>
           </div>
-        </div>
 
-        <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour--grijs-100">
-          <div class="rvo-card__content card-content-flex">
-            <h2 class="utrecht-heading-2 rvo-margin--none">Samenwerken</h2>
-            <p class="rvo-padding-block-end--sm">
-              <template v-if="isAuthenticated">
-                Ga naar je projecten en werk samen met je collega's aan een pre-scan, DPIA en/of IAMA.
-              </template>
-              <template v-else>
-                Log in om samen met collega's aan een pre-scan, DPIA of IAMA te werken. Beheer projecten,
-                nodig leden uit en houd de voortgang bij.
-              </template>
-            </p>
-            <button
-              class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md"
-              @click="goToProjects"
-            >
-              {{ isAuthenticated ? 'Naar projecten' : 'Inloggen' }}
-            </button>
+          <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour--grijs-100">
+            <div class="rvo-card__content card-content-flex">
+              <h3 class="utrecht-heading-3 rvo-margin--none">Samenwerken</h3>
+              <p v-if="isAuthenticated">
+                Ga naar je projecten om samen met collega's en adviseurs te werken. Groepeer je
+                pre-scans, DPIA's en IAMA's in projecten en nodig anderen uit. Inclusief
+                versiebeheer en de mogelijkheid om opmerkingen te plaatsen.
+              </p>
+              <p v-else>
+                Log in om samen met collega's en adviseurs te werken. Groepeer je pre-scans, DPIA's
+                en IAMA's in projecten en nodig anderen uit. Inclusief versiebeheer en de
+                mogelijkheid om opmerkingen te plaatsen.
+              </p>
+              <button
+                class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+                @click="goToProjects"
+              >
+                {{ isAuthenticated ? 'Naar projecten' : 'Inloggen' }}
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
+
+    <section class="landing-section" aria-labelledby="landing-pillars-title">
+      <h2 id="landing-pillars-title" class="utrecht-heading-2">Voor de overheid, door de overheid</h2>
+      <ul class="landing-pillars" role="list">
+        <li v-for="pillar in pillars" :key="pillar.title" class="landing-pillar">
+          <component
+            :is="pillar.icon"
+            class="landing-pillar__icon"
+            :size="32"
+            aria-hidden="true"
+            focusable="false"
+          />
+          <div>
+            <h3 class="utrecht-heading-3 rvo-margin--none">{{ pillar.title }}</h3>
+            <p class="rvo-margin--none">{{ pillar.body }}</p>
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <section id="assessments" class="landing-section" aria-labelledby="landing-assessments-title">
+      <h2 id="landing-assessments-title" class="utrecht-heading-2">De drie assessments</h2>
+      <div class="rvo-layout-grid-container">
+        <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--three">
+          <div
+            v-for="assessment in assessments"
+            :key="assessment.title"
+            class="rvo-card rvo-card--outline rvo-card--padding-md"
+          >
+            <div class="rvo-card__content">
+              <h3 class="utrecht-heading-3 rvo-margin--none">{{ assessment.title }}</h3>
+              <p class="rvo-margin--none">{{ assessment.oneLiner }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="rvo-margin-block-start--md">
+        <router-link to="/over" class="rvo-link">Lees meer over de invulhulpen</router-link>
+      </p>
+    </section>
   </div>
 </template>

--- a/apps/boekhouding-frontend/test/cov/App.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/App.cov.test.ts
@@ -19,7 +19,7 @@ vi.mock('@overheid-assessment/core', () => ({
   AppBanner: {
     name: 'AppBanner',
     props: ['message', 'title', 'homeUrl'],
-    template: '<div class="app-banner-stub" :data-home-url="homeUrl" />',
+    template: '<div class="app-banner-stub" :data-home-url="homeUrl" :data-message="message" />',
   },
 }))
 

--- a/apps/boekhouding-frontend/test/cov/views-AboutAssessments.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-AboutAssessments.cov.test.ts
@@ -86,6 +86,12 @@ describe('AboutAssessments', () => {
       expect(text).toContain('Zie ook')
     })
 
+    it('has parallel version headings: "DPIA versie 3.0" and "IAMA versie 2.0"', () => {
+      const text = mountAbout().text()
+      expect(text).toContain('DPIA versie 3.0')
+      expect(text).toContain('IAMA versie 2.0')
+    })
+
     it('links to the DPIA informational models and reporting model', () => {
       const wrapper = mountAbout()
       const hrefs = wrapper.findAll('a').map((a) => a.attributes('href'))

--- a/apps/boekhouding-frontend/test/cov/views-LandingPage.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-LandingPage.cov.test.ts
@@ -35,9 +35,17 @@ const mountPage = () =>
     global: {
       stubs: {
         AppHeader: { template: '<header class="app-header-stub" />' },
+        RouterLink: {
+          name: 'RouterLink',
+          props: ['to'],
+          template: '<a class="router-link" :href="to"><slot /></a>',
+        },
       },
     },
   })
+
+const standaloneLinks = (wrapper: ReturnType<typeof mountPage>) =>
+  wrapper.findAll('a').filter((a) => a.attributes('href') === '/zonder-account/')
 
 beforeEach(() => {
   routerPush.mockClear()
@@ -46,27 +54,72 @@ beforeEach(() => {
 })
 
 describe('LandingPage', () => {
-  describe('standaloneUrl from getConfig()', () => {
-    it('renders the standalone link with the configured href', () => {
+  describe('hero', () => {
+    it('renders exactly one h1 with the grip headline', () => {
       const wrapper = mountPage()
-      const link = wrapper.find('a.utrecht-button')
-      expect(link.exists()).toBe(true)
-      expect(link.attributes('href')).toBe('/zonder-account/')
-      expect(link.text()).toBe('Start zonder account')
+      const h1s = wrapper.findAll('h1')
+      expect(h1s).toHaveLength(1)
+      expect(h1s[0].text()).toBe("Krijg grip op pre-scans, DPIA's en IAMA's")
     })
 
-    it('renders the page heading', () => {
+    it('introduces the pre-scan as the starting point and the ways of working, with no en/em-dash', () => {
       const wrapper = mountPage()
-      expect(wrapper.find('h1').text()).toBe('Invulhulpen')
+      const lead = wrapper.find('.landing-hero__lead').text()
+      expect(lead).toContain('Begin met de pre-scan')
+      expect(lead).toContain('zonder account')
+      // Project rule: use a normal hyphen "-", never an en/em-dash.
+      expect(lead).not.toMatch(/[–—]/)
+    })
+
+    it('has no buttons or links in the hero (the choice lives in the block below)', () => {
+      const wrapper = mountPage()
+      const hero = wrapper.find('.landing-hero')
+      expect(hero.findAll('a')).toHaveLength(0)
+      expect(hero.findAll('button')).toHaveLength(0)
     })
   })
 
-  describe('Samenwerken text (v-if="isAuthenticated")', () => {
+  describe('standalone link from getConfig().standaloneUrl', () => {
+    it('renders the standalone link once, in the zelfstandig card', () => {
+      const wrapper = mountPage()
+      const links = standaloneLinks(wrapper)
+      expect(links).toHaveLength(1)
+      expect(links[0].text()).toBe('Start zonder account')
+    })
+  })
+
+  describe('"Kies hoe je werkt" paths', () => {
+    it('describes the zelfstandig path in prose (local browser + offline)', () => {
+      const wrapper = mountPage()
+      const text = wrapper.text()
+      expect(text).toContain('Zelfstandig invullen')
+      expect(text).toContain('lokaal in je browser')
+      expect(text).toContain('offline')
+    })
+
+    it('describes the samenwerken path with projects, version control and comments', () => {
+      const wrapper = mountPage()
+      const text = wrapper.text()
+      expect(text).toContain('Groepeer je pre-scans')
+      expect(text).toContain('versiebeheer')
+      expect(text).toContain('opmerkingen')
+    })
+
+    it('makes the login button primary (blue), like the start button', () => {
+      const wrapper = mountPage()
+      const button = wrapper.find('button.utrecht-button')
+      expect(button.classes()).toContain('utrecht-button--primary-action')
+    })
+  })
+
+  describe('Samenwerken copy (v-if="isAuthenticated")', () => {
     it('shows the unauthenticated copy when not logged in', () => {
       authenticated.value = false
       const wrapper = mountPage()
       const text = wrapper.text()
       expect(text).toContain('Log in om samen met collega')
+      // Collaborators are framed as colleagues and advisers in the samenwerken card.
+      expect(text).toContain('adviseurs')
       expect(text).not.toContain('Ga naar je projecten')
     })
 
@@ -79,7 +132,7 @@ describe('LandingPage', () => {
     })
   })
 
-  describe('button label (isAuthenticated ? \'Naar projecten\' : \'Inloggen\')', () => {
+  describe('Samenwerken button label (ternary)', () => {
     it('labels the button "Inloggen" when not authenticated', () => {
       authenticated.value = false
       const wrapper = mountPage()
@@ -110,6 +163,71 @@ describe('LandingPage', () => {
       await flushPromises()
       expect(login).toHaveBeenCalledTimes(1)
       expect(routerPush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('"Voor de overheid, door de overheid" pillars', () => {
+    it('uses the tagline as the section heading', () => {
+      const wrapper = mountPage()
+      const heading = wrapper.find('#landing-pillars-title')
+      expect(heading.exists()).toBe(true)
+      expect(heading.text()).toBe('Voor de overheid, door de overheid')
+    })
+
+    it('renders four pillars whose icons are all decorative', () => {
+      const wrapper = mountPage()
+      expect(wrapper.findAll('.landing-pillar')).toHaveLength(4)
+      const icons = wrapper.findAll('.landing-pillar__icon')
+      expect(icons).toHaveLength(4)
+      for (const icon of icons) {
+        expect(icon.attributes('aria-hidden')).toBe('true')
+        expect(icon.attributes('focusable')).toBe('false')
+      }
+    })
+
+    it('includes the AMT-inspired pillar headings and drops the AI-verordening pillar', () => {
+      const wrapper = mountPage()
+      const text = wrapper.text()
+      expect(text).toContain('Gebaseerd op rijksbrede kaders')
+      expect(text).toContain('Alles op één plek')
+      expect(text).toContain('Standaardisatie')
+      expect(text).toContain('Stapsgewijs')
+      expect(text).not.toContain('Aansluitend op de AI-verordening')
+    })
+
+    it('cites the DPIA reporting model v3.0 and the IAMA v2.0', () => {
+      const wrapper = mountPage()
+      const text = wrapper.text()
+      expect(text).toContain('versie 3.0')
+      expect(text).toContain('versie 2.0')
+    })
+  })
+
+  describe('de drie assessments', () => {
+    it('renders three cards with the full name and abbreviation as heading', () => {
+      const wrapper = mountPage()
+      const section = wrapper.find('#assessments')
+      expect(section.exists()).toBe(true)
+      expect(section.findAll('.rvo-card')).toHaveLength(3)
+      expect(section.findAll('h3').map((h) => h.text())).toEqual([
+        'Pre-scan',
+        'Data Protection Impact Assessment (DPIA)',
+        'Impact Assessment Mensenrechten en Algoritmes (IAMA)',
+      ])
+    })
+
+    it('frames the IAMA as preventive without the absolute "altijd"', () => {
+      const wrapper = mountPage()
+      const text = wrapper.find('#assessments').text()
+      expect(text).toContain('voorafgaand aan de ontwikkeling of inzet')
+      expect(text).not.toContain('altijd')
+    })
+
+    it('links to the over page', () => {
+      const wrapper = mountPage()
+      const overLink = wrapper.find('a[href="/over"]')
+      expect(overLink.exists()).toBe(true)
+      expect(overLink.text()).toBe('Lees meer over de invulhulpen')
     })
   })
 })

--- a/apps/standalone-form/src/components/LandingView.vue
+++ b/apps/standalone-form/src/components/LandingView.vue
@@ -155,6 +155,10 @@ async function downloadOfflineApp() {
           <li>wanneer sprake is van een verplichting op basis van departementaal beleid; of</li>
           <li>bij gegevensverwerkingen van persoonsgegevens die waarschijnlijk een hoog risico inhouden voor de rechten en vrijheden van betrokkenen.</li>
         </ol>
+        <h3 class="utrecht-heading-3">DPIA versie 3.0</h3>
+        <p>
+          Deze invulhulp is gebaseerd op het Rapportagemodel DPIA Rijksdienst, versie 3.0. Dit is het actuele rijksbrede rapportagemodel voor de DPIA.
+        </p>
         <h3 class="utrecht-heading-3">Bronnen</h3>
         <ul>
           <li><a href="https://www.kcbr.nl/sites/default/files/2023-08/Rapportagemodel%20DPIA%20Rijksdienst%20v3.0.docx" target="_blank" rel="noopener noreferrer">Rapportagemodel DPIA Rijksdienst</a></li>

--- a/packages/assessment-core/src/components/AppBanner.vue
+++ b/packages/assessment-core/src/components/AppBanner.vue
@@ -7,7 +7,7 @@ withDefaults(defineProps<{
   subtitle?: string
   homeUrl?: string
 }>(), {
-  message: 'De invulhulp voor pre-scan, DPIA en IAMA is in ontwikkeling.',
+  message: 'Invulhulpen is in ontwikkeling en kan fouten bevatten.',
   linkUrl: 'https://github.com/MinBZK/par-dpia-form',
   linkLabel: 'Bètaversie',
   title: 'Invulhulpen',

--- a/packages/assessment-core/test/cov/components-AppBanner.cov.test.ts
+++ b/packages/assessment-core/test/cov/components-AppBanner.cov.test.ts
@@ -7,7 +7,7 @@ describe('AppBanner default props', () => {
     const wrapper = mount(AppBanner)
 
     const text = wrapper.find('.rvo-alert-text')
-    expect(text.text()).toContain('De invulhulp voor pre-scan, DPIA en IAMA is in ontwikkeling.')
+    expect(text.text()).toContain('Invulhulpen is in ontwikkeling en kan fouten bevatten.')
 
     const link = text.find('a.rvo-link')
     expect(link.text()).toBe('Bètaversie')


### PR DESCRIPTION
Redesign van de publieke landingspagina (`apps/boekhouding-frontend`, route `/`), in sobere
Nederlandse overheidsstijl en geïnspireerd op AMT, met enkele consistentie-verbeteringen.

## Landingspagina
- **Hero**: taakgerichte kop "Krijg grip op pre-scans, DPIA's en IAMA's" + korte intro die de
  pre-scan als startpunt introduceert. Geen concurrerende knoppen; de keuze staat in het blok eronder.
- **Kies hoe je werkt**: twee gelijkwaardige routekaarten - zelfstandig (zonder account) en
  samenwerken (met account) - beide met een primaire knop.
- **Voor de overheid, door de overheid**: vier pijlers (rijksbrede kaders, alles op één plek,
  standaardisatie, stapsgewijs).
- **De drie assessments**: pre-scan, DPIA (Data Protection Impact Assessment) en IAMA (Impact
  Assessment Mensenrechten en Algoritmes), met verwijzing naar `/over`.

## Bètaversie-balk gelijkgetrokken
De `AppBanner`-default (core) toont in beide apps dezelfde melding:
"Invulhulpen is in ontwikkeling en kan fouten bevatten."

## Versie-consistentie
Rapportagemodel DPIA Rijksdienst (versie 3.0) en IAMA versie 2.0 zijn consistent vermeld op de
landingspagina, `/over` en de standalone-uitleg (parallelle koppen).

## Kwaliteit
- WCAG 2.2 AA: axe-core scan in een echte browser, **0 overtredingen**.
- **100% testdekking** behouden in alle workspaces; type-check en build groen.
- Copy feitelijk geverifieerd (eigenaar BZK, rolnamen, IAMA-scope, bron- en versievermeldingen).

## Niet in deze PR
De **contactpagina** staat in een aparte (concept-)PR (#354) zodat het team de inhoud kan
afstemmen - mede omdat IAMA onder een ander team binnen BZK valt.
