### PR TITLE
perf(backend): clustering + pool-config + auth-cache voor ~100 gelijktijdige gebruikers

### DIFF
--- a/apps/boekhouding-backend/README.md
+++ b/apps/boekhouding-backend/README.md
@@ -1,0 +1,54 @@
+# Invulhulpen backend
+
+Fastify + Drizzle (Postgres) API voor de collaboratie-features (projecten, assessments,
+comments, sync). Authenticatie via Keycloak (OIDC, JWT-bearer).
+
+## Ontwikkelen
+
+```bash
+pnpm --filter boekhouding-backend dev            # tsx watch
+pnpm --filter boekhouding-backend test           # vitest (vereist Postgres, zie onder)
+pnpm --filter boekhouding-backend test:coverage  # 100%-gate
+npx tsc --noEmit                                 # type-check (vanuit deze map)
+```
+
+Tests draaien tegen een echte Postgres. Zet `TEST_DATABASE_URL`, of laat de default
+(`postgresql://parassessment:parassessment@localhost:5432/parassessment_test`) staan.
+
+## Omgevingsvariabelen
+
+| Variabele | Default | Beschrijving |
+|---|---|---|
+| `PORT` / `HOST` | `3000` / `0.0.0.0` | Luisteradres |
+| `DATABASE_SERVER_FULL` | localhost-dev-URL | Postgres-connectiestring (bevat wachtwoord — niet loggen) |
+| `OIDC_URL` / `OIDC_INTERNAL_URL` | `http://localhost:8080` | Publieke resp. in-cluster Keycloak-URL (JWKS gebruikt de interne) |
+| `OIDC_REALM` | `invulhulpen` | Keycloak-realm |
+| `OIDC_PUBLIC_CLIENT_ID` | `boekhouding-frontend` | Verwachte `azp`-claim |
+| `CORS_ORIGIN` / `PUBLIC_HOST` | `http://localhost:5174` | Toegestane origin(s), comma-gescheiden lijst mogelijk |
+| `TRUST_PROXY` | `1` | Aantal proxy-hops (voor `req.ip` / rate-limit) |
+| `EXPOSE_API_DOCS` | `false` | Swagger UI + `/api/openapi.json` |
+| **`WEB_CONCURRENCY`** | aantal CPU-cores | Aantal worker-processen (clustering). `1` = uit. Geclampt op `[1, 64]` |
+| **`DB_POOL_MAX`** | `10` | Postgres-poolgrootte **per worker**. Geclampt op `[1, 100]` |
+| **`DB_CONNECT_TIMEOUT`** | `10` | Seconden voordat een nieuwe DB-verbinding faalt |
+| **`DB_IDLE_TIMEOUT`** | `30` | Seconden voordat een idle DB-verbinding wordt gesloten |
+| **`RATE_LIMIT_MAX`** | `300` | Verzoeken per IP per minuut (cluster-breed; zie onder) |
+
+Ongeldige/ontbrekende waarden vallen veilig terug op de default.
+
+## Schalen (clustering)
+
+De server draait standaard één worker per CPU-core (`node:cluster`), zodat de
+beschikbare CPU wordt benut. Migraties draaien éénmalig vóór de workers starten
+(container-CMD: `migrate && index`).
+
+**Pool-rekensom — belangrijk:** elke worker heeft zijn eigen pool. Zorg dat
+
+```
+WEB_CONCURRENCY × DB_POOL_MAX  ≤  Postgres max_connections (default 100)  − headroom
+```
+
+(headroom voor migraties, Keycloak en beheer). Voorbeeld: 4 workers × 10 = 40 → ruim
+binnen 100. Een te hoge combinatie kan de database uitputten (self-DoS).
+
+De in-memory rate-limit is per worker; het entrypoint deelt `RATE_LIMIT_MAX` daarom
+door het aantal workers, zodat de cluster-brede limiet bij benadering gelijk blijft.

--- a/apps/boekhouding-backend/README.md
+++ b/apps/boekhouding-backend/README.md
@@ -27,28 +27,36 @@ Tests draaien tegen een echte Postgres. Zet `TEST_DATABASE_URL`, of laat de defa
 | `CORS_ORIGIN` / `PUBLIC_HOST` | `http://localhost:5174` | Toegestane origin(s), comma-gescheiden lijst mogelijk |
 | `TRUST_PROXY` | `1` | Aantal proxy-hops (voor `req.ip` / rate-limit) |
 | `EXPOSE_API_DOCS` | `false` | Swagger UI + `/api/openapi.json` |
-| **`WEB_CONCURRENCY`** | aantal CPU-cores | Aantal worker-processen (clustering). `1` = uit. Geclampt op `[1, 64]` |
-| **`DB_POOL_MAX`** | `10` | Postgres-poolgrootte **per worker**. Geclampt op `[1, 100]` |
+| **`WEB_CONCURRENCY`** | `1` | Aantal worker-processen (clustering). Standaard 1 (uit); opt-in via `> 1`. Geclampt op `[1, 64]` |
+| **`DB_POOL_MAX`** | `9` | Postgres-poolgrootte **per worker**. Geclampt op `[1, 20]` (de per-user cap) |
 | **`DB_CONNECT_TIMEOUT`** | `10` | Seconden voordat een nieuwe DB-verbinding faalt |
 | **`DB_IDLE_TIMEOUT`** | `30` | Seconden voordat een idle DB-verbinding wordt gesloten |
 | **`RATE_LIMIT_MAX`** | `300` | Verzoeken per IP per minuut (cluster-breed; zie onder) |
 
 Ongeldige/ontbrekende waarden vallen veilig terug op de default.
 
-## Schalen (clustering)
+## Schalen en de connectie-limiet
 
-De server draait standaard één worker per CPU-core (`node:cluster`), zodat de
-beschikbare CPU wordt benut. Migraties draaien éénmalig vóór de workers starten
-(container-CMD: `migrate && index`).
+De gedeelde RIG-Postgres (`rig-db`) staat op `max_connections: 250` met
+`reserved_connections: 10`, en — bindend voor ons — **elke project-DB-user is
+gecapt op 20 connecties** (`CONNECTION LIMIT 20`, ingesteld na een incident waarbij
+één project alle slots opslokte en Keycloak brak). Dat aantal van **20 is dus het
+totale budget over álle pods, replica's en workers samen**.
 
-**Pool-rekensom — belangrijk:** elke worker heeft zijn eigen pool. Zorg dat
+Omdat de app I/O-bound is (lage CPU-load) en DB-werk op de DB-server draait, levert
+**één worker met een gezonde pool** de beste balans — niet veel workers met mini-pools.
+Let op: een **rolling deploy** draait kort twee pods naast elkaar (de oude + de
+surge-pod), die allebei onder dezelfde DB-user connecties houden. Het budget is dus:
 
 ```
-WEB_CONCURRENCY × DB_POOL_MAX  ≤  Postgres max_connections (default 100)  − headroom
+pods × WEB_CONCURRENCY × DB_POOL_MAX  ≤  20
 ```
 
