### PR TITLE
perf(backend): JWKS warm-up, compressie, parallelle sync-poll (vervolg op #350)

### DIFF
--- a/apps/boekhouding-backend/README.md
+++ b/apps/boekhouding-backend/README.md
@@ -1,0 +1,54 @@
+# Invulhulpen backend
+
+Fastify + Drizzle (Postgres) API voor de collaboratie-features (projecten, assessments,
+comments, sync). Authenticatie via Keycloak (OIDC, JWT-bearer).
+
+## Ontwikkelen
+
+```bash
+pnpm --filter boekhouding-backend dev            # tsx watch
+pnpm --filter boekhouding-backend test           # vitest (vereist Postgres, zie onder)
+pnpm --filter boekhouding-backend test:coverage  # 100%-gate
+npx tsc --noEmit                                 # type-check (vanuit deze map)
+```
+
+Tests draaien tegen een echte Postgres. Zet `TEST_DATABASE_URL`, of laat de default
+(`postgresql://parassessment:parassessment@localhost:5432/parassessment_test`) staan.
+
+## Omgevingsvariabelen
+
+| Variabele | Default | Beschrijving |
+|---|---|---|
+| `PORT` / `HOST` | `3000` / `0.0.0.0` | Luisteradres |
+| `DATABASE_SERVER_FULL` | localhost-dev-URL | Postgres-connectiestring (bevat wachtwoord — niet loggen) |
+| `OIDC_URL` / `OIDC_INTERNAL_URL` | `http://localhost:8080` | Publieke resp. in-cluster Keycloak-URL (JWKS gebruikt de interne) |
+| `OIDC_REALM` | `invulhulpen` | Keycloak-realm |
+| `OIDC_PUBLIC_CLIENT_ID` | `boekhouding-frontend` | Verwachte `azp`-claim |
+| `CORS_ORIGIN` / `PUBLIC_HOST` | `http://localhost:5174` | Toegestane origin(s), comma-gescheiden lijst mogelijk |
+| `TRUST_PROXY` | `1` | Aantal proxy-hops (voor `req.ip` / rate-limit) |
+| `EXPOSE_API_DOCS` | `false` | Swagger UI + `/api/openapi.json` |
+| **`WEB_CONCURRENCY`** | aantal CPU-cores | Aantal worker-processen (clustering). `1` = uit. Geclampt op `[1, 64]` |
+| **`DB_POOL_MAX`** | `10` | Postgres-poolgrootte **per worker**. Geclampt op `[1, 100]` |
+| **`DB_CONNECT_TIMEOUT`** | `10` | Seconden voordat een nieuwe DB-verbinding faalt |
+| **`DB_IDLE_TIMEOUT`** | `30` | Seconden voordat een idle DB-verbinding wordt gesloten |
+| **`RATE_LIMIT_MAX`** | `300` | Verzoeken per IP per minuut (cluster-breed; zie onder) |
+
+Ongeldige/ontbrekende waarden vallen veilig terug op de default.
+
+## Schalen (clustering)
+
+De server draait standaard één worker per CPU-core (`node:cluster`), zodat de
+beschikbare CPU wordt benut. Migraties draaien éénmalig vóór de workers starten
+(container-CMD: `migrate && index`).
+
+**Pool-rekensom — belangrijk:** elke worker heeft zijn eigen pool. Zorg dat
+
+```
+WEB_CONCURRENCY × DB_POOL_MAX  ≤  Postgres max_connections (default 100)  − headroom
+```
+
+(headroom voor migraties, Keycloak en beheer). Voorbeeld: 4 workers × 10 = 40 → ruim
+binnen 100. Een te hoge combinatie kan de database uitputten (self-DoS).
+
+De in-memory rate-limit is per worker; het entrypoint deelt `RATE_LIMIT_MAX` daarom
+door het aantal workers, zodat de cluster-brede limiet bij benadering gelijk blijft.

--- a/apps/boekhouding-backend/README.md
+++ b/apps/boekhouding-backend/README.md
@@ -27,28 +27,36 @@ Tests draaien tegen een echte Postgres. Zet `TEST_DATABASE_URL`, of laat de defa
 | `CORS_ORIGIN` / `PUBLIC_HOST` | `http://localhost:5174` | Toegestane origin(s), comma-gescheiden lijst mogelijk |
 | `TRUST_PROXY` | `1` | Aantal proxy-hops (voor `req.ip` / rate-limit) |
 | `EXPOSE_API_DOCS` | `false` | Swagger UI + `/api/openapi.json` |
-| **`WEB_CONCURRENCY`** | aantal CPU-cores | Aantal worker-processen (clustering). `1` = uit. Geclampt op `[1, 64]` |
-| **`DB_POOL_MAX`** | `10` | Postgres-poolgrootte **per worker**. Geclampt op `[1, 100]` |
+| **`WEB_CONCURRENCY`** | `1` | Aantal worker-processen (clustering). Standaard 1 (uit); opt-in via `> 1`. Geclampt op `[1, 64]` |
+| **`DB_POOL_MAX`** | `9` | Postgres-poolgrootte **per worker**. Geclampt op `[1, 20]` (de per-user cap) |
 | **`DB_CONNECT_TIMEOUT`** | `10` | Seconden voordat een nieuwe DB-verbinding faalt |
 | **`DB_IDLE_TIMEOUT`** | `30` | Seconden voordat een idle DB-verbinding wordt gesloten |
 | **`RATE_LIMIT_MAX`** | `300` | Verzoeken per IP per minuut (cluster-breed; zie onder) |
 
 Ongeldige/ontbrekende waarden vallen veilig terug op de default.
 
-## Schalen (clustering)
+## Schalen en de connectie-limiet
 
-De server draait standaard één worker per CPU-core (`node:cluster`), zodat de
-beschikbare CPU wordt benut. Migraties draaien éénmalig vóór de workers starten
-(container-CMD: `migrate && index`).
+De gedeelde RIG-Postgres (`rig-db`) staat op `max_connections: 250` met
+`reserved_connections: 10`, en — bindend voor ons — **elke project-DB-user is
+gecapt op 20 connecties** (`CONNECTION LIMIT 20`, ingesteld na een incident waarbij
+één project alle slots opslokte en Keycloak brak). Dat aantal van **20 is dus het
+totale budget over álle pods, replica's en workers samen**.
 
-**Pool-rekensom — belangrijk:** elke worker heeft zijn eigen pool. Zorg dat
+Omdat de app I/O-bound is (lage CPU-load) en DB-werk op de DB-server draait, levert
+**één worker met een gezonde pool** de beste balans — niet veel workers met mini-pools.
+Let op: een **rolling deploy** draait kort twee pods naast elkaar (de oude + de
+surge-pod), die allebei onder dezelfde DB-user connecties houden. Het budget is dus:
 
 ```
-WEB_CONCURRENCY × DB_POOL_MAX  ≤  Postgres max_connections (default 100)  − headroom
+pods × WEB_CONCURRENCY × DB_POOL_MAX  ≤  20
 ```
 
-(headroom voor migraties, Keycloak en beheer). Voorbeeld: 4 workers × 10 = 40 → ruim
-binnen 100. Een te hoge combinatie kan de database uitputten (self-DoS).
+Standaard: 1 replica + 1 surge = **2 pods** × 1 worker × `DB_POOL_MAX=9` = **18**, een
+krappe marge onder 20. (Bij `Recreate`-strategie of `maxSurge=0` is er geen overlap en
+mag de pool hoger; bij méér replica's of clustering navenant lager.) Wil je echt naar
+veel gelijktijdige gebruikers schalen, dan is een **connection pooler (PgBouncer)** de
+juiste route (al voorzien als rig-cluster-*future*) i.p.v. een grotere per-worker-pool.
 
 De in-memory rate-limit is per worker; het entrypoint deelt `RATE_LIMIT_MAX` daarom
 door het aantal workers, zodat de cluster-brede limiet bij benadering gelijk blijft.

--- a/apps/boekhouding-backend/package.json
+++ b/apps/boekhouding-backend/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@fastify/compress": "^8.3.1",
     "@fastify/cors": "^11.0.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/rate-limit": "^10.3.0",

--- a/apps/boekhouding-backend/src/app.ts
+++ b/apps/boekhouding-backend/src/app.ts
@@ -1,4 +1,5 @@
 import Fastify, { type FastifyInstance } from 'fastify'
+import compress from '@fastify/compress'
 import cors from '@fastify/cors'
 import helmet from '@fastify/helmet'
 import rateLimit from '@fastify/rate-limit'
@@ -50,6 +51,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   })
 
   await app.register(cors, config.cors)
