### PR TITLE
fix(backend): dicht simultane save-race via atomic conditional UPDATE (Forgejo #50)

### DIFF
--- a/apps/boekhouding-backend/src/routes/assessments.ts
+++ b/apps/boekhouding-backend/src/routes/assessments.ts
@@ -7,6 +7,15 @@ import { requireAssessmentAccess } from '../middleware/assessmentAccess.js'
 import { diffStates } from '../utils/diffStates.js'
 import { rebuildState } from '../utils/rebuildState.js'
 
+// Sentinel to trigger transaction rollback when a concurrent write wins the
+// optimistic-lock race (conditional UPDATE affected 0 rows).
+class OptimisticLockError extends Error {
+  constructor() {
+    super('Optimistic lock conflict')
+    this.name = 'OptimisticLockError'
+  }
+}
+
 export async function assessmentRoutes(app: FastifyInstance) {
   app.addHook('preHandler', requireAuth)
 
@@ -68,6 +77,9 @@ export async function assessmentRoutes(app: FastifyInstance) {
         instance: request.url,
       })
     }
+    // Fast-fail for obviously stale clients. The authoritative check below
+    // runs in the WHERE-clause of the UPDATE to prevent simultaneous races
+    // (two concurrent writes with the same expectedVersion).
     if (assessment.currentVersion !== expectedVersion) {
       return reply.status(409).type('application/problem+json').send({
         type: 'https://httpproblems.com/http-status/409',
@@ -86,7 +98,8 @@ export async function assessmentRoutes(app: FastifyInstance) {
       : []
 
     // No content changes: update cachedState only (saves UI-state like
-    // navigation position without creating a new version)
+    // navigation position without creating a new version). No version bump,
+    // no race risk — cachedState UI-state only, overwrite is acceptable.
     if (previousState && edits.length === 0 && !changeDescription) {
       await db
         .update(assessmentInstances)
@@ -112,71 +125,86 @@ export async function assessmentRoutes(app: FastifyInstance) {
       && !lastVersion.changeDescription
       && (Date.now() - lastVersion.createdAt.getTime()) < CONSOLIDATION_WINDOW_MS
 
-    if (canConsolidate) {
-      // Consolidate: add edits to existing version, update timestamps.
-      // Bump currentVersion so optimistic locking detects concurrent writes
-      // from sessions that hold a stale expectedVersion.
-      const nextVersion = assessment.currentVersion + 1
-
-      if (edits.length > 0) {
-        await db.insert(assessmentEdits).values(
-          edits.map(edit => ({ ...edit, assessmentVersionId: lastVersion.id })),
-        )
-      }
-
-      await db
-        .update(assessmentVersions)
-        .set({ version: nextVersion, updatedAt: new Date() })
-        .where(eq(assessmentVersions.id, lastVersion.id))
-
-      const updateData: Record<string, unknown> = {
-        currentVersion: nextVersion,
-        cachedState: state,
-        updatedAt: new Date(),
-      }
-      if (name) updateData.name = name
-
-      const [updated] = await db
-        .update(assessmentInstances)
-        .set(updateData)
-        .where(eq(assessmentInstances.id, assessmentId))
-        .returning()
-
-      return updated
-    }
-
-    // New version
     const nextVersion = assessment.currentVersion + 1
 
-    const [versionRow] = await db.insert(assessmentVersions).values({
-      assessmentInstanceId: assessmentId,
-      version: nextVersion,
-      createdBy: userId,
-      changeDescription,
-    }).returning()
+    // Single transaction with the optimistic-lock check in the UPDATE's
+    // WHERE-clause (currentVersion = expectedVersion): this both closes the
+    // simultaneous-save race and prevents orphan version/edit rows.
+    try {
+      const updated = await db.transaction(async (tx) => {
+        // Conditional UPDATE first: it gates the version/edit writes below.
+        const updateData: Record<string, unknown> = {
+          currentVersion: nextVersion,
+          cachedState: state,
+          updatedAt: new Date(),
+        }
+        if (name) updateData.name = name
 
-    // Log field-level changes linked to the new version
-    if (edits.length > 0) {
-      await db.insert(assessmentEdits).values(
-        edits.map(edit => ({ ...edit, assessmentVersionId: versionRow.id })),
-      )
+        const lockedRows = await tx
+          .update(assessmentInstances)
+          .set(updateData)
+          .where(and(
+            eq(assessmentInstances.id, assessmentId),
+            eq(assessmentInstances.currentVersion, expectedVersion),
+          ))
+          .returning()
+
+        if (lockedRows.length === 0) {
+          // Signal 409 to outer handler via a sentinel throw that triggers rollback.
+          throw new OptimisticLockError()
+        }
+
+        if (canConsolidate) {
+          // Consolidate: add edits to existing version, bump its version number.
+          if (edits.length > 0) {
+            await tx.insert(assessmentEdits).values(
+              edits.map(edit => ({ ...edit, assessmentVersionId: lastVersion.id })),
+            )
+          }
+
+          await tx
+            .update(assessmentVersions)
+            .set({ version: nextVersion, updatedAt: new Date() })
+            .where(eq(assessmentVersions.id, lastVersion.id))
+        } else {
+          // New version row.
+          const [versionRow] = await tx.insert(assessmentVersions).values({
+            assessmentInstanceId: assessmentId,
+            version: nextVersion,
+            createdBy: userId,
+            changeDescription,
+          }).returning()
+
+          if (edits.length > 0) {
+            await tx.insert(assessmentEdits).values(
+              edits.map(edit => ({ ...edit, assessmentVersionId: versionRow.id })),
+            )
+          }
+        }
+
+        return lockedRows[0]
+      })
+
+      return updated
+    } catch (err) {
+      if (err instanceof OptimisticLockError) {
+        // Read fresh version for the client response.
+        const [fresh] = await db
+          .select({ currentVersion: assessmentInstances.currentVersion })
+          .from(assessmentInstances)
+          .where(eq(assessmentInstances.id, assessmentId))
+          .limit(1)
+        return reply.status(409).type('application/problem+json').send({
+          type: 'https://httpproblems.com/http-status/409',
+          title: 'Conflict',
+          status: 409,
+          detail: 'Assessment is gewijzigd door een andere gebruiker',
+          instance: request.url,
+          currentVersion: fresh?.currentVersion,
+        })
+      }
+      throw err
     }
-
-    // Update assessment instance: cachedState + currentVersion
-    const updateData: Record<string, unknown> = {
-      currentVersion: nextVersion,
-      cachedState: state,
-      updatedAt: new Date(),
-    }
-    if (name) updateData.name = name
-
-    const [updated] = await db
-      .update(assessmentInstances)
-      .set(updateData)
-      .where(eq(assessmentInstances.id, assessmentId))
-      .returning()
-
-    return updated
   })
 
   // Delete assessment

--- a/apps/boekhouding-backend/test/routes/assessmentsSaveRace.test.ts
+++ b/apps/boekhouding-backend/test/routes/assessmentsSaveRace.test.ts
@@ -1,0 +1,265 @@
+// Integration tests for the optimistic-locking save-race (issue #50).
+//
+// Verifies that simultaneous PUT /assessments/:id requests carrying the same
+// expectedVersion cannot both succeed — exactly one wins, the other receives
+// 409 Conflict, and no orphan assessmentVersions / assessmentEdits rows are
+// left behind for the loser.
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { buildApp } from '../../src/app.js'
+import { db } from '../../src/db/connection.js'
+import { assessmentVersions, assessmentEdits, assessmentInstances } from '../../src/db/schema.js'
+import { eq } from 'drizzle-orm'
+import { getJwks } from '../helpers/testContext.js'
+import { truncateAll } from '../helpers/testDb.js'
+import { createUser, createProject, addMember, createAssessment, type SeededUser } from '../helpers/fixtures.js'
+
+let app: FastifyInstance
+const jwks = getJwks()
+
+async function tokenFor(user: SeededUser) {
+  return jwks.signToken({ sub: user.oidcSub, email: user.email })
+}
+
+function authHeader(token: string) {
+  return { authorization: `Bearer ${token}` }
+}
+
+function makeState(urn: string, answers: Record<string, unknown> = {}) {
+  return {
+    metadata: { createdAt: '2026-01-01T00:00:00Z', urn },
+    answers,
+  }
+}
+
+const URN = 'urn:nl:dpia:3.0'
+
+beforeAll(async () => {
+  app = await buildApp({ logger: false })
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+  await jwks.close()
+})
+
+beforeEach(async () => {
+  await truncateAll(process.env.DATABASE_SERVER_FULL!)
+})
+
+async function seed(user: SeededUser) {
+  const project = await createProject(user.id)
+  await addMember(project.id, user.id, 'owner')
+  // Initial state with one answer so diff against next save produces edits.
+  const assessment = await createAssessment(project.id, user.id, {
+    cachedState: makeState(URN, { '0.1': { value: 'Start', lastEditedAt: '2026-01-01T00:00:00Z' } }),
+  })
+  return { project, assessment }
+}
+
+describe('PUT /assessments/:id — optimistic locking (issue #50)', () => {
+  it('happy path: save with correct expectedVersion returns 200 and bumps version', async () => {
+    const user = await createUser()
+    const { assessment } = await seed(user)
+    const token = await tokenFor(user)
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(token),
+      payload: {
+        state: makeState(URN, { '0.1': { value: 'A', lastEditedAt: '2026-01-02T00:00:00Z' } }),
+        expectedVersion: 1,
+      },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().currentVersion).toBe(2)
+  })
+
+  it('sequential stale save returns 409', async () => {
+    const user = await createUser()
+    const { assessment } = await seed(user)
+    const token = await tokenFor(user)
+
+    const first = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(token),
+      payload: {
+        state: makeState(URN, { '0.1': { value: 'A', lastEditedAt: '2026-01-02T00:00:00Z' } }),
+        expectedVersion: 1,
+      },
+    })
+    expect(first.statusCode).toBe(200)
+
+    // Second save with same expectedVersion=1 is now stale (actual is 2).
+    const second = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(token),
+      payload: {
+        state: makeState(URN, { '0.1': { value: 'B', lastEditedAt: '2026-01-03T00:00:00Z' } }),
+        expectedVersion: 1,
+      },
+    })
+    expect(second.statusCode).toBe(409)
+    expect(second.json().currentVersion).toBe(2)
+  })
+
+  it('simultaneous race: two concurrent saves with same expectedVersion — exactly one wins', async () => {
+    // Use two different users so both saves fall into the new-version branch
+    // (consolidation requires same user), which is the branch where orphan
+    // assessmentVersions rows are most likely.
+    const userA = await createUser()
+    const userB = await createUser()
+    const project = await createProject(userA.id)
+    await addMember(project.id, userA.id, 'owner')
+    await addMember(project.id, userB.id, 'editor')
+    const assessment = await createAssessment(project.id, userA.id, {
+      cachedState: makeState(URN, { '0.1': { value: 'Start', lastEditedAt: '2026-01-01T00:00:00Z' } }),
+    })
+    const tokenA = await tokenFor(userA)
+    const tokenB = await tokenFor(userB)
+
+    const results = await Promise.all([
+      app.inject({
+        method: 'PUT',
+        url: `/api/v1/assessments/${assessment.id}`,
+        headers: authHeader(tokenA),
+        payload: {
+          state: makeState(URN, { '0.1': { value: 'A wins?', lastEditedAt: '2026-01-02T00:00:00Z' } }),
+          expectedVersion: 1,
+        },
+      }),
+      app.inject({
+        method: 'PUT',
+        url: `/api/v1/assessments/${assessment.id}`,
+        headers: authHeader(tokenB),
+        payload: {
+          state: makeState(URN, { '0.1': { value: 'B wins?', lastEditedAt: '2026-01-02T00:00:00Z' } }),
+          expectedVersion: 1,
+        },
+      }),
+    ])
+
+    const statuses = results.map(r => r.statusCode).sort()
+    expect(statuses).toEqual([200, 409])
+
+    // DB must show exactly version 2, and exactly one assessmentVersions row
+    // for version 2 (loser's transaction rolled back).
+    const [inst] = await db
+      .select({ currentVersion: assessmentInstances.currentVersion })
+      .from(assessmentInstances)
+      .where(eq(assessmentInstances.id, assessment.id))
+    expect(inst.currentVersion).toBe(2)
+
+    const versions = await db
+      .select({ version: assessmentVersions.version })
+      .from(assessmentVersions)
+      .where(eq(assessmentVersions.assessmentInstanceId, assessment.id))
+    const v2count = versions.filter(v => v.version === 2).length
+    expect(v2count).toBe(1)
+
+    // No orphan edits (edits only linked to the winning version row).
+    const allEdits = await db
+      .select({ id: assessmentEdits.id, versionId: assessmentEdits.assessmentVersionId })
+      .from(assessmentEdits)
+      .innerJoin(assessmentVersions, eq(assessmentEdits.assessmentVersionId, assessmentVersions.id))
+      .where(eq(assessmentVersions.assessmentInstanceId, assessment.id))
+    const versionIds = new Set(
+      (await db
+        .select({ id: assessmentVersions.id })
+        .from(assessmentVersions)
+        .where(eq(assessmentVersions.assessmentInstanceId, assessment.id))).map(v => v.id),
+    )
+    for (const e of allEdits) {
+      expect(versionIds.has(e.versionId)).toBe(true)
+    }
+  })
+
+  it('simultaneous consolidate race: same user, two concurrent saves — exactly one wins, no orphan edits', async () => {
+    const user = await createUser()
+    const { assessment } = await seed(user)
+    const token = await tokenFor(user)
+
+    // Get to version 2 first so consolidation window applies for next saves.
+    const prep = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(token),
+      payload: {
+        state: makeState(URN, { '0.1': { value: 'prep', lastEditedAt: '2026-01-02T00:00:00Z' } }),
+        expectedVersion: 1,
+      },
+    })
+    expect(prep.statusCode).toBe(200)
+    expect(prep.json().currentVersion).toBe(2)
+
+    // Two concurrent saves with expectedVersion=2, both by same user → consolidation branch.
+    const results = await Promise.all([
+      app.inject({
+        method: 'PUT',
+        url: `/api/v1/assessments/${assessment.id}`,
+        headers: authHeader(token),
+        payload: {
+          state: makeState(URN, { '0.1': { value: 'race A', lastEditedAt: '2026-01-03T00:00:00Z' } }),
+          expectedVersion: 2,
+        },
+      }),
+      app.inject({
+        method: 'PUT',
+        url: `/api/v1/assessments/${assessment.id}`,
+        headers: authHeader(token),
+        payload: {
+          state: makeState(URN, { '0.1': { value: 'race B', lastEditedAt: '2026-01-03T00:00:00Z' } }),
+          expectedVersion: 2,
+        },
+      }),
+    ])
+
+    const statuses = results.map(r => r.statusCode).sort()
+    expect(statuses).toEqual([200, 409])
+
+    // After race: currentVersion = 3 and no orphan edits.
+    const [inst] = await db
+      .select({ currentVersion: assessmentInstances.currentVersion })
+      .from(assessmentInstances)
+      .where(eq(assessmentInstances.id, assessment.id))
+    expect(inst.currentVersion).toBe(3)
+  })
+
+  it('non-lock DB error during save propagates as 500 and rolls back (re-throw branch)', async () => {
+    const user = await createUser()
+    const { assessment } = await seed(user)
+    const token = await tokenFor(user)
+
+    // Pre-create the version row the save will try to insert (version 2), so the
+    // new-version INSERT violates unique(assessmentInstanceId, version). That is a
+    // non-OptimisticLockError that must propagate as 500, not be swallowed as 409.
+    await db.insert(assessmentVersions).values({
+      assessmentInstanceId: assessment.id,
+      version: 2,
+      createdBy: user.id,
+    })
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/v1/assessments/${assessment.id}`,
+      headers: authHeader(token),
+      payload: {
+        state: makeState(URN, { '0.1': { value: 'B', lastEditedAt: '2026-01-03T00:00:00Z' } }),
+        expectedVersion: 1,
+        changeDescription: 'forceer nieuwe versie',
+      },
+    })
+
+    expect(res.statusCode).toBe(500)
+    // Transaction rolled back: currentVersion stays at 1.
+    const [inst] = await db
+      .select({ currentVersion: assessmentInstances.currentVersion })
+      .from(assessmentInstances)
+      .where(eq(assessmentInstances.id, assessment.id))
+    expect(inst.currentVersion).toBe(1)
+  })
+})


### PR DESCRIPTION
## Wat
Dicht de optimistic-lock **save-race** (TOCTOU) op `PUT /assessments/:id`. De JS-check `assessment.currentVersion !== expectedVersion` was check-then-act: twee bijna-gelijktijdige PUT's met dezelfde `expectedVersion` passeerden beide en overschreven elkaars `cachedState` (de append-only edits overleefden, maar het snapshot raakte uit sync met de edit-history).

**Oplossing:** de hele save-flow in één `db.transaction()`, met de autoritatieve check in de **WHERE-clause van de `assessmentInstances`-UPDATE** (`eq(id) AND eq(currentVersion, expectedVersion)`). 0 rijen → `OptimisticLockError` → rollback → **409**; een andere DB-fout → re-throw → 500. Dit voorkomt orphan `assessmentVersions`/`assessmentEdits`-rijen.

## Herkomst
Overgebracht vanaf Forgejo `mybee-pr/53`, commit `d16f023` (*Closes Forgejo #50*). De overige 9 commits van die branch staan al (equivalent) op `experimenteel/samenwerken` — alleen deze fix was nog nieuw. Aangepast voor deze branch: een **coverage-test voor het non-lock re-throw-pad (500)** toegevoegd zodat de 100%-gate gehaald wordt, plus een dode test-helper verwijderd.

## Veiligheidsscan (adversarieel, 3 lenzen) — veilig
- **Correctheid:** race echt dicht onder READ COMMITTED (conditional UPDATE als eerste TX-write, exclusieve rij-lock, rollback). Geen orphan-rijen.
- **Regressie:** geen waarneembare gedragswijziging voor normale (niet-gelijktijdige) saves; response-vorm identiek. Consolidate-volgorde omgedraaid maar eindtoestand gelijk.
- **Lek/security:** 409-pad stuurt alleen een `currentVersion`-integer (aanvrager is al geautoriseerd); de 500-re-throw lekt **geen** ruwe DB-fout (error-handler stuurt voor ≥500 een vaste generieke string).

## ⚠️ Merge-volgorde t.o.v. PR #351
Deze fix en PR #351 raken beide `assessments.ts` (PR #351 wikkelt de save in twee losse transacties — alleen atomiciteit; deze fix is de **superset** met de conditional UPDATE). Aanrader: **merge eerst deze PR**, rebase daarna #351 en behoud de fix-versie van de save-handler.

## Verificatie
363 tests, **100% coverage**, `tsc --noEmit` schoon.
