### PR TITLE
Leg publiccode landingURL om van GitHub Pages naar invulhulpen.rijksapp.nl

### DIFF
--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -1,7 +1,7 @@
 publiccodeYmlVersion: "0.3"
 name: Invulhulp voor pre-scan en DPIA
 url: "https://github.com/MinBZK/par-dpia-form"
-landingURL: "https://minbzk.github.io/par-dpia-form/"
+landingURL: "https://invulhulpen.rijksapp.nl"
 softwareType: standalone/web
 releaseDate: "2025-06-02"
 platforms:


### PR DESCRIPTION
## Wat

De invulhulp draait op **invulhulpen.rijksapp.nl**. De oude GitHub Pages-site (`minbzk.github.io/par-dpia-form/`) wordt uitgefaseerd. Deze PR legt de publieke `landingURL` om naar het live domein:

- `publiccode.yaml` → `landingURL` naar `https://invulhulpen.rijksapp.nl`

## Context

`main` deployt zelf al niet meer naar `gh-pages`: de oude `pr-preview.yaml` + `release-and-deploy.yaml` (die `rossjrw/pr-preview-action` en `JamesIves/github-pages-deploy-action` gebruikten) zijn bij de #283-merge vervangen door de ZAD-preview (`deploy-preview.yaml`) en de release-asset (`release.yaml`).

De **offline/standalone** variant blijft beschikbaar via `invulhulpen.rijksapp.nl/zonder-account` en als single-file release-asset.

## Vervolg (buiten deze PR)

De `gh-pages`-branch wordt herbestemd tot een **client-side redirect** naar `invulhulpen.rijksapp.nl` (#380), zodat bestaande links niet 404'en. Het gedateerde `docs/rapport/rapport_v0.1.1.md` houdt bewust zijn historische `minbzk.github.io`-URL. Externe `github.io`-links (nl-design-system, Logius, Algoritmekader) blijven ongewijzigd.