### PR TITLE
fix(ci): broken-link-check op elke PR, test/lockfile-URLs uitsluiten

### DIFF
--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -3,10 +3,9 @@ on:
   # Run daily at 9:00 AM
   schedule:
     - cron: '0 9 * * *'
-  # Run on PRs to main
+  # Run the link check on every PR (the begrippenkader-sync jobs below are
+  # gated to schedule/dispatch and PRs to main only).
   pull_request:
-    branches:
-      - main
   # Allow manual triggering
   workflow_dispatch:
 
@@ -45,6 +44,8 @@ jobs:
             --exclude "https://httpproblems.com/.*"
             --exclude "^http://(keycloak|backend|postgres):[0-9]+"
             --exclude "https://github.com/MinBZK/par-dpia-form/blob/main/schemas/.*"
+            --exclude-path '/test/'
+            --exclude-path 'pnpm-lock\.yaml'
             '**/*.yaml'
             '**/*.md'
             '**/*.ts'
@@ -71,7 +72,9 @@ jobs:
   sync-begrippenkader-dpia:
     runs-on: ubuntu-latest
     needs: check-links
-    if: always()
+    # Run on schedule/dispatch, and on PRs only when they target main (these
+    # jobs auto-commit external content, so don't run them on arbitrary PRs).
+    if: ${{ always() && (github.event_name != 'pull_request' || github.base_ref == 'main') }}
     permissions:
       contents: write
       pull-requests: write
@@ -128,7 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     # Allow this job to continue even if the check-links job fails
     needs: check-links
-    if: always()
+    # Run on schedule/dispatch, and on PRs only when they target main (these
+    # jobs auto-commit external content, so don't run them on arbitrary PRs).
+    if: ${{ always() && (github.event_name != 'pull_request' || github.base_ref == 'main') }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Probleem

De `Check for broken links`-job (lychee) faalde — maar niet op echte kapotte links. De "broken" links waren **voorbeeld-/placeholder-URLs in test-fixtures** en **package-URLs in `pnpm-lock.yaml`**:

- `https://e.com/p?a=1&b=2`, `https://a/` → `packages/assessment-core/test/markdown.test.ts`
- `https://example/schema.json` → `packages/assessment-core/test/cov/utils-importDetect.cov.test.ts`
- `http://keycloak.internal:8080/...`, `realm-x` → `apps/boekhouding-backend/test/cov/config.cov.test.ts`
- `https://tsx.is/` → `pnpm-lock.yaml`

Het zijn geen documentatielinks; lychee hoort test-fixtures en lockfiles niet te checken.

## Oplossing

- **Test-bestanden en `pnpm-lock.yaml` uitsluiten** via `--exclude-path` (let op: lychee's `--exclude-path` is **regex**, geen glob — `/test/` en `pnpm-lock\.yaml`). Lokaal geverifieerd met lychee 0.24.2: de fixture/lockfile-URLs zijn weg, en **133 echte URLs** (ncsc, github/MinBZK, rijksoverheid, ...) worden nog gewoon gecheckt.
- **De link-check draait nu op elke PR** (was: alleen PR's naar `main`), consistent met `test`/`pre-commit`/`build-standalone`.
- De **begrippenkader-sync-jobs** (die externe content auto-committen) blijven beperkt tot schedule/dispatch en PR's naar `main`, zodat ze niet op willekeurige PR's gaan auto-committen.

Verificatie: actionlint groen; lychee-`--dump` lokaal bevestigt 0 fixture/lockfile-URLs en 133 resterende echte links.