+  await app.register(compress, { global: true })
   await app.register(rateLimit, { max: options.rateLimitMax ?? config.rateLimit.max, timeWindow: '1 minute' })
 
   if (exposeApiDocs) await app.register(swagger, {

--- a/apps/boekhouding-backend/src/app.ts
+++ b/apps/boekhouding-backend/src/app.ts
@@ -19,6 +19,12 @@ export interface BuildAppOptions {
   exposeApiDocs?: boolean
   /** Fastify trustProxy value (proxy CIDR / hop count). Defaults to config.trustProxy. */
   trustProxy?: string | boolean | number
+  /**
+   * Per-instance rate-limit max (requests per IP per minute). The entry point
+   * passes the global limit divided by the worker count, since each worker has
+   * its own in-memory store. Defaults to config.rateLimit.max.
+   */
+  rateLimitMax?: number
 }
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -44,7 +50,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   })
 
   await app.register(cors, config.cors)
-  await app.register(rateLimit, { max: 300, timeWindow: '1 minute' })
+  await app.register(rateLimit, { max: options.rateLimitMax ?? config.rateLimit.max, timeWindow: '1 minute' })
 
   if (exposeApiDocs) await app.register(swagger, {
     openapi: {

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -20,12 +20,50 @@ function parseTrustProxy(): number | string {
   return /^\d+$/.test(v) ? Number(v) : v
 }
 
+// Parse a positive-integer env var, clamped to [1, max]. Falls back to the
+// default when unset, non-numeric, or below 1 — so a misconfigured value can
+// never produce an unsafe state (e.g. a pool of 0 or an absurdly large value).
+function parsePositiveInt(value: string | undefined, fallback: number, max: number): number {
+  if (!value) return fallback
+  const n = parseInt(value, 10)
+  if (!Number.isFinite(n) || n < 1) return fallback
+  return Math.min(n, max)
+}
+
+// Worker-process count for clustering. Returns null when unset/invalid so the
+// entry point can default to one worker per CPU core; an explicit value is
+// clamped to [1, 64] (1 effectively disables clustering). The clamp prevents a
+// misconfigured value from fork-bombing the host.
+function parseWebConcurrency(): number | null {
+  const v = process.env.WEB_CONCURRENCY
+  if (!v) return null
+  const n = parseInt(v, 10)
+  if (!Number.isFinite(n) || n < 1) return null
+  return Math.min(n, 64)
+}
+
 export const config = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: process.env.HOST || '0.0.0.0',
+  webConcurrency: parseWebConcurrency(),
   exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
   trustProxy: parseTrustProxy(),
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
+  // Postgres connection pool. Defaults match postgres.js but are now explicit and
+  // tunable per deployment. With clustering, size DB_POOL_MAX so that
+  // workers × DB_POOL_MAX stays below the server's max_connections (default 100),
+  // leaving headroom for migrations and other clients.
+  db: {
+    max: parsePositiveInt(process.env.DB_POOL_MAX, 10, 100),
+    connectTimeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT, 10, 300),
+    idleTimeout: parsePositiveInt(process.env.DB_IDLE_TIMEOUT, 30, 86400),
+  },
+  // Global request limit per IP per minute. Under clustering the in-memory store
+  // is per worker, so the entry point divides this across workers to keep the
+  // cluster-wide limit close to `max`.
+  rateLimit: {
+    max: parsePositiveInt(process.env.RATE_LIMIT_MAX, 300, 100000),
+  },
   cors: {
     origin: corsOrigin,
     credentials: true,

--- a/apps/boekhouding-backend/src/config.ts
+++ b/apps/boekhouding-backend/src/config.ts
@@ -49,12 +49,16 @@ export const config = {
   exposeApiDocs: process.env.EXPOSE_API_DOCS === 'true',
   trustProxy: parseTrustProxy(),
   databaseUrl: process.env.DATABASE_SERVER_FULL || 'postgresql://parassessment:parassessment@localhost:5432/parassessment',
-  // Postgres connection pool. Defaults match postgres.js but are now explicit and
-  // tunable per deployment. With clustering, size DB_POOL_MAX so that
-  // workers × DB_POOL_MAX stays below the server's max_connections (default 100),
-  // leaving headroom for migrations and other clients.
+  // Postgres connection pool, PER worker process. The RIG shared Postgres caps
+  // each project DB user at 20 connections total (see README), and a rolling
+  // deploy briefly runs two pods (old + surge), so the budget is:
+  //   pods × WEB_CONCURRENCY × DB_POOL_MAX  ≤  20.
+  // Default 9 → 2 pods × 1 worker × 9 = 18, a tight margin under 20. The app is
+  // I/O-bound so one worker with this pool is plenty; the ceiling is the cap.
+  // Raise the pool / add workers/replicas only within that budget, or put a
+  // connection pooler (PgBouncer) in front.
   db: {
-    max: parsePositiveInt(process.env.DB_POOL_MAX, 10, 100),
+    max: parsePositiveInt(process.env.DB_POOL_MAX, 9, 20),
     connectTimeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT, 10, 300),
     idleTimeout: parsePositiveInt(process.env.DB_IDLE_TIMEOUT, 30, 86400),
   },

--- a/apps/boekhouding-backend/src/db/connection.ts
+++ b/apps/boekhouding-backend/src/db/connection.ts
@@ -3,6 +3,10 @@ import postgres from 'postgres'
 import { config } from '../config.js'
 import * as schema from './schema.js'
 
-const queryClient = postgres(config.databaseUrl)
+const queryClient = postgres(config.databaseUrl, {
+  max: config.db.max,
+  connect_timeout: config.db.connectTimeout,
+  idle_timeout: config.db.idleTimeout,
+})
 
 export const db = drizzle(queryClient, { schema })

--- a/apps/boekhouding-backend/src/index.ts
+++ b/apps/boekhouding-backend/src/index.ts
@@ -1,6 +1,7 @@
 import cluster from 'node:cluster'
 import { buildApp } from './app.js'
 import { config } from './config.js'
+import { warmUpJwks } from './middleware/auth.js'
 
 // Single worker by default. The app is I/O-bound (low CPU), and the shared
 // Postgres caps this DB user at 20 connections total, so each extra worker
@@ -22,6 +23,10 @@ if (workers > 1 && cluster.isPrimary) {
   // limit across workers to keep the cluster-wide limit close to the configured value.
   const rateLimitMax = Math.max(1, Math.ceil(config.rateLimit.max / workers))
   const app = await buildApp({ rateLimitMax })
+
+  // Best-effort: prime the JWKS cache so the first authenticated request doesn't
+  // pay the cold Keycloak fetch. Failure here is swallowed (warmUpJwks is best-effort).
+  await warmUpJwks()
 
   try {
     await app.listen({ port: config.port, host: config.host })

--- a/apps/boekhouding-backend/src/index.ts
+++ b/apps/boekhouding-backend/src/index.ts
@@ -1,11 +1,31 @@
+import cluster from 'node:cluster'
+import { availableParallelism } from 'node:os'
 import { buildApp } from './app.js'
 import { config } from './config.js'
 
-const app = await buildApp()
+// One worker per CPU core by default, so we actually use the available CPU.
+// WEB_CONCURRENCY pins the count (1 disables clustering; lower it when scaling
+// horizontally via replicas instead). The value is clamped in config.ts.
+const workers = config.webConcurrency ?? availableParallelism()
 
-try {
-  await app.listen({ port: config.port, host: config.host })
-} catch (err) {
-  app.log.error(err)
-  process.exit(1)
+if (workers > 1 && cluster.isPrimary) {
+  // Migrations already ran once before this process started (the container CMD
+  // runs `migrate && index`), so the primary only supervises workers.
+  for (let i = 0; i < workers; i++) cluster.fork()
+  cluster.on('exit', (worker, code, signal) => {
+    console.error(`worker ${worker.process.pid} exited (${signal || code}); starting a replacement`)
+    cluster.fork()
+  })
+} else {
+  // Each worker keeps its own in-memory rate-limit store, so divide the global
+  // limit across workers to keep the cluster-wide limit close to the configured value.
+  const rateLimitMax = Math.max(1, Math.ceil(config.rateLimit.max / workers))
+  const app = await buildApp({ rateLimitMax })
+
+  try {
+    await app.listen({ port: config.port, host: config.host })
+  } catch (err) {
+    app.log.error(err)
+    process.exit(1)
+  }
 }

--- a/apps/boekhouding-backend/src/index.ts
+++ b/apps/boekhouding-backend/src/index.ts
@@ -1,12 +1,13 @@
 import cluster from 'node:cluster'
-import { availableParallelism } from 'node:os'
 import { buildApp } from './app.js'
 import { config } from './config.js'
 
-// One worker per CPU core by default, so we actually use the available CPU.
-// WEB_CONCURRENCY pins the count (1 disables clustering; lower it when scaling
-// horizontally via replicas instead). The value is clamped in config.ts.
-const workers = config.webConcurrency ?? availableParallelism()
+// Single worker by default. The app is I/O-bound (low CPU), and the shared
+// Postgres caps this DB user at 20 connections total, so each extra worker
+// multiplies connection pressure (workers × DB_POOL_MAX). Opt into clustering
+// by setting WEB_CONCURRENCY > 1, and then lower DB_POOL_MAX so that
+// WEB_CONCURRENCY × DB_POOL_MAX stays within the budget (see README/config.ts).
+const workers = config.webConcurrency ?? 1
 
 if (workers > 1 && cluster.isPrimary) {
   // Migrations already ran once before this process started (the container CMD

--- a/apps/boekhouding-backend/src/middleware/auth.ts
+++ b/apps/boekhouding-backend/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { db } from '../db/connection.js'
 import { users } from '../db/schema.js'
 import { eq, and, isNull } from 'drizzle-orm'
 import { config } from '../config.js'
+import { userIdCache } from '../utils/userIdCache.js'
 
 export interface AuthUser {
   id: string
@@ -33,7 +34,7 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
 
   const token = authHeader.slice(7)
 
-  let payload: { sub?: string; email?: string; name?: string; preferred_username?: string; azp?: string }
+  let payload: { sub?: string; email?: string; name?: string; preferred_username?: string; azp?: string; exp?: number }
   try {
     const result = await jwtVerify(token, jwks, {
       issuer: config.keycloak.issuer,
@@ -72,6 +73,18 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
   }
 
   const displayName = payload.name || payload.preferred_username || payload.email
+
+  // Identity cache: the token is already fully validated above (signature,
+  // issuer, azp, exp), so a hit only skips the users-lookup — never validation.
+  // Authorization is still checked live downstream, so a cache hit cannot leak
+  // access. On a hit, email/displayName come from this request's token, so no
+  // personal data is kept in the cache itself.
+  const now = Date.now()
+  const cachedId = userIdCache.get(payload.sub, now)
+  if (cachedId !== undefined) {
+    request.user = { id: cachedId, email: payload.email, displayName }
+    return
+  }
 
   // Find or create user by OIDC subject
   let [user] = await db
@@ -148,6 +161,10 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
       }
     }
   }
+
+  // Cache the resolved id. The TTL is bounded and never outlives the token, so
+  // a stale identity (or a removed user) can persist for at most the TTL.
+  userIdCache.set(payload.sub, user.id, payload.exp, now)
 
   request.user = {
     id: user.id,

--- a/apps/boekhouding-backend/src/middleware/auth.ts
+++ b/apps/boekhouding-backend/src/middleware/auth.ts
@@ -18,7 +18,34 @@ declare module 'fastify' {
   }
 }
 
-const jwks = createRemoteJWKSet(new URL(config.keycloak.jwksUri))
+// Tighter timeout than the jose default (5000ms): fail fast on a cold/slow
+// Keycloak so the first request is not blocked for 5 seconds. The cooldown
+// matches the jose default so burst behaviour is unchanged.
+const jwks = createRemoteJWKSet(new URL(config.keycloak.jwksUri), {
+  timeoutDuration: 2500,
+  cooldownDuration: 30000,
+})
+
+async function defaultWarm() {
+  await jwks.reload()
+}
+
+/**
+ * Pre-warm the JWKS cache so the first authenticated request does not pay the
+ * cold-fetch cost. Best-effort: any error (Keycloak unreachable at startup) is
+ * swallowed silently.
+ *
+ * The `warm` parameter is injectable for testing; production code uses the
+ * default which calls `jwks.reload()`.
+ */
+export async function warmUpJwks(warm: () => Promise<void> = defaultWarm): Promise<void> {
+  try {
+    await warm()
+  } catch {
+    // Keycloak may not be reachable yet at worker start — that is expected.
+    // The first real request will trigger a fresh fetch.
+  }
+}
 
 export async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
   const authHeader = request.headers.authorization

--- a/apps/boekhouding-backend/src/routes/sync.ts
+++ b/apps/boekhouding-backend/src/routes/sync.ts
@@ -12,8 +12,8 @@ import { requireAuth } from '../middleware/auth.js'
  *
  * Does NOT expose user UUIDs (AVG dataminimalisatie).
  *
- * Performance: uses a single query combining auth check (project_members) and sync data (assessment_instances +
- * assessment_versions) via joins. This avoids 3 sequential round-trips per poll.
+ * Performance: fires two independent queries in parallel (Promise.all) — one join query for auth + sync data,
+ * one count query for comments. This avoids sequential round-trips per poll.
  */
 export async function syncRoutes(app: FastifyInstance) {
   app.addHook('preHandler', requireAuth)
@@ -42,34 +42,42 @@ export async function syncRoutes(app: FastifyInstance) {
     const { assessmentId } = request.params
     const userId = request.user!.id
 
-    // Single query: combines assessment lookup, project membership check, and latest version author.
-    // - INNER JOIN project_members: fails (no rows) if user has no access → 403/404 decision below
-    // - LEFT JOIN assessment_versions on currentVersion: latest version row (nullable for edge cases)
-    const [row] = await db
-      .select({
-        currentVersion: assessmentInstances.currentVersion,
-        updatedAt: assessmentInstances.updatedAt,
-        projectId: assessmentInstances.projectId,
-        memberRole: projectMembers.role,
-        latestVersionCreatedBy: assessmentVersions.createdBy,
-      })
-      .from(assessmentInstances)
-      .leftJoin(
-        assessmentVersions,
-        and(
-          eq(assessmentVersions.assessmentInstanceId, assessmentInstances.id),
-          eq(assessmentVersions.version, assessmentInstances.currentVersion),
-        ),
-      )
-      .leftJoin(
-        projectMembers,
-        and(
-          eq(projectMembers.projectId, assessmentInstances.projectId),
-          eq(projectMembers.userId, userId),
-        ),
-      )
-      .where(eq(assessmentInstances.id, assessmentId))
-      .limit(1)
+    // The row/access query and the comment count are independent — run them in
+    // parallel so a poll costs one round-trip, not two. Guards apply after both resolve.
+    const [rowResult, countResult] = await Promise.all([
+      db
+        .select({
+          currentVersion: assessmentInstances.currentVersion,
+          updatedAt: assessmentInstances.updatedAt,
+          projectId: assessmentInstances.projectId,
+          memberRole: projectMembers.role,
+          latestVersionCreatedBy: assessmentVersions.createdBy,
+        })
+        .from(assessmentInstances)
+        .leftJoin(
+          assessmentVersions,
+          and(
+            eq(assessmentVersions.assessmentInstanceId, assessmentInstances.id),
+            eq(assessmentVersions.version, assessmentInstances.currentVersion),
+          ),
+        )
+        .leftJoin(
+          projectMembers,
+          and(
+            eq(projectMembers.projectId, assessmentInstances.projectId),
+            eq(projectMembers.userId, userId),
+          ),
+        )
+        .where(eq(assessmentInstances.id, assessmentId))
+        .limit(1),
+      db
+        .select({ total: count() })
+        .from(comments)
+        .where(eq(comments.assessmentInstanceId, assessmentId)),
+    ])
+
+    const [row] = rowResult
+    const [{ total }] = countResult
 
     if (!row) {
       return reply.status(404).type('application/problem+json').send({
@@ -90,14 +98,6 @@ export async function syncRoutes(app: FastifyInstance) {
         instance: request.url,
       })
     }
-
-    // Comment count lets clients detect deletions — when a comment is removed, the
-    // /comments?since=... poll returns nothing about it (there's no row left to match).
-    // A mismatch between server count and local thread+reply count triggers a full refresh.
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(comments)
-      .where(eq(comments.assessmentInstanceId, assessmentId))
 
     return {
       version: row.currentVersion,

--- a/apps/boekhouding-backend/src/utils/userIdCache.ts
+++ b/apps/boekhouding-backend/src/utils/userIdCache.ts
@@ -1,0 +1,54 @@
+// In-memory cache mapping an OIDC subject (`sub`) to our internal user id, so
+// that authenticated polling clients don't trigger a users-lookup on every
+// request. Security/privacy properties (see the PR scaling audit):
+//
+// - Stores ONLY the internal id — never email/displayName. The per-request
+//   token carries those, so no personal data lingers in process memory
+//   (AVG dataminimalisatie).
+// - Caches nothing about authorization. Project/assessment access is always
+//   checked live against the database, so revoking access takes effect at once.
+// - An entry never outlives its token: the TTL is capped at `maxTtlMs` AND at
+//   the token's own remaining lifetime.
+// - Bounded size with oldest-first eviction, so a flood of distinct subjects
+//   cannot exhaust memory (availability / DoS).
+// - The cache only ever maps to an already-resolved id; on any uncertainty the
+//   caller falls back to the database lookup — it never grants access on its own.
+export interface UserIdCache {
+  /** Returns the cached id for `oidcSub`, or undefined on a miss/expired entry. */
+  get(oidcSub: string, now: number): string | undefined
+  /** Caches `id` for `oidcSub`. `tokenExpSeconds` is the JWT `exp` claim (seconds). */
+  set(oidcSub: string, id: string, tokenExpSeconds: number | undefined, now: number): void
+  clear(): void
+}
+
+export function createUserIdCache(maxEntries = 10_000, maxTtlMs = 60_000): UserIdCache {
+  const store = new Map<string, { id: string; expiresAt: number }>()
+  return {
+    get(oidcSub, now) {
+      const entry = store.get(oidcSub)
+      if (!entry) return undefined
+      if (entry.expiresAt <= now) {
+        store.delete(oidcSub)
+        return undefined
+      }
+      return entry.id
+    },
+    set(oidcSub, id, tokenExpSeconds, now) {
+      let ttl = maxTtlMs
+      if (tokenExpSeconds !== undefined) {
+        ttl = Math.min(ttl, tokenExpSeconds * 1000 - now)
+      }
+      if (ttl <= 0) return
+      if (store.size >= maxEntries && !store.has(oidcSub)) {
+        // Map preserves insertion order, so the first key is the oldest.
+        store.delete(store.keys().next().value as string)
+      }
+      store.set(oidcSub, { id, expiresAt: now + ttl })
+    },
+    clear() {
+      store.clear()
+    },
+  }
+}
+
+export const userIdCache = createUserIdCache()

--- a/apps/boekhouding-backend/test/cov/app.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/app.cov.test.ts
@@ -136,6 +136,18 @@ describe('registered route prefixes', () => {
   })
 })
 
+describe('response compression', () => {
+  it('compresses a large response with gzip when Accept-Encoding: gzip is sent', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/openapi.json',
+      headers: { 'accept-encoding': 'gzip' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-encoding']).toBe('gzip')
+  })
+})
+
 describe('error handler — RFC 9457 problem+json', () => {
   it('returns 500 with generic detail when the error has no statusCode', async () => {
     const res = await app.inject({ method: 'GET', url: '/__cov/throw-no-status' })

--- a/apps/boekhouding-backend/test/cov/app.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/app.cov.test.ts
@@ -61,6 +61,18 @@ describe('buildApp — options handling', () => {
       await defaultApp.close()
     }
   })
+
+  it('applies the rateLimitMax option (per-worker limit) instead of the config default', async () => {
+    const limitedApp = await buildApp({ logger: false, rateLimitMax: 1 })
+    await limitedApp.ready()
+    try {
+      expect((await limitedApp.inject({ method: 'GET', url: '/api/health' })).statusCode).toBe(200)
+      // A second request from the same client exceeds the per-instance limit of 1.
+      expect((await limitedApp.inject({ method: 'GET', url: '/api/health' })).statusCode).toBe(429)
+    } finally {
+      await limitedApp.close()
+    }
+  })
 })
 
 describe('API_VERSION constant', () => {

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -187,38 +187,38 @@ describe('config — parseTrustProxy', () => {
 describe('config — db pool (parsePositiveInt with clamping)', () => {
   it('uses safe defaults when the pool env vars are unset', async () => {
     const config = await loadConfig()
-    expect(config.db).toEqual({ max: 10, connectTimeout: 10, idleTimeout: 30 })
+    expect(config.db).toEqual({ max: 9, connectTimeout: 10, idleTimeout: 30 })
   })
 
   it('accepts a valid override within range', async () => {
-    process.env.DB_POOL_MAX = '20'
+    process.env.DB_POOL_MAX = '12'
     process.env.DB_CONNECT_TIMEOUT = '5'
     process.env.DB_IDLE_TIMEOUT = '120'
     const config = await loadConfig()
-    expect(config.db).toEqual({ max: 20, connectTimeout: 5, idleTimeout: 120 })
+    expect(config.db).toEqual({ max: 12, connectTimeout: 5, idleTimeout: 120 })
   })
 
   it('falls back to the default for a non-numeric value', async () => {
     process.env.DB_POOL_MAX = 'abc'
     const config = await loadConfig()
-    expect(config.db.max).toBe(10)
+    expect(config.db.max).toBe(9)
   })
 
   it('falls back to the default for a value below 1 (e.g. 0)', async () => {
     process.env.DB_POOL_MAX = '0'
     const config = await loadConfig()
-    expect(config.db.max).toBe(10)
+    expect(config.db.max).toBe(9)
   })
 
-  it('clamps a value above the maximum (pool capped at 100)', async () => {
+  it('clamps a value above the per-user cap (pool capped at 20)', async () => {
     process.env.DB_POOL_MAX = '500'
     const config = await loadConfig()
-    expect(config.db.max).toBe(100)
+    expect(config.db.max).toBe(20)
   })
 })
 
 describe('config — webConcurrency (parseWebConcurrency)', () => {
-  it('returns null when WEB_CONCURRENCY is unset (entry point defaults to CPU count)', async () => {
+  it('returns null when WEB_CONCURRENCY is unset (entry point defaults to 1 worker)', async () => {
     const config = await loadConfig()
     expect(config.webConcurrency).toBeNull()
   })

--- a/apps/boekhouding-backend/test/cov/config.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/config.cov.test.ts
@@ -15,6 +15,11 @@ const ENV_KEYS = [
   'HOST',
   'DATABASE_SERVER_FULL',
   'TRUST_PROXY',
+  'DB_POOL_MAX',
+  'DB_CONNECT_TIMEOUT',
+  'DB_IDLE_TIMEOUT',
+  'WEB_CONCURRENCY',
+  'RATE_LIMIT_MAX',
 ] as const
 
 const originalEnv: Record<string, string | undefined> = {}
@@ -176,5 +181,82 @@ describe('config — parseTrustProxy', () => {
     process.env.TRUST_PROXY = '10.0.0.0/8'
     const config = await loadConfig()
     expect(config.trustProxy).toBe('10.0.0.0/8')
+  })
+})
+
+describe('config — db pool (parsePositiveInt with clamping)', () => {
+  it('uses safe defaults when the pool env vars are unset', async () => {
+    const config = await loadConfig()
+    expect(config.db).toEqual({ max: 10, connectTimeout: 10, idleTimeout: 30 })
+  })
+
+  it('accepts a valid override within range', async () => {
+    process.env.DB_POOL_MAX = '20'
+    process.env.DB_CONNECT_TIMEOUT = '5'
+    process.env.DB_IDLE_TIMEOUT = '120'
+    const config = await loadConfig()
+    expect(config.db).toEqual({ max: 20, connectTimeout: 5, idleTimeout: 120 })
+  })
+
+  it('falls back to the default for a non-numeric value', async () => {
+    process.env.DB_POOL_MAX = 'abc'
+    const config = await loadConfig()
+    expect(config.db.max).toBe(10)
+  })
+
+  it('falls back to the default for a value below 1 (e.g. 0)', async () => {
+    process.env.DB_POOL_MAX = '0'
+    const config = await loadConfig()
+    expect(config.db.max).toBe(10)
+  })
+
+  it('clamps a value above the maximum (pool capped at 100)', async () => {
+    process.env.DB_POOL_MAX = '500'
+    const config = await loadConfig()
+    expect(config.db.max).toBe(100)
+  })
+})
+
+describe('config — webConcurrency (parseWebConcurrency)', () => {
+  it('returns null when WEB_CONCURRENCY is unset (entry point defaults to CPU count)', async () => {
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBeNull()
+  })
+
+  it('returns the parsed worker count when set to a valid value', async () => {
+    process.env.WEB_CONCURRENCY = '4'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBe(4)
+  })
+
+  it('returns null for a non-numeric value', async () => {
+    process.env.WEB_CONCURRENCY = 'abc'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBeNull()
+  })
+
+  it('returns null for a value below 1 (e.g. 0)', async () => {
+    process.env.WEB_CONCURRENCY = '0'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBeNull()
+  })
+
+  it('clamps an excessive value to 64 (prevents a fork bomb)', async () => {
+    process.env.WEB_CONCURRENCY = '100'
+    const config = await loadConfig()
+    expect(config.webConcurrency).toBe(64)
+  })
+})
+
+describe('config — rateLimit', () => {
+  it('defaults the rate-limit max to 300', async () => {
+    const config = await loadConfig()
+    expect(config.rateLimit.max).toBe(300)
+  })
+
+  it('honours a RATE_LIMIT_MAX override', async () => {
+    process.env.RATE_LIMIT_MAX = '500'
+    const config = await loadConfig()
+    expect(config.rateLimit.max).toBe(500)
   })
 })

--- a/apps/boekhouding-backend/test/cov/middleware-auth-jwks.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/middleware-auth-jwks.cov.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import { warmUpJwks } from '../../src/middleware/auth.js'
+
+describe('warmUpJwks — best-effort pre-warming', () => {
+  it('resolves without throwing when the warm action succeeds', async () => {
+    const warm = vi.fn().mockResolvedValue(undefined)
+    await expect(warmUpJwks(warm)).resolves.toBeUndefined()
+    expect(warm).toHaveBeenCalledOnce()
+  })
+
+  it('swallows the error and resolves when the warm action rejects (Keycloak unreachable)', async () => {
+    const warm = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+    await expect(warmUpJwks(warm)).resolves.toBeUndefined()
+    expect(warm).toHaveBeenCalledOnce()
+  })
+
+  it('uses the default warm action when called without arguments (covers defaultWarm branch)', async () => {
+    // The test JWKS server is running (configured in test/setup.ts), so the
+    // real reload() against the loopback server must also succeed without throwing.
+    await expect(warmUpJwks()).resolves.toBeUndefined()
+  })
+})

--- a/apps/boekhouding-backend/test/cov/middleware-auth.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/middleware-auth.cov.test.ts
@@ -6,6 +6,7 @@ import { truncateAll } from '../helpers/testDb.js'
 import { config } from '../../src/config.js'
 import { db } from '../../src/db/connection.js'
 import { users } from '../../src/db/schema.js'
+import { userIdCache } from '../../src/utils/userIdCache.js'
 import { eq } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import type { TokenClaims } from '../helpers/testJwks.js'
@@ -149,6 +150,10 @@ describe('requireAuth — displayName precedence + user provisioning', () => {
     expect((await getProjects(authHeader(t))).statusCode).toBe(200)
     const [before] = await db.select().from(users).where(eq(users.oidcSub, sub))
 
+    // Clear the identity cache so the second request re-reads the existing user
+    // from the DB (exercising the "found, unchanged" branch) rather than hitting
+    // the cache and short-circuiting.
+    userIdCache.clear()
     expect((await getProjects(authHeader(t))).statusCode).toBe(200)
     const [after] = await db.select().from(users).where(eq(users.oidcSub, sub))
 
@@ -164,11 +169,31 @@ describe('requireAuth — displayName precedence + user provisioning', () => {
 
     expect((await getProjects(authHeader(await token({ sub, email: firstEmail, name: 'Oude Naam' })))).statusCode).toBe(200)
 
+    // A fresh (uncached) login must sync the changed claims; clear the cache to
+    // simulate TTL expiry between the two logins.
+    userIdCache.clear()
     expect((await getProjects(authHeader(await token({ sub, email: secondEmail, name: 'Nieuwe Naam' })))).statusCode).toBe(200)
 
     const [row] = await db.select().from(users).where(eq(users.oidcSub, sub))
     expect(row.email).toBe(secondEmail)
     expect(row.displayName).toBe('Nieuwe Naam')
+  })
+
+  it('cache hit: a second request with the same sub skips the DB sync (changes lag until TTL)', async () => {
+    const sub = randomUUID()
+    const firstEmail = `${sub}-old@example.com`
+    const secondEmail = `${sub}-new@example.com`
+
+    // First login populates the cache.
+    expect((await getProjects(authHeader(await token({ sub, email: firstEmail, name: 'Oude Naam' })))).statusCode).toBe(200)
+
+    // Second login with changed claims but WITHOUT clearing the cache: the cache
+    // hit serves the id and skips the users-lookup + sync, so the DB is unchanged.
+    expect((await getProjects(authHeader(await token({ sub, email: secondEmail, name: 'Nieuwe Naam' })))).statusCode).toBe(200)
+
+    const [row] = await db.select().from(users).where(eq(users.oidcSub, sub))
+    expect(row.email).toBe(firstEmail)
+    expect(row.displayName).toBe('Oude Naam')
   })
 
   it('first login does NOT take over an email already claimed by another subject (409)', async () => {

--- a/apps/boekhouding-backend/test/cov/utils-userIdCache.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-userIdCache.cov.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { createUserIdCache, userIdCache } from '../../src/utils/userIdCache.js'
+
+describe('userIdCache — get', () => {
+  it('returns undefined on a miss (no entry)', () => {
+    const cache = createUserIdCache(2, 1000)
+    expect(cache.get('absent', 0)).toBeUndefined()
+  })
+
+  it('returns the id while the entry is fresh', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('sub', 'id-1', undefined, 0)
+    expect(cache.get('sub', 999)).toBe('id-1')
+  })
+
+  it('treats an entry as expired once now reaches expiresAt and deletes it', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('sub', 'id-1', undefined, 0) // expiresAt = 1000
+    expect(cache.get('sub', 1000)).toBeUndefined()
+    // Deleted: a later read with a still-fresh clock is also a miss.
+    expect(cache.get('sub', 0)).toBeUndefined()
+  })
+})
+
+describe('userIdCache — set TTL handling', () => {
+  it('uses the max TTL when the token has no exp', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('sub', 'id-1', undefined, 0)
+    expect(cache.get('sub', 999)).toBe('id-1')
+    expect(cache.get('sub', 1000)).toBeUndefined()
+  })
+
+  it('caps the TTL at the token exp when it is sooner than maxTtl', () => {
+    const cache = createUserIdCache(2, 1000)
+    // exp = 0.5s → 500ms; now = 100ms → remaining 400ms < maxTtl 1000ms
+    cache.set('sub', 'id-1', 0.5, 100)
+    expect(cache.get('sub', 499)).toBe('id-1')
+    expect(cache.get('sub', 500)).toBeUndefined()
+  })
+
+  it('uses maxTtl when the token exp is further away', () => {
+    const cache = createUserIdCache(2, 1000)
+    // exp = 100s → 100000ms remaining, far beyond maxTtl 1000ms
+    cache.set('sub', 'id-1', 100, 0)
+    expect(cache.get('sub', 999)).toBe('id-1')
+    expect(cache.get('sub', 1000)).toBeUndefined()
+  })
+
+  it('does not cache when the token is already expired (non-positive TTL)', () => {
+    const cache = createUserIdCache(2, 1000)
+    // exp = 1s → 1000ms; now = 5000ms → remaining negative
+    cache.set('sub', 'id-1', 1, 5000)
+    expect(cache.get('sub', 5000)).toBeUndefined()
+  })
+})
+
+describe('userIdCache — bounded size', () => {
+  it('evicts the oldest entry when a new key exceeds maxEntries', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('a', 'id-a', undefined, 0)
+    cache.set('b', 'id-b', undefined, 0)
+    cache.set('c', 'id-c', undefined, 0) // size was 2 → evicts oldest ('a')
+
+    expect(cache.get('a', 0)).toBeUndefined()
+    expect(cache.get('b', 0)).toBe('id-b')
+    expect(cache.get('c', 0)).toBe('id-c')
+  })
+
+  it('does not evict when updating an existing key at capacity', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('a', 'id-a', undefined, 0)
+    cache.set('b', 'id-b', undefined, 0)
+    cache.set('b', 'id-b2', undefined, 0) // at capacity but key exists → update only
+
+    expect(cache.get('a', 0)).toBe('id-a')
+    expect(cache.get('b', 0)).toBe('id-b2')
+  })
+})
+
+describe('userIdCache — clear + default instance', () => {
+  it('clear() empties the cache', () => {
+    const cache = createUserIdCache(2, 1000)
+    cache.set('a', 'id-a', undefined, 0)
+    cache.clear()
+    expect(cache.get('a', 0)).toBeUndefined()
+  })
+
+  it('exposes a default instance built with the built-in limits', () => {
+    userIdCache.clear()
+    userIdCache.set('sub', 'id-x', undefined, 0)
+    expect(userIdCache.get('sub', 0)).toBe('id-x')
+    userIdCache.clear()
+    expect(userIdCache.get('sub', 0)).toBeUndefined()
+  })
+})

--- a/apps/boekhouding-backend/test/helpers/testDb.ts
+++ b/apps/boekhouding-backend/test/helpers/testDb.ts
@@ -7,6 +7,7 @@ import { migrate } from 'drizzle-orm/postgres-js/migrator'
 import postgres from 'postgres'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { userIdCache } from '../../src/utils/userIdCache.js'
 
 const migrationsFolder = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle')
 
@@ -32,6 +33,9 @@ const TABLES = [
 ] as const
 
 export async function truncateAll(databaseUrl: string): Promise<void> {
+  // Reset the in-memory identity cache too, so a cached id from a previous test
+  // can't survive the DB truncate and shadow a freshly created user.
+  userIdCache.clear()
   const client = postgres(databaseUrl, { max: 1 })
   try {
     await client.unsafe(`TRUNCATE TABLE ${TABLES.join(', ')} RESTART IDENTITY CASCADE`)

--- a/containers/frontend/nginx.conf
+++ b/containers/frontend/nginx.conf
@@ -22,5 +22,11 @@ http {
     sendfile on;
     keepalive_timeout 65;
 
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+    gzip_comp_level 5;
+    gzip_vary on;
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   apps/boekhouding-backend:
     dependencies:
+      '@fastify/compress':
+        specifier: ^8.3.1
+        version: 8.3.1
       '@fastify/cors':
         specifier: ^11.0.0
         version: 11.2.0
@@ -989,6 +992,9 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/compress@8.3.1':
+    resolution: {integrity: sha512-BUpItLr6MUX9e9ukg5Y6xekyA/7pBFG8QWtFCrUDm9ctoBc3R2/nA16yOaOWtVoccpXGjdDEYA/MxAb5+8cxag==}
+
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
 
@@ -1531,6 +1537,10 @@ packages:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1648,6 +1658,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -1718,6 +1731,9 @@ packages:
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1879,6 +1895,12 @@ packages:
       sqlite3:
         optional: true
 
+  duplexify@3.7.1:
+    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1895,6 +1917,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2034,6 +2059,14 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2185,6 +2218,9 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2252,6 +2288,9 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2412,6 +2451,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -2495,6 +2538,9 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
@@ -2561,6 +2607,9 @@ packages:
   pdfmake@0.3.6:
     resolution: {integrity: sha512-c3uVTdwaNqE/Qaum8BTi9StbFyrYunaR+c94kA6vZA5eHuLFSnvw3pK6Y/0OU4xTFbjKsaHwdeAJinV9ci+OcQ==}
     engines: {node: '>=20'}
+
+  peek-stream@1.1.3:
+    resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -2641,14 +2690,27 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  pumpify@2.0.1:
+    resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2663,6 +2725,17 @@ packages:
   read-package-json-fast@4.0.0:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -2704,6 +2777,12 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.0:
     resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
@@ -2794,6 +2873,9 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2801,6 +2883,12 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2832,6 +2920,9 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  through2@2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -3134,6 +3225,9 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -3152,6 +3246,10 @@ packages:
   xmldoc@2.0.3:
     resolution: {integrity: sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==}
     engines: {node: '>=12.0.0'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -3695,6 +3793,17 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.2
+
+  '@fastify/compress@8.3.1':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      fastify-plugin: 5.1.0
+      mime-db: 1.54.0
+      minipass: 7.1.3
+      peek-stream: 1.1.3
+      pump: 3.0.4
+      pumpify: 2.0.1
+      readable-stream: 4.7.0
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -4314,6 +4423,10 @@ snapshots:
 
   abbrev@2.0.0: {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   abstract-logging@2.0.1: {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -4414,6 +4527,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -4470,6 +4588,8 @@ snapshots:
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
+  core-util-is@1.0.3: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4533,6 +4653,20 @@ snapshots:
     optionalDependencies:
       postgres: 3.4.8
 
+  duplexify@3.7.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      stream-shift: 1.0.3
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   editorconfig@1.0.7:
@@ -4547,6 +4681,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@6.0.1: {}
 
@@ -4767,6 +4905,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -4938,6 +5080,8 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4982,6 +5126,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -5149,6 +5295,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.54.0: {}
+
   mime@3.0.0: {}
 
   minimatch@10.2.4:
@@ -5213,6 +5361,10 @@ snapshots:
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   open@10.2.0:
     dependencies:
@@ -5288,6 +5440,12 @@ snapshots:
       pdfkit: 0.17.2
       xmldoc: 2.0.3
 
+  peek-stream@1.1.3:
+    dependencies:
+      buffer-from: 1.1.2
+      duplexify: 3.7.1
+      through2: 2.0.5
+
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.1.0: {}
@@ -5358,11 +5516,26 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
 
+  process@0.11.10: {}
+
   proto-list@1.2.4: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  pumpify@2.0.1:
+    dependencies:
+      duplexify: 4.1.3
+      inherits: 2.0.4
+      pump: 3.0.4
 
   punycode@2.3.1: {}
 
@@ -5374,6 +5547,30 @@ snapshots:
     dependencies:
       json-parse-even-better-errors: 4.0.0
       npm-normalize-package-bin: 4.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   real-require@0.2.0: {}
 
@@ -5427,6 +5624,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
     dependencies:
@@ -5491,6 +5692,8 @@ snapshots:
 
   std-env@4.0.0: {}
 
+  stream-shift@1.0.3: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -5502,6 +5705,14 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -5530,6 +5741,11 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  through2@2.0.5:
+    dependencies:
+      readable-stream: 2.3.8
+      xtend: 4.0.2
 
   tiny-inflate@1.0.3: {}
 
@@ -5813,6 +6029,8 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
@@ -5826,6 +6044,8 @@ snapshots:
   xmldoc@2.0.3:
     dependencies:
       sax: 1.5.0
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
Vervolg-quick-wins op **#350** (gestapeld: base `perf/backend-concurrency-scaling`).

## Wijzigingen
- **JWKS-hardening** (`auth.ts`, `index.ts`): expliciete `timeoutDuration: 2500` (i.p.v. de jose-default 5000ms) + best-effort `warmUpJwks()` bij worker-start. Tokenvalidatie ongewijzigd. *(Hygiëne voor de koude-start na een deploy — niet de fix voor een "elke-klik-traag"-symptoom.)*
- **Response-compressie backend** (`app.ts`): `@fastify/compress` (global) voor grote JSON-payloads.
- **Compressie statische assets** (`containers/frontend/nginx.conf`): `gzip on` voor de SPA-bundle (JS/CSS/HTML) — die ging ongecomprimeerd over de lijn. Gevalideerd met `nginx -t`. De ingress (ingress-nginx, defaults) geeft de backend-compressie door; voor de API is daar niets nodig.
- **Parallelle sync-poll** (`sync.ts`): de twee onafhankelijke queries via `Promise.all`.

## Bijgewerkt na merge van #353
- De atomische save (`db.transaction`) is hieruit verwijderd — gedekt door **#353** (transactie + conditional UPDATE), gemerged. Raakt `assessments.ts` dus niet meer → geen conflict.
- Gerebaset op de actuele #350-head.

## Verificatie
**100% coverage**, `tsc` schoon, `nginx -t` ok. Conflictvrij met samenwerken.