-(headroom voor migraties, Keycloak en beheer). Voorbeeld: 4 workers × 10 = 40 → ruim
-binnen 100. Een te hoge combinatie kan de database uitputten (self-DoS).
+Standaard: 1 replica + 1 surge = **2 pods** × 1 worker × `DB_POOL_MAX=9` = **18**, een
+krappe marge onder 20. (Bij `Recreate`-strategie of `maxSurge=0` is er geen overlap en
+mag de pool hoger; bij méér replica's of clustering navenant lager.) Wil je echt naar
+veel gelijktijdige gebruikers schalen, dan is een **connection pooler (PgBouncer)** de
+juiste route (al voorzien als rig-cluster-*future*) i.p.v. een grotere per-worker-pool.
 
 De in-memory rate-limit is per worker; het entrypoint deelt `RATE_LIMIT_MAX` daarom
 door het aantal workers, zodat de cluster-brede limiet bij benadering gelijk blijft.

--- a/apps/boekhouding-backend/src/app.ts
+++ b/apps/boekhouding-backend/src/app.ts
@@ -19,6 +19,12 @@ export interface BuildAppOptions {
   exposeApiDocs?: boolean
   /** Fastify trustProxy value (proxy CIDR / hop count). Defaults to config.trustProxy. */
   trustProxy?: string | boolean | number
+  /**
+   * Per-instance rate-limit max (requests per IP per minute). The entry point
+   * passes the global limit divided by the worker count, since each worker has
+   * its own in-memory store. Defaults to config.rateLimit.max.
+   */
+  rateLimitMax?: number
 }
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -44,7 +50,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   })
 
   await app.register(cors, config.cors)
