### PR TITLE
fix(claude): marketplace directory-source naar repo-root

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
     "assessment-tools": {
       "source": {
         "source": "directory",
-        "path": "./.claude/plugins"
+        "path": "."
       }
     }
   },


### PR DESCRIPTION
## Probleem

`/doctor` meldde: `Marketplace assessment-tools failed to load: cache-miss`. De `assessments`-plugin werd daardoor niet geladen voor wie de repo clonet.

## Oorzaak

De `assessment-tools` marketplace is in `.claude/settings.json` gedefinieerd als **directory-source**, maar het pad wees naar `./.claude/plugins`. Een directory-marketplace wordt herkend aan een `.claude-plugin/marketplace.json` in de root van het opgegeven pad — en die staat in de **repo-root**, niet in `./.claude/plugins`. De submap bevat alleen de plugin zelf (`assessments/.claude-plugin/plugin.json`), geen marketplace-manifest. Dus kon de marketplace niet laden.

## Fix

Pad gecorrigeerd van `./.claude/plugins` naar `.`, zodat de directory-source de repo-root als marketplace-root gebruikt. De plugin-`source` in `marketplace.json` (`./.claude/plugins/assessments`) blijft daarmee correct resolven.

Geen netwerk/clone nodig: de marketplace komt rechtstreeks uit de uitgecheckte repo, offline en altijd gelijk aan de code op die commit.

## Verificatie

- `.claude-plugin/marketplace.json` (repo-root) declareert `name: assessment-tools` met plugin `assessments` → `source: ./.claude/plugins/assessments` ✅
- Na de fix laadt de marketplace en zijn de `assessments`-skills beschikbaar.