### PR TITLE
fix: prescan feedback KIA logix and IAMA text

### DIFF
--- a/sources/prescan.yaml
+++ b/sources/prescan.yaml
@@ -953,7 +953,7 @@ tasks:
 - task: Kinderrechten
   description: >-
     Bij het verwerken van persoonsgegevens kan er een digitale dienst worden aangeboden die gericht is op personen jonger dan 18 jaar.<br>
-    Als de dienst primair bedoeld is voor deze doelgroep, moet een Kinderrechten Impact Assessment (KIA) worden uitgevoerd. In dat geval is er sprake van een KIA-verplichting.
+    Als de dienst primair bedoeld is voor deze doelgroep, dan wordt aanbevolen om een Kinderrechten Impact Assessment (KIA) uit te voeren (zie de richtsnoeren van de Europese Commissie bij artikel 28 van de Digital Services Act).
   id: "7"
   type:
   - task_group
@@ -1009,9 +1009,9 @@ tasks:
       dependencies:
         - type: conditional
           condition:
-            id: "7.1.1"
+            id: "7.1.2"
             operator: equals
-            value: true
+            value: false
           action: show
           calculation:
             scoreKey: "digitaledienst_minderjarig"
@@ -1080,10 +1080,10 @@ assessments:
         criteria:
           - id: "digitale_dienst"
             expression: "bool(answers('7.1.1'))"
-            explanation: "er een digitale dienst wordt aangeboden"
+            explanation: "Er een digitale dienst wordt aangeboden"
           - id: "minderjarigen"
             expression: "bool(answers('7.1.2'))"
-            explanation: "deze primair bedoeld is voor gebruik door personen jonger dan 18 jaar"
+            explanation: "Deze primair bedoeld is voor gebruik door personen jonger dan 18 jaar"
   - id: "IAMA"
     levels:
       - level: "recommended"
@@ -1092,7 +1092,10 @@ assessments:
         criteria:
           - id: "hoog_risico_ai"
             expression: "bool(answers('6.1.2'))"
-            explanation: "Het IAMA is aanbevolen om de impact op grondrechten in kaart te brengen."
+            explanation: "Er gebruik wordt gemaakt van een hoog risico AI-systeem"
           - id: "impactvol_algoritme"
             expression: "bool(answers('6.1.3'))"
+            explanation: "Er gebruik wordt gemaakt van een impactvol algoritme"
+          - id: "impact_grondrechten"
+            expression: "bool(answers('6.1.2')) || bool(answers('6.1.3'))"
             explanation: "Het IAMA is aanbevolen om de impact op grondrechten in kaart te brengen."


### PR DESCRIPTION
In deze PR: 
  - KIA-zin → aanbeveling i.p.v. verplichting, met verwijzing naar DSA art. 28
  - IAMA-tussenresultaat → reden-bullets (hoog risico AI / impactvol algoritme) + grondrechten-conclusie
  - KIA-bullets met hoofdletter
  - aanpassing KIA logica: de 7.1.3-dependency (7.1.3 alleen tonen bij 7.1.2 = Nee)

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have tested the changes locally and verified that they work as expected.
- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have read, understood and agree to the [Developer Certificate of Origin](/DCO.md), which this project utilizes.