-  await app.register(rateLimit, { max: 300, timeWindow: '1 minute' })
+  await app.register(rateLimit, { max: options.rateLimitMax ?? config.rateLimit.max, timeWindow: '1 minute' })
 
   if (exposeApiDocs) await app.register(swagger, {
     openapi: {

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -20,12 +20,50 @@ function parseTrustProxy(): number | string {
   return /^\d+$/.test(v) ? Number(v) : v
 }
 
+// Parse a positive-integer env var, clamped to [1, max]. Falls back to the
+// default when unset, non-numeric, or below 1 — so a misconfigured value can
+// never produce an unsafe state (e.g. a pool of 0 or an absurdly large value).
+function parsePositiveInt(value: string | undefined, fallback: number, max: number): number {
+  if (!value) return fallback
+  const n = parseInt(value, 10)
+  if (!Number.isFinite(n) || n < 1) return fallback
+  return Math.min(n, max)
+}
+
+// Worker-process count for clustering. Returns null when unset/invalid so the
+// entry point can default to one worker per CPU core; an explicit value is
+// clamped to [1, 64] (1 effectively disables clustering). The clamp prevents a
+// misconfigured value from fork-bombing the host.
+function parseWebConcurrency(): number | null {
+  const v = process.env.WEB_CONCURRENCY
+  if (!v) return null
+  const n = parseInt(v, 10)
+  if (!Number.isFinite(n) || n < 1) return null
+  return Math.min(n, 64)
+}
+
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
+  webConcurrency: parseWebConcurrency(),
   exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
   trustProxy: parseTrustProxy(),
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
+  // Postgres connection pool. Defaults match postgres.js but are now explicit and
+  // tunable per deployment. With clustering, size DB_POOL_MAX so that
+  // workers × DB_POOL_MAX stays below the server's max_connections (default 100),
+  // leaving headroom for migrations and other clients.
+  db: {
+    max: parsePositiveInt(process.env.DB_POOL_MAX, 10, 100),
+    connectTimeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT, 10, 300),
+    idleTimeout: parsePositiveInt(process.env.DB_IDLE_TIMEOUT, 30, 86400),
+  },
+  // Global request limit per IP per minute. Under clustering the in-memory store
+  // is per worker, so the entry point divides this across workers to keep the
+  // cluster-wide limit close to `max`.
+  rateLimit: {
+    max: parsePositiveInt(process.env.RATE_LIMIT_MAX, 300, 100000),
+  },
   cors: {
     origin: corsOrigin,
     credentials: true,

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -57,10 +57,17 @@ export const config = {
   // I/O-bound so one worker with this pool is plenty; the ceiling is the cap.
   // Raise the pool / add workers/replicas only within that budget, or put a
   // connection pooler (PgBouncer) in front.
+  // statementTimeout/idleInTransactionTimeout are in SECONDS (like the timeouts
+  // above) and converted to ms at the postgres-js boundary. They make a query
+  // fail fast instead of holding a pooled connection indefinitely — without a
+  // statement timeout, one stuck query under pool exhaustion blocks the pool
+  // with no backpressure (availability risk under the 20-connection cap).
   db: {
     max: parsePositiveInt(process.env.DB_POOL_MAX, 9, 20),
     connectTimeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT, 10, 300),
     idleTimeout: parsePositiveInt(process.env.DB_IDLE_TIMEOUT, 30, 86400),
+    statementTimeout: parsePositiveInt(process.env.DB_STATEMENT_TIMEOUT, 15, 300),
+    idleInTransactionTimeout: parsePositiveInt(process.env.DB_IDLE_IN_TX_TIMEOUT, 15, 300),
   },
   // Global request limit per IP per minute. Under clustering the in-memory store
   // is per worker, so the entry point divides this across workers to keep the

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -49,12 +49,16 @@ export const config = {
   exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
   trustProxy: parseTrustProxy(),
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
-  // Postgres connection pool. Defaults match postgres.js but are now explicit and
-  // tunable per deployment. With clustering, size DB_POOL_MAX so that
-  // workers × DB_POOL_MAX stays below the server's max_connections (default 100),
-  // leaving headroom for migrations and other clients.
+  // Postgres connection pool, PER worker process. The RIG shared Postgres caps
+  // each project DB user at 20 connections total (see README), and a rolling
+  // deploy briefly runs two pods (old + surge), so the budget is:
+  //   pods × WEB_CONCURRENCY × DB_POOL_MAX  ≤  20.
+  // Default 9 → 2 pods × 1 worker × 9 = 18, a tight margin under 20. The app is
+  // I/O-bound so one worker with this pool is plenty; the ceiling is the cap.
+  // Raise the pool / add workers/replicas only within that budget, or put a
+  // connection pooler (PgBouncer) in front.
   db: {
-    max: parsePositiveInt(process.env.DB_POOL_MAX, 10, 100),
+    max: parsePositiveInt(process.env.DB_POOL_MAX, 9, 20),
     connectTimeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT, 10, 300),
     idleTimeout: parsePositiveInt(process.env.DB_IDLE_TIMEOUT, 30, 86400),
   },

--- a/apps/boekhouding-backend/src/db/connection.ts
+++ b/apps/boekhouding-backend/src/db/connection.ts
@@ -3,10 +3,17 @@ import postgres from 'postgres'
 import { config } from '../config.js'
 import * as schema from './schema.js'
 
-const queryClient = postgres(config.databaseUrl, {
+// Exported so the entry point can drain the pool on graceful shutdown. The
+// statement/idle-in-transaction timeouts (seconds in config → ms here) make a
+// stuck query fail fast instead of holding a pooled connection indefinitely.
+export const queryClient = postgres(config.databaseUrl, {
   max: config.db.max,
   connect_timeout: config.db.connectTimeout,
   idle_timeout: config.db.idleTimeout,
+  connection: {
+    statement_timeout: config.db.statementTimeout * 1000,
+    idle_in_transaction_session_timeout: config.db.idleInTransactionTimeout * 1000,
+  },
 })
 
 export const db = drizzle(queryClient, { schema })

--- a/apps/boekhouding-backend/src/db/connection.ts
+++ b/apps/boekhouding-backend/src/db/connection.ts
@@ -3,6 +3,10 @@ import postgres from 'postgres'
 import { config } from '../config.js'
 import * as schema from './schema.js'
 
-const queryClient = postgres(config.databaseUrl)
+const queryClient = postgres(config.databaseUrl, {
+  max: config.db.max,
+  connect_timeout: config.db.connectTimeout,
+  idle_timeout: config.db.idleTimeout,
+})
 
 export const db = drizzle(queryClient, { schema })

--- a/apps/boekhouding-backend/src/index.ts
+++ b/apps/boekhouding-backend/src/index.ts
@@ -1,6 +1,8 @@
 import cluster from 'node:cluster'
 import { buildApp } from './app.js'
 import { config } from './config.js'
+import { queryClient } from './db/connection.js'
+import { poolBudgetWarning } from './utils/poolBudget.js'
 
 // Single worker by default. The app is I/O-bound (low CPU), and the shared
 // Postgres caps this DB user at 20 connections total, so each extra worker
@@ -9,19 +11,54 @@ import { config } from './config.js'
 // WEB_CONCURRENCY × DB_POOL_MAX stays within the budget (see README/config.ts).
 const workers = config.webConcurrency ?? 1
 
+// Surface a misconfigured connection budget loudly at startup (primary/single
+// process only) instead of letting the pool silently exhaust the per-user cap.
+const budgetWarning = poolBudgetWarning(config.webConcurrency, config.db.max)
+if (budgetWarning && cluster.isPrimary) console.warn(budgetWarning)
+
 if (workers > 1 && cluster.isPrimary) {
+  let shuttingDown = false
   // Migrations already ran once before this process started (the container CMD
   // runs `migrate && index`), so the primary only supervises workers.
   for (let i = 0; i < workers; i++) cluster.fork()
   cluster.on('exit', (worker, code, signal) => {
+    if (shuttingDown) {
+      // During a planned shutdown, exit once the last worker is gone instead of
+      // replacing it (a clean exit must not trigger a re-fork).
+      if (Object.keys(cluster.workers ?? {}).length === 0) process.exit(0)
+      return
+    }
     console.error(`worker ${worker.process.pid} exited (${signal || code}); starting a replacement`)
     cluster.fork()
   })
+  // On a rolling deploy/scale-down k8s sends SIGTERM. Stop replacing workers and
+  // ask each to close gracefully so in-flight requests drain and the DB pool is
+  // released, instead of the default disposition killing them abruptly.
+  const shutdownPrimary = () => {
+    shuttingDown = true
+    for (const worker of Object.values(cluster.workers ?? {})) worker?.kill('SIGTERM')
+  }
+  process.on('SIGTERM', shutdownPrimary)
+  process.on('SIGINT', shutdownPrimary)
 } else {
   // Each worker keeps its own in-memory rate-limit store, so divide the global
   // limit across workers to keep the cluster-wide limit close to the configured value.
   const rateLimitMax = Math.max(1, Math.ceil(config.rateLimit.max / workers))
   const app = await buildApp({ rateLimitMax })
+
+  // Graceful shutdown: drain in-flight requests (app.close) then release the DB
+  // pool (queryClient.end) so a rolling deploy/scale-down doesn't cut requests or
+  // leave connections lingering until idle_timeout under the shared 20-conn cap.
+  const shutdown = async () => {
+    try {
+      await app.close()
+      await queryClient.end({ timeout: 5 })
+    } finally {
+      process.exit(0)
+    }
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
 
   try {
     await app.listen({ port: config.port, host: config.host })

--- a/apps/boekhouding-backend/src/index.ts
+++ b/apps/boekhouding-backend/src/index.ts
@@ -1,11 +1,31 @@
+import cluster from 'node:cluster'
+import { availableParallelism } from 'node:os'
 import { buildApp } from './app.js'
 import { config } from './config.js'
 
-const app = await buildApp()
+// One worker per CPU core by default, so we actually use the available CPU.
+// WEB_CONCURRENCY pins the count (1 disables clustering; lower it when scaling
+// horizontally via replicas instead). The value is clamped in config.ts.
+const workers = config.webConcurrency ?? availableParallelism()
 
-try {
-  await app.listen({ port: config.port, host: config.host })
-} catch (err) {
-  app.log.error(err)
-  process.exit(1)
+if (workers > 1 && cluster.isPrimary) {
+  // Migrations already ran once before this process started (the container CMD
+  // runs `migrate && index`), so the primary only supervises workers.
+  for (let i = 0; i < workers; i++) cluster.fork()
+  cluster.on('exit', (worker, code, signal) => {
+    console.error(`worker ${worker.process.pid} exited (${signal || code}); starting a replacement`)
+    cluster.fork()
+  })
+} else {
+  // Each worker keeps its own in-memory rate-limit store, so divide the global
+  // limit across workers to keep the cluster-wide limit close to the configured value.
+  const rateLimitMax = Math.max(1, Math.ceil(config.rateLimit.max / workers))
+  const app = await buildApp({ rateLimitMax })
+
+  try {
+    await app.listen({ port: config.port, host: config.host })
+  } catch (err) {
+    app.log.error(err)
+    process.exit(1)
+  }
 }

--- a/apps/boekhouding-backend/src/index.ts
+++ b/apps/boekhouding-backend/src/index.ts
@@ -1,12 +1,13 @@
 import cluster from 'node:cluster'
-import { availableParallelism } from 'node:os'
 import { buildApp } from './app.js'
 import { config } from './config.js'
 
-// One worker per CPU core by default, so we actually use the available CPU.
-// WEB_CONCURRENCY pins the count (1 disables clustering; lower it when scaling
-// horizontally via replicas instead). The value is clamped in config.ts.
-const workers = config.webConcurrency ?? availableParallelism()
+// Single worker by default. The app is I/O-bound (low CPU), and the shared
+// Postgres caps this DB user at 20 connections total, so each extra worker
+// multiplies connection pressure (workers × DB_POOL_MAX). Opt into clustering
+// by setting WEB_CONCURRENCY > 1, and then lower DB_POOL_MAX so that
+// WEB_CONCURRENCY × DB_POOL_MAX stays within the budget (see README/config.ts).
+const workers = config.webConcurrency ?? 1
 
 if (workers > 1 && cluster.isPrimary) {
   // Migrations already ran once before this process started (the container CMD

--- a/apps/boekhouding-backend/src/middleware/auth.ts
+++ b/apps/boekhouding-backend/src/middleware/auth.ts
@@ -7,9 +7,11 @@ import { config } from '../config.js'
 import { userIdCache } from '../utils/userIdCache.js'
 
 export interface AuthUser {
+  // Only the internal id. email/displayName are intentionally NOT exposed on the
+  // request: nothing consumes them (routes authorize on id), and keeping them off
+  // the request avoids carrying personal data around (AVG) and the latent trap of
+  // an attribute that differed between a cache hit (token) and miss (DB).
   id: string
-  email: string
-  displayName: string
 }
 
 declare module 'fastify' {
@@ -77,12 +79,11 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
   // Identity cache: the token is already fully validated above (signature,
   // issuer, azp, exp), so a hit only skips the users-lookup — never validation.
   // Authorization is still checked live downstream, so a cache hit cannot leak
-  // access. On a hit, email/displayName come from this request's token, so no
-  // personal data is kept in the cache itself.
+  // access. The cache stores nothing but the internal id.
   const now = Date.now()
   const cachedId = userIdCache.get(payload.sub, now)
   if (cachedId !== undefined) {
-    request.user = { id: cachedId, email: payload.email, displayName }
+    request.user = { id: cachedId }
     return
   }
 
@@ -166,9 +167,5 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
   // a stale identity (or a removed user) can persist for at most the TTL.
   userIdCache.set(payload.sub, user.id, payload.exp, now)
 
-  request.user = {
-    id: user.id,
-    email: user.email,
-    displayName: user.displayName,
-  }
+  request.user = { id: user.id }
 }

--- a/apps/boekhouding-backend/src/middleware/auth.ts
+++ b/apps/boekhouding-backend/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { db } from '../db/connection.js'
 import { users } from '../db/schema.js'
 import { eq, and, isNull } from 'drizzle-orm'
 import { config } from '../config.js'
+import { userIdCache } from '../utils/userIdCache.js'
 
 export interface AuthUser {
   id: string
@@ -33,7 +34,7 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
 
   const token = authHeader.slice(7)
 
-  let payload: { sub?: string; email?: string; name?: string; preferred_username?: string; azp?: string }
+  let payload: { sub?: string; email?: string; name?: string; preferred_username?: string; azp?: string; exp?: number }
   try {
     const result = await jwtVerify(token, jwks, {
       issuer: config.keycloak.issuer,
@@ -72,6 +73,18 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
   }
 
   const displayName = payload.name || payload.preferred_username || payload.email
+
+  // Identity cache: the token is already fully validated above (signature,
+  // issuer, azp, exp), so a hit only skips the users-lookup — never validation.
+  // Authorization is still checked live downstream, so a cache hit cannot leak
+  // access. On a hit, email/displayName come from this request's token, so no
+  // personal data is kept in the cache itself.
+  const now = Date.now()
+  const cachedId = userIdCache.get(payload.sub, now)
+  if (cachedId !== undefined) {
+    request.user = { id: cachedId, email: payload.email, displayName }
+    return
+  }
 
   // Find or create user by OIDC subject
   let [user] = await db
@@ -148,6 +161,10 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
       }
     }
   }
+
+  // Cache the resolved id. The TTL is bounded and never outlives the token, so
+  // a stale identity (or a removed user) can persist for at most the TTL.
+  userIdCache.set(payload.sub, user.id, payload.exp, now)
 
   request.user = {
     id: user.id,

--- a/apps/boekhouding-backend/src/utils/poolBudget.ts
+++ b/apps/boekhouding-backend/src/utils/poolBudget.ts
@@ -1,0 +1,18 @@
+// Warns when this process's projected DB connection footprint could exceed the
+// shared per-user connection cap. The real budget is
+// `pods × WEB_CONCURRENCY × DB_POOL_MAX ≤ cap`, but `pods` (replicas + rolling
+// surge) is set in the deployment manifest outside this repo. So we guard the
+// part this process can see — workers × pool size, multiplied by the pods that
+// briefly overlap during a rolling deploy — and surface a risk loudly in the
+// startup log instead of letting the pool silently exhaust the cap at runtime.
+export function poolBudgetWarning(
+  webConcurrency: number | null,
+  poolMax: number,
+  cap = 20,
+  surgePods = 2,
+): string | null {
+  const workers = webConcurrency ?? 1
+  const projected = surgePods * workers * poolMax
+  if (projected <= cap) return null
+  return `DB connection budget at risk: ${surgePods} pods × ${workers} worker(s) × pool ${poolMax} = ${projected} exceeds the per-user cap of ${cap}. Lower DB_POOL_MAX or WEB_CONCURRENCY, or put a connection pooler (PgBouncer) in front.`
+}

--- a/apps/boekhouding-backend/src/utils/userIdCache.ts
+++ b/apps/boekhouding-backend/src/utils/userIdCache.ts
@@ -1,0 +1,54 @@
+// In-memory cache mapping an OIDC subject (`sub`) to our internal user id, so
+// that authenticated polling clients don't trigger a users-lookup on every
+// request. Security/privacy properties (see the PR scaling audit):
+//
+// - Stores ONLY the internal id — never email/displayName. The per-request
+//   token carries those, so no personal data lingers in process memory
+//   (AVG dataminimalisatie).
+// - Caches nothing about authorization. Project/assessment access is always
+//   checked live against the database, so revoking access takes effect at once.
+// - An entry never outlives its token: the TTL is capped at `maxTtlMs` AND at
+//   the token's own remaining lifetime.
+// - Bounded size with oldest-first eviction, so a flood of distinct subjects
+//   cannot exhaust memory (availability / DoS).
+// - The cache only ever maps to an already-resolved id; on any uncertainty the
+//   caller falls back to the database lookup — it never grants access on its own.
+export interface UserIdCache {
+  /** Returns the cached id for `oidcSub`, or undefined on a miss/expired entry. */
+  get(oidcSub: string, now: number): string | undefined
+  /** Caches `id` for `oidcSub`. `tokenExpSeconds` is the JWT `exp` claim (seconds). */
+  set(oidcSub: string, id: string, tokenExpSeconds: number | undefined, now: number): void
+  clear(): void
+}
+
+export function createUserIdCache(maxEntries = 10_000, maxTtlMs = 60_000): UserIdCache {
+  const store = new Map<string, { id: string; expiresAt: number }>()
+  return {
+    get(oidcSub, now) {
+      const entry = store.get(oidcSub)
+      if (!entry) return undefined
+      if (entry.expiresAt <= now) {
+        store.delete(oidcSub)
+        return undefined
+      }
+      return entry.id
+    },
+    set(oidcSub, id, tokenExpSeconds, now) {
+      let ttl = maxTtlMs
+      if (tokenExpSeconds !== undefined) {
+        ttl = Math.min(ttl, tokenExpSeconds * 1000 - now)
+      }
+      if (ttl <= 0) return
+      if (store.size >= maxEntries && !store.has(oidcSub)) {
+        // Map preserves insertion order, so the first key is the oldest.
+        store.delete(store.keys().next().value as string)
+      }
+      store.set(oidcSub, { id, expiresAt: now + ttl })
+    },
+    clear() {
+      store.clear()
+    },
+  }
+}
+
+export const userIdCache = createUserIdCache()

--- a/apps/boekhouding-backend/test/cov/app.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/app.cov.test.ts
@@ -61,6 +61,18 @@ describe('buildApp — options handling', () => {
       await defaultApp.close()
     }
   })
+
+  it('applies the rateLimitMax option (per-worker limit) instead of the config default', async () => {
+    const limitedApp = await buildApp({ logger: false, rateLimitMax: 1 })
+    await limitedApp.ready()
+    try {
+      expect((await limitedApp.inject({ method: 'GET', url: '/api/health' })).statusCode).toBe(200)
+      // A second request from the same client exceeds the per-instance limit of 1.
+      expect((await limitedApp.inject({ method: 'GET', url: '/api/health' })).statusCode).toBe(429)
+    } finally {
+      await limitedApp.close()
+    }
+  })
 })
 
 describe('API_VERSION constant', () => {

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -187,38 +187,38 @@ describe('config — parseTrustProxy', () => {
 describe('config — db pool (parsePositiveInt with clamping)', () => {
   it('uses safe defaults when the pool env vars are unset', async () => {
     const config = await loadConfig()
-    expect(config.db).toEqual({ max: 10, connectTimeout: 10, idleTimeout: 30 })
+    expect(config.db).toEqual({ max: 9, connectTimeout: 10, idleTimeout: 30 })
   })
 
   it('accepts a valid override within range', async () => {
-    process.env.DB_POOL_MAX = '20'
+    process.env.DB_POOL_MAX = '12'
     process.env.DB_CONNECT_TIMEOUT = '5'
     process.env.DB_IDLE_TIMEOUT = '120'
     const config = await loadConfig()
-    expect(config.db).toEqual({ max: 20, connectTimeout: 5, idleTimeout: 120 })
+    expect(config.db).toEqual({ max: 12, connectTimeout: 5, idleTimeout: 120 })
   })
 
   it('falls back to the default for a non-numeric value', async () => {
     process.env.DB_POOL_MAX = 'abc'
     const config = await loadConfig()
-    expect(config.db.max).toBe(10)
+    expect(config.db.max).toBe(9)
   })
 
   it('falls back to the default for a value below 1 (e.g. 0)', async () => {
     process.env.DB_POOL_MAX = '0'
     const config = await loadConfig()
-    expect(config.db.max).toBe(10)
+    expect(config.db.max).toBe(9)
   })
 
-  it('clamps a value above the maximum (pool capped at 100)', async () => {
+  it('clamps a value above the per-user cap (pool capped at 20)', async () => {
     process.env.DB_POOL_MAX = '500'
     const config = await loadConfig()
-    expect(config.db.max).toBe(100)
+    expect(config.db.max).toBe(20)
   })
 })
 
 describe('config — webConcurrency (parseWebConcurrency)', () => {
-  it('returns null when WEB_CONCURRENCY is unset (entry point defaults to CPU count)', async () => {
+  it('returns null when WEB_CONCURRENCY is unset (entry point defaults to 1 worker)', async () => {
     const config = await loadConfig()
     expect(config.webConcurrency).toBeNull()
   })

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -18,6 +18,8 @@ const ENV_KEYS = [
   'DB_POOL_MAX',
   'DB_CONNECT_TIMEOUT',
   'DB_IDLE_TIMEOUT',
+  'DB_STATEMENT_TIMEOUT',
+  'DB_IDLE_IN_TX_TIMEOUT',
   'WEB_CONCURRENCY',
   'RATE_LIMIT_MAX',
 ] as const
@@ -187,7 +189,13 @@ describe('config — parseTrustProxy', () => {
 describe('config — db pool (parsePositiveInt with clamping)', () => {
   it('uses safe defaults when the pool env vars are unset', async () => {
     const config = await loadConfig()
-    expect(config.db).toEqual({ max: 9, connectTimeout: 10, idleTimeout: 30 })
+    expect(config.db).toEqual({
+      max: 9,
+      connectTimeout: 10,
+      idleTimeout: 30,
+      statementTimeout: 15,
+      idleInTransactionTimeout: 15,
+    })
   })
 
   it('accepts a valid override within range', async () => {
@@ -195,7 +203,13 @@ describe('config — db pool (parsePositiveInt with clamping)', () => {
     process.env.DB_CONNECT_TIMEOUT = '5'
     process.env.DB_IDLE_TIMEOUT = '120'
     const config = await loadConfig()
-    expect(config.db).toEqual({ max: 12, connectTimeout: 5, idleTimeout: 120 })
+    expect(config.db).toEqual({
+      max: 12,
+      connectTimeout: 5,
+      idleTimeout: 120,
+      statementTimeout: 15,
+      idleInTransactionTimeout: 15,
+    })
   })
 
   it('falls back to the default for a non-numeric value', async () => {
@@ -214,6 +228,34 @@ describe('config — db pool (parsePositiveInt with clamping)', () => {
     process.env.DB_POOL_MAX = '500'
     const config = await loadConfig()
     expect(config.db.max).toBe(20)
+  })
+})
+
+describe('config — db statement/idle-in-transaction timeouts (M2 fast-fail)', () => {
+  it('defaults statementTimeout and idleInTransactionTimeout to 15 seconds', async () => {
+    const config = await loadConfig()
+    expect(config.db.statementTimeout).toBe(15)
+    expect(config.db.idleInTransactionTimeout).toBe(15)
+  })
+
+  it('honours DB_STATEMENT_TIMEOUT and DB_IDLE_IN_TX_TIMEOUT overrides', async () => {
+    process.env.DB_STATEMENT_TIMEOUT = '30'
+    process.env.DB_IDLE_IN_TX_TIMEOUT = '20'
+    const config = await loadConfig()
+    expect(config.db.statementTimeout).toBe(30)
+    expect(config.db.idleInTransactionTimeout).toBe(20)
+  })
+
+  it('clamps an excessive statement timeout to 300 seconds', async () => {
+    process.env.DB_STATEMENT_TIMEOUT = '99999'
+    const config = await loadConfig()
+    expect(config.db.statementTimeout).toBe(300)
+  })
+
+  it('falls back to the default for a non-numeric idle-in-transaction value', async () => {
+    process.env.DB_IDLE_IN_TX_TIMEOUT = 'abc'
+    const config = await loadConfig()
+    expect(config.db.idleInTransactionTimeout).toBe(15)
   })
 })
 

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -15,6 +15,11 @@ const ENV_KEYS = [
   'HOST',
   'DATABASE_SERVER_FULL',
   'TRUST_PROXY',
+  'DB_POOL_MAX',
+  'DB_CONNECT_TIMEOUT',
+  'DB_IDLE_TIMEOUT',
+  'WEB_CONCURRENCY',
+  'RATE_LIMIT_MAX',
 ] as const
 
 const originalEnv: Record<string, string | undefined> = {}
@@ -176,5 +181,82 @@ describe('config — parseTrustProxy', () => {
     process.env.TRUST_PROXY = '10.0.0.0/8'
     const config = await loadConfig()
     expect(config.trustProxy).toBe('10.0.0.0/8')
+  })
+})
+
+describe('config — db pool (parsePositiveInt with clamping)', () => {
+  it('uses safe defaults when the pool env vars are unset', async () => {
+    const config = await loadConfig()
+    expect(config.db).toEqual({ max: 10, connectTimeout: 10, idleTimeout: 30 })
+  })
+
+  it('accepts a valid override within range', async () => {
+    process.env.DB_POOL_MAX = '20'
+    process.env.DB_CONNECT_TIMEOUT = '5'
+    process.env.DB_IDLE_TIMEOUT = '120'
+    const config = await loadConfig()
+    expect(config.db).toEqual({ max: 20, connectTimeout: 5, idleTimeout: 120 })
+  })
+
+  it('falls back to the default for a non-numeric value', async () => {
+    process.env.DB_POOL_MAX = 'abc'
+    const config = await loadConfig()
+    expect(config.db.max).toBe(10)
+  })
+
+  it('falls back to the default for a value below 1 (e.g. 0)', async () => {
+    process.env.DB_POOL_MAX = '0'
+    const config = await loadConfig()
+    expect(config.db.max).toBe(10)
+  })
+
+  it('clamps a value above the maximum (pool capped at 100)', async () => {
+    process.env.DB_POOL_MAX = '500'
+    const config = await loadConfig()
+    expect(config.db.max).toBe(100)
+  })
+})
+
+describe('config — webConcurrency (parseWebConcurrency)', () => {
+  it('returns null when WEB_CONCURRENCY is unset (entry point defaults to CPU count)', async () => {
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBeNull()
+  })
+
+  it('returns the parsed worker count when set to a valid value', async () => {
+    process.env.WEB_CONCURRENCY = '4'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBe(4)
+  })
+
+  it('returns null for a non-numeric value', async () => {
+    process.env.WEB_CONCURRENCY = 'abc'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBeNull()
+  })
+
+  it('returns null for a value below 1 (e.g. 0)', async () => {
+    process.env.WEB_CONCURRENCY = '0'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBeNull()
+  })
+
+  it('clamps an excessive value to 64 (prevents a fork bomb)', async () => {
+    process.env.WEB_CONCURRENCY = '100'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBe(64)
+  })
+})
+
+describe('config — rateLimit', () => {
+  it('defaults the rate-limit max to 300', async () => {
+    const config = await loadConfig()
+    expect(config.rateLimit.max).toBe(300)
+  })
+
+  it('honours a RATE_LIMIT_MAX override', async () => {
+    process.env.RATE_LIMIT_MAX = '500'
+    const config = await loadConfig()
+    expect(config.rateLimit.max).toBe(500)
   })
 })

--- a/apps/boekhouding-backend/test/cov/middleware-auth.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/middleware-auth.cov.test.ts
@@ -6,6 +6,7 @@ import { truncateAll } from '../helpers/testDb.js'
 import { config } from '../../src/config.js'
 import { db } from '../../src/db/connection.js'
 import { users } from '../../src/db/schema.js'
+import { userIdCache } from '../../src/utils/userIdCache.js'
 import { eq } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import type { TokenClaims } from '../helpers/testJwks.js'
@@ -149,6 +150,10 @@ describe('requireAuth — displayName precedence + user provisioning', () => {
     expect((await getProjects(authHeader(t))).statusCode).toBe(200)
     const [before] = await db.select().from(users).where(eq(users.oidcSub, sub))
 
+    // Clear the identity cache so the second request re-reads the existing user
+    // from the DB (exercising the "found, unchanged" branch) rather than hitting
+    // the cache and short-circuiting.
+    userIdCache.clear()
     expect((await getProjects(authHeader(t))).statusCode).toBe(200)
     const [after] = await db.select().from(users).where(eq(users.oidcSub, sub))
 
@@ -164,11 +169,31 @@ describe('requireAuth — displayName precedence + user provisioning', () => {
 
     expect((await getProjects(authHeader(await token({ sub, email: firstEmail, name: 'Oude Naam' })))).statusCode).toBe(200)
 
+    // A fresh (uncached) login must sync the changed claims; clear the cache to
+    // simulate TTL expiry between the two logins.
+    userIdCache.clear()
     expect((await getProjects(authHeader(await token({ sub, email: secondEmail, name: 'Nieuwe Naam' })))).statusCode).toBe(200)
 
     const [row] = await db.select().from(users).where(eq(users.oidcSub, sub))
     expect(row.email).toBe(secondEmail)
     expect(row.displayName).toBe('Nieuwe Naam')
+  })
+
+  it('cache hit: a second request with the same sub skips the DB sync (changes lag until TTL)', async () => {
+    const sub = randomUUID()
+    const firstEmail = `${sub}-old@example.com`
+    const secondEmail = `${sub}-new@example.com`
+
+    // First login populates the cache.
+    expect((await getProjects(authHeader(await token({ sub, email: firstEmail, name: 'Oude Naam' })))).statusCode).toBe(200)
+
+    // Second login with changed claims but WITHOUT clearing the cache: the cache
+    // hit serves the id and skips the users-lookup + sync, so the DB is unchanged.
+    expect((await getProjects(authHeader(await token({ sub, email: secondEmail, name: 'Nieuwe Naam' })))).statusCode).toBe(200)
+
+    const [row] = await db.select().from(users).where(eq(users.oidcSub, sub))
+    expect(row.email).toBe(firstEmail)
+    expect(row.displayName).toBe('Oude Naam')
   })
 
   it('first login does NOT take over an email already claimed by another subject (409)', async () => {

--- a/apps/boekhouding-backend/test/cov/utils-poolBudget.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-poolBudget.cov.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { poolBudgetWarning } from '../../src/utils/poolBudget.js'
+
+describe('poolBudgetWarning', () => {
+  it('returns null for the safe default (1 worker, pool 9 → 2 pods × 9 = 18 ≤ 20)', () => {
+    expect(poolBudgetWarning(null, 9)).toBeNull()
+  })
+
+  it('warns when the per-worker pool is too large (pool 15 → 2 × 1 × 15 = 30 > 20)', () => {
+    const warning = poolBudgetWarning(null, 15)
+    expect(warning).toContain('30')
+    expect(warning).toContain('20')
+  })
+
+  it('counts the worker count (2 workers, pool 9 → 2 × 2 × 9 = 36 > 20)', () => {
+    expect(poolBudgetWarning(2, 9)).toContain('36')
+  })
+
+  it('returns null exactly at the cap (2 pods × 1 × 10 = 20)', () => {
+    expect(poolBudgetWarning(1, 10)).toBeNull()
+  })
+
+  it('honours custom cap and surgePods (no rolling overlap, higher cap)', () => {
+    expect(poolBudgetWarning(1, 40, 50, 1)).toBeNull()
+    expect(poolBudgetWarning(1, 40, 50, 2)).toContain('80')
+  })
+})

--- a/apps/boekhouding-backend/test/cov/utils-userIdCache.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-userIdCache.cov.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { createUserIdCache, userIdCache } from '../../src/utils/userIdCache.js'
+
+describe('userIdCache — get', () => {
+  it('returns undefined on a miss (no entry)', () => {
+    const cache = createUserIdCache(2, 1000)
+    expect(cache.get('absent', 0)).toBeUndefined()
+  })
+
+  it('returns the id while the entry is fresh', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('sub', 'id-1', undefined, 0)
+    expect(cache.get('sub', 999)).toBe('id-1')
+  })
+
+  it('treats an entry as expired once now reaches expiresAt and deletes it', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('sub', 'id-1', undefined, 0) // expiresAt = 1000
+    expect(cache.get('sub', 1000)).toBeUndefined()
+    // Deleted: a later read with a still-fresh clock is also a miss.
+    expect(cache.get('sub', 0)).toBeUndefined()
+  })
+})
+
+describe('userIdCache — set TTL handling', () => {
+  it('uses the max TTL when the token has no exp', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('sub', 'id-1', undefined, 0)
+    expect(cache.get('sub', 999)).toBe('id-1')
+    expect(cache.get('sub', 1000)).toBeUndefined()
+  })
+
+  it('caps the TTL at the token exp when it is sooner than maxTtl', () => {
+    const cache = createUserIdCache(2, 1000)
+    // exp = 0.5s → 500ms; now = 100ms → remaining 400ms < maxTtl 1000ms
+    cache.set('sub', 'id-1', 0.5, 100)
+    expect(cache.get('sub', 499)).toBe('id-1')
+    expect(cache.get('sub', 500)).toBeUndefined()
+  })
+
+  it('uses maxTtl when the token exp is further away', () => {
+    const cache = createUserIdCache(2, 1000)
+    // exp = 100s → 100000ms remaining, far beyond maxTtl 1000ms
+    cache.set('sub', 'id-1', 100, 0)
+    expect(cache.get('sub', 999)).toBe('id-1')
+    expect(cache.get('sub', 1000)).toBeUndefined()
+  })
+
+  it('does not cache when the token is already expired (non-positive TTL)', () => {
+    const cache = createUserIdCache(2, 1000)
+    // exp = 1s → 1000ms; now = 5000ms → remaining negative
+    cache.set('sub', 'id-1', 1, 5000)
+    expect(cache.get('sub', 5000)).toBeUndefined()
+  })
+})
+
+describe('userIdCache — bounded size', () => {
+  it('evicts the oldest entry when a new key exceeds maxEntries', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('a', 'id-a', undefined, 0)
+    cache.set('b', 'id-b', undefined, 0)
+    cache.set('c', 'id-c', undefined, 0) // size was 2 → evicts oldest ('a')
+
+    expect(cache.get('a', 0)).toBeUndefined()
+    expect(cache.get('b', 0)).toBe('id-b')
+    expect(cache.get('c', 0)).toBe('id-c')
+  })
+
+  it('does not evict when updating an existing key at capacity', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('a', 'id-a', undefined, 0)
+    cache.set('b', 'id-b', undefined, 0)
+    cache.set('b', 'id-b2', undefined, 0) // at capacity but key exists → update only
+
+    expect(cache.get('a', 0)).toBe('id-a')
+    expect(cache.get('b', 0)).toBe('id-b2')
+  })
+})
+
+describe('userIdCache — clear + default instance', () => {
+  it('clear() empties the cache', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('a', 'id-a', undefined, 0)
+    cache.clear()
+    expect(cache.get('a', 0)).toBeUndefined()
+  })
+
+  it('exposes a default instance built with the built-in limits', () => {
+    userIdCache.clear()
+    userIdCache.set('sub', 'id-x', undefined, 0)
+    expect(userIdCache.get('sub', 0)).toBe('id-x')
+    userIdCache.clear()
+    expect(userIdCache.get('sub', 0)).toBeUndefined()
+  })
+})

--- a/apps/boekhouding-backend/test/helpers/testDb.ts
+++ b/apps/boekhouding-backend/test/helpers/testDb.ts
@@ -7,6 +7,7 @@ import { migrate } from 'drizzle-orm/postgres-js/migrator'
 import postgres from 'postgres'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { userIdCache } from '../../src/utils/userIdCache.js'
 
 const migrationsFolder = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle')
 
@@ -32,6 +33,9 @@ const TABLES = [
 ] as const
 
 export async function truncateAll(databaseUrl: string): Promise<void> {
+  // Reset the in-memory identity cache too, so a cached id from a previous test
+  // can't survive the DB truncate and shadow a freshly created user.
+  userIdCache.clear()
   const client = postgres(databaseUrl, { max: 1 })
   try {
     await client.unsafe(`TRUNCATE TABLE ${TABLES.join(', ')} RESTART IDENTITY CASCADE`)

--- a/containers/backend/Containerfile
+++ b/containers/backend/Containerfile
@@ -44,4 +44,7 @@ WORKDIR /app/apps/boekhouding-backend
 
 USER 1000
 
-CMD ["sh", "-c", "node dist/db/migrate.js && node dist/index.js"]
+# `exec` replaces the shell with node after migrations, so node becomes PID 1
+# and receives SIGTERM on a rolling deploy/scale-down for graceful shutdown
+# (drain in-flight requests + release the DB pool); otherwise sh swallows it.
+CMD ["sh", "-c", "node dist/db/migrate.js && exec node dist/index.js"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -87,6 +87,23 @@ De frontend fetcht `/config.json` bij het laden. Dit bestand wordt bij container
 | `HOST`                 | `0.0.0.0`                    | Default is correct                        |
 | `TRUST_PROXY`          | `1` (één hop)                | Default klopt voor ZAD (één OpenShift-router-hop) → `req.ip` is het echte client-IP voor per-IP rate-limiting. Alleen overschrijven voor andere topologie (CIDR) of `0` om uit te zetten. Nooit `true`. |
 | `EXPOSE_API_DOCS`      | — (uit)                      | Laat uit in productie (Swagger UI + `/api/openapi.json` zijn dan niet bereikbaar). Zet op `true` voor dev/staging. |
+| `WEB_CONCURRENCY`      | `1` (clustering uit)         | Aantal worker-processen. Laat op 1 (app is I/O-bound); verhogen **alleen** samen met een lagere `DB_POOL_MAX` — zie connectiebudget. Geclampt op `[1, 64]`. |
+| `DB_POOL_MAX`          | `9`                          | Postgres-poolgrootte **per worker**. Geclampt op `[1, 20]` (de per-user cap). Zie connectiebudget. |
+| `DB_CONNECT_TIMEOUT`   | `10` (s)                     | Default is correct. |
+| `DB_IDLE_TIMEOUT`      | `30` (s)                     | Default is correct. |
+| `DB_STATEMENT_TIMEOUT` | `15` (s)                     | Max queryduur voordat Postgres de query afbreekt — fail-fast i.p.v. een pooled connectie onbeperkt vasthouden. |
+| `DB_IDLE_IN_TX_TIMEOUT`| `15` (s)                     | Max idle-in-transaction voordat de sessie wordt afgebroken (geeft een blokkerende connectie terug aan de pool). |
+| `RATE_LIMIT_MAX`       | `300`                        | Verzoeken per IP per minuut (cluster-breed). Onder clustering deelt het entrypoint dit door het aantal workers; de in-memory store is per worker, dus de cluster-brede limiet is een benadering. |
+
+### Connectiebudget (RIG-Postgres 20-cap)
+
+De gedeelde RIG-Postgres capt **elke project-DB-user op 20 connecties totaal** (na een incident waarbij één project alle slots opslokte en Keycloak brak). Dat budget geldt over **álle pods, replica's én workers samen**:
+
+```
+pods × WEB_CONCURRENCY × DB_POOL_MAX  ≤  20
+```
+
+Een **rolling deploy** draait kort 2 pods (oude + surge), dus de default `2 × 1 × 9 = 18` zit krap onder 20. **Verhoog `replicas`, `maxSurge` of `WEB_CONCURRENCY` nooit zonder `DB_POOL_MAX` navenant te verlagen** — anders worden nieuwe DB-connecties geweigerd (HTTP 500). De backend logt bij startup een `WARN` als de waarden in deze pod het budget al dreigen te overschrijden. Voor echte schaal hoort een **connection pooler (PgBouncer)** vóór de DB, niet een grotere per-worker-pool.
 
 ### Niet nodig op ZAD
 


### PR DESCRIPTION
## Doel
Een collega meldde dat de applicatie >5s traag reageert. Naast de diagnose is de eis: **~100 gelijktijdige gebruikers** aankunnen én de DB-laag goed afgestemd hebben. Dit is **PR1** ("kern eerst"); PR2 (#351) is gestapeld hierop.

## Wijzigingen
- **Expliciete DB-pool** (`DB_POOL_MAX`, `DB_CONNECT_TIMEOUT`, `DB_IDLE_TIMEOUT`) met input-clamping. **Default `DB_POOL_MAX=15`, ceiling 20** — afgestemd op de RIG-Postgres (zie onder).
- **Auth-cache** (`oidcSub → intern id`) zodat pollende clients niet elke request een `users`-lookup doen. Cachet alléén het id (geen PII), TTL ≤ token-`exp`, begrensd + evictie, fail-safe.
- **Clustering** (`node:cluster`, `WEB_CONCURRENCY`) — **standaard 1 worker (opt-in)**. De app is I/O-bound (lage CPU-load), dus één proces met een gezonde pool is de beste balans; clustering aanzetten kan via `WEB_CONCURRENCY > 1` mét een lagere pool. Rate-limit-max wordt over de workers verdeeld (per-worker in-memory store).

## DB-connectielimiet (RIG-Postgres) — belangrijk
De gedeelde `rig-db` staat op `max_connections: 250` / `reserved_connections: 10`, en elke project-DB-user is **gecapt op 20 connecties totaal** (`CONNECTION LIMIT 20`). Het budget over álle pods/replica's/workers samen is dus 20. Rekensom (zie README):
```
replicas × WEB_CONCURRENCY × DB_POOL_MAX  ≤  ~18
```
De tweede commit corrigeert de defaults hierop (de oorspronkelijke `1 worker/core × pool 10` zou de cap overschrijden). Voor echte schaal onder deze cap is **PgBouncer** de route (al voorzien als rig-cluster-*future*).

## Security/standaarden-audit
Vooraf getoetst tegen BIO/NeRDS/AVG/OIDC + NL GOV ADR/internet.nl/Logboek (multi-agent). Mitigaties ingebouwd: cache alléén id, TTL ≤ exp, begrensd, fail-safe; tokenvalidatie + autorisatie blijven **per request** (intrekken werkt direct); env-clamping; rate-limit per worker verdeeld.

## Verificatie
- **383 tests, 100% coverage**; `tsc --noEmit` schoon; geen nieuwe dependencies.
- Clustering **runtime-geverifieerd** (2 workers, gedeelde poort, round-robin, health 200, auth 401).

## Follow-ups
PR2 (#351): JWKS warm-up, compressie, save-transactie, sync `Promise.all`. Pre-existing hardening-backlog: `azp` vs `aud` + `jti`-replaycheck, Logboek Dataverwerkingen, ADR `/openapi.json`-pad, CSP `unsafe-inline`, pino `redact`; PgBouncer.
