### PR TITLE
feat(rvo): upgrade @nl-rvo component-library-css 4.20.2 + design-tokens 2.4.1 (button-migratie)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,7 +82,7 @@ De tsconfigs in `apps/*` en `packages/*` erven gedeelde instellingen via `extend
 - API-calls via `api.ts` naar `/api/v1/`, Bearer token via `useAuth().getToken()`
 - Gedeelde componenten komen uit `@overheid-assessment/core`
 - Dialogen: native `<dialog>` met `showModal()` (focus trap automatisch, `::backdrop` voor overlay). Geen handmatige backdrop-divs of `.open` property.
-- RVO buttons: `utrecht-button utrecht-button--primary-action utrecht-button--rvo-md` (NIET `--rvo-primary-action`). Varianten: `--primary-action`, `--secondary-action`, `--rvo-tertiary-action`. Sizes: `--rvo-xs`, `--rvo-md`
+- RVO buttons: `rvo-button rvo-button--primary rvo-button--size-md`. Varianten: `--primary`, `--secondary`, `--tertiary`, `--quaternary`, `--warning`. Sizes: `--size-xs`, `--size-sm`, `--size-md`. Icon-positie: `--icon-before` / `--icon-after`. Volle breedte: `--full-width`. (Sinds `@nl-rvo/component-library-css` 4.16 is Button van `utrecht-button*` naar `rvo-button*` gemigreerd; `utrecht-button` bestaat niet meer.)
 
 ## Database
 

--- a/apps/boekhouding-frontend/package.json
+++ b/apps/boekhouding-frontend/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@nl-rvo/assets": "^1.0.0-alpha.360",
-    "@nl-rvo/component-library-css": "4.8.0",
-    "@nl-rvo/design-tokens": "1.9.0",
+    "@nl-rvo/component-library-css": "4.20.2",
+    "@nl-rvo/design-tokens": "2.4.1",
     "@overheid-assessment/core": "workspace:*",
     "@tabler/icons-vue": "^3.44.0",
     "keycloak-js": "^26.2.4",

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -108,7 +108,7 @@ dialog::backdrop {
   border-color: var(--rvo-color-rood, #d52b1e);
 }
 
-.confirm-dialog__actions .utrecht-button--secondary-action:hover {
+.confirm-dialog__actions .rvo-button--secondary:hover {
   background-color: var(--rvo-color-hemelblauw);
   border-color: var(--rvo-color-hemelblauw);
   color: var(--rvo-color-wit, #fff);
@@ -132,14 +132,14 @@ dialog::backdrop {
   color: var(--rvo-color-grijs-500, #666);
 }
 
-.rvo-alert .utrecht-button:hover {
+.rvo-alert .rvo-button:hover {
   text-decoration: none;
 }
 
 /* Fix anchor elements styled as buttons (RVO button classes don't fully reset anchor defaults) */
-a.utrecht-button {
+a.rvo-button {
   text-decoration: none;
-  color: var(--_utrecht-button-color);
+  color: var(--rvo-button-color);
 }
 
 a.card-link {

--- a/apps/boekhouding-frontend/src/components/AppHeader.vue
+++ b/apps/boekhouding-frontend/src/components/AppHeader.vue
@@ -18,7 +18,7 @@ const { user, isAuthenticated, logout } = useAuth()
     <div class="app-header__left">
       <button
         v-if="backRoute || showBack"
-        class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs utrecht-button--icon-gap app-header__back"
+        class="rvo-button rvo-button--tertiary rvo-button--size-xs rvo-button--icon-before app-header__back"
         @click="backRoute ? router.push(backRoute) : router.back()"
       >
         <IconArrowLeft :size="16" /> {{ backLabel || 'Terug' }}
@@ -30,7 +30,7 @@ const { user, isAuthenticated, logout } = useAuth()
       <template v-if="isAuthenticated">
         <span v-if="user" class="app-header__user">{{ user.displayName }}</span>
         <button
-          class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs utrecht-button--icon-gap"
+          class="rvo-button rvo-button--tertiary rvo-button--size-xs rvo-button--icon-before"
           @click="logout"
         >
           <IconLogout :size="16" /> Uitloggen

--- a/apps/boekhouding-frontend/src/components/ConflictResolutionDialog.vue
+++ b/apps/boekhouding-frontend/src/components/ConflictResolutionDialog.vue
@@ -87,7 +87,7 @@ function handleResolve() {
       <div class="confirm-dialog__actions">
         <button
           type="button"
-          class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+          class="rvo-button rvo-button--primary rvo-button--size-md"
           @click="handleResolve"
         >Toepassen</button>
       </div>

--- a/apps/boekhouding-frontend/src/components/SessionExpiredDialog.vue
+++ b/apps/boekhouding-frontend/src/components/SessionExpiredDialog.vue
@@ -23,7 +23,7 @@ watch(sessionExpired, (expired) => {
       <div class="confirm-dialog__actions">
         <button
           type="button"
-          class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+          class="rvo-button rvo-button--primary rvo-button--size-md"
           @click="relogin()"
         >Opnieuw inloggen</button>
       </div>

--- a/apps/boekhouding-frontend/src/views/AssessmentEditor.vue
+++ b/apps/boekhouding-frontend/src/views/AssessmentEditor.vue
@@ -376,7 +376,7 @@ const confirmDelete = async () => {
   <div v-else-if="error" class="rvo-max-width-layout rvo-max-width-layout--md" role="alert">
     <h2 class="utrecht-heading-2">Foutmelding</h2>
     <p>{{ error }}</p>
-    <button class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs utrecht-button--icon-gap" @click="assessment ? router.push(`/project/${assessment.projectId}`) : router.push('/projecten')">
+    <button class="rvo-button rvo-button--tertiary rvo-button--size-xs rvo-button--icon-before" @click="assessment ? router.push(`/project/${assessment.projectId}`) : router.push('/projecten')">
       <IconArrowLeft :size="16" /> Terug naar project
     </button>
   </div>
@@ -411,8 +411,8 @@ const confirmDelete = async () => {
               @keydown.enter="saveName"
               @keydown.escape="cancelName"
             />
-            <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-xs" @click="saveName">Opslaan</button>
-            <button class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs" @click="cancelName">Annuleer</button>
+            <button class="rvo-button rvo-button--primary rvo-button--size-xs" @click="saveName">Opslaan</button>
+            <button class="rvo-button rvo-button--tertiary rvo-button--size-xs" @click="cancelName">Annuleer</button>
           </div>
         </div>
         <div class="form-subheader__right">
@@ -496,14 +496,14 @@ const confirmDelete = async () => {
       </label>
       <div class="confirm-dialog__actions">
         <button
-          class="utrecht-button utrecht-button--rvo-md confirm-dialog__delete"
-          :class="deleteConfirmInput === 'VERWIJDEREN' ? 'utrecht-button--primary-action' : 'confirm-dialog__delete--disabled'"
+          class="rvo-button rvo-button--size-md confirm-dialog__delete"
+          :class="deleteConfirmInput === 'VERWIJDEREN' ? 'rvo-button--primary' : 'confirm-dialog__delete--disabled'"
           :disabled="deleteConfirmInput !== 'VERWIJDEREN'"
           @click="confirmDelete"
         >
           Assessment verwijderen
         </button>
-        <button class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md" @click="deleteModalOpen = false; deleteConfirmInput = ''">
+        <button class="rvo-button rvo-button--secondary rvo-button--size-md" @click="deleteModalOpen = false; deleteConfirmInput = ''">
           Annuleer
         </button>
       </div>

--- a/apps/boekhouding-frontend/src/views/LandingPage.vue
+++ b/apps/boekhouding-frontend/src/views/LandingPage.vue
@@ -88,7 +88,7 @@ const assessments = [
               </p>
               <a
                 :href="standaloneUrl"
-                class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+                class="rvo-button rvo-button--primary rvo-button--size-md"
               >
                 Start zonder account
               </a>
@@ -109,7 +109,7 @@ const assessments = [
                 mogelijkheid om opmerkingen te plaatsen.
               </p>
               <button
-                class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+                class="rvo-button rvo-button--primary rvo-button--size-md"
                 @click="goToProjects"
               >
                 {{ isAuthenticated ? 'Naar projecten' : 'Inloggen' }}

--- a/apps/boekhouding-frontend/src/views/ProjectDetail.vue
+++ b/apps/boekhouding-frontend/src/views/ProjectDetail.vue
@@ -349,14 +349,14 @@ const formatDate = (dateStr: string) =>
             @keydown.escape="cancelName"
           />
           <div class="editable-field-actions">
-            <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-xs" @click="saveName">Opslaan</button>
-            <button class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs" @click="cancelName">Annuleer</button>
+            <button class="rvo-button rvo-button--primary rvo-button--size-xs" @click="saveName">Opslaan</button>
+            <button class="rvo-button rvo-button--tertiary rvo-button--size-xs" @click="cancelName">Annuleer</button>
           </div>
         </div>
         <div class="project-actions">
           <button
             v-if="isOwner"
-            class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs utrecht-button--icon-gap"
+            class="rvo-button rvo-button--tertiary rvo-button--size-xs rvo-button--icon-before"
             @click="router.push(`/project/${projectId}/leden`)"
           >
             <IconUsers :size="16" /> Leden beheren
@@ -393,8 +393,8 @@ const formatDate = (dateStr: string) =>
           @keydown.escape="cancelDescription"
         />
         <div class="editable-field-actions">
-          <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-xs" @click="saveDescription">Opslaan</button>
-          <button class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs" @click="cancelDescription">Annuleer</button>
+          <button class="rvo-button rvo-button--primary rvo-button--size-xs" @click="saveDescription">Opslaan</button>
+          <button class="rvo-button rvo-button--tertiary rvo-button--size-xs" @click="cancelDescription">Annuleer</button>
         </div>
       </div>
 
@@ -423,7 +423,7 @@ const formatDate = (dateStr: string) =>
             <h3 class="utrecht-heading-3 rvo-margin--none">Pre-scan</h3>
             <p>Toets of een DPIA, DTIA, IAMA of KIA nodig is.</p>
             <div class="card-button">
-              <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" @click="openStartDialog('prescan')">
+              <button class="rvo-button rvo-button--primary rvo-button--size-md" @click="openStartDialog('prescan')">
                 Start pre-scan
               </button>
             </div>
@@ -434,7 +434,7 @@ const formatDate = (dateStr: string) =>
             <h3 class="utrecht-heading-3 rvo-margin--none">DPIA</h3>
             <p>Vul stap voor stap het rijksmodel DPIA in.</p>
             <div class="card-button">
-              <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" @click="openStartDialog('dpia')">
+              <button class="rvo-button rvo-button--primary rvo-button--size-md" @click="openStartDialog('dpia')">
                 Start DPIA
               </button>
             </div>
@@ -445,7 +445,7 @@ const formatDate = (dateStr: string) =>
             <h3 class="utrecht-heading-3 rvo-margin--none">IAMA</h3>
             <p>Breng de impact op mensenrechten van een algoritme in kaart.</p>
             <div class="card-button">
-              <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" @click="openStartDialog('iama')">
+              <button class="rvo-button rvo-button--primary rvo-button--size-md" @click="openStartDialog('iama')">
                 Start IAMA
               </button>
             </div>
@@ -567,14 +567,14 @@ const formatDate = (dateStr: string) =>
 
       <div class="start-dialog__actions">
         <button
-          class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+          class="rvo-button rvo-button--primary rvo-button--size-md"
           :disabled="dialogSubmitting"
           @click="submitDialog"
         >
           {{ dialogSubmitting ? 'Bezig...' : (dialogAssessmentType === 'dpia' ? 'Start DPIA' : dialogAssessmentType === 'iama' ? 'Start IAMA' : 'Start pre-scan') }}
         </button>
         <button
-          class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md"
+          class="rvo-button rvo-button--secondary rvo-button--size-md"
           :disabled="dialogSubmitting"
           @click="closeDialog"
         >
@@ -598,14 +598,14 @@ const formatDate = (dateStr: string) =>
       </label>
       <div class="confirm-dialog__actions">
         <button
-          class="utrecht-button utrecht-button--rvo-md confirm-dialog__delete"
-          :class="deleteConfirmInput === 'VERWIJDEREN' ? 'utrecht-button--primary-action' : 'confirm-dialog__delete--disabled'"
+          class="rvo-button rvo-button--size-md confirm-dialog__delete"
+          :class="deleteConfirmInput === 'VERWIJDEREN' ? 'rvo-button--primary' : 'confirm-dialog__delete--disabled'"
           :disabled="deleteConfirmInput !== 'VERWIJDEREN'"
           @click="confirmDeleteProject"
         >
           Project verwijderen
         </button>
-        <button class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md" @click="deleteProjectModalOpen = false; deleteConfirmInput = ''">
+        <button class="rvo-button rvo-button--secondary rvo-button--size-md" @click="deleteProjectModalOpen = false; deleteConfirmInput = ''">
           Annuleer
         </button>
       </div>

--- a/apps/boekhouding-frontend/src/views/ProjectList.vue
+++ b/apps/boekhouding-frontend/src/views/ProjectList.vue
@@ -68,7 +68,7 @@ const handleCreate = async () => {
       </div>
 
       <div v-if="!showCreateForm">
-        <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md utrecht-button--icon-gap" @click="showCreateForm = true">
+        <button class="rvo-button rvo-button--primary rvo-button--size-md rvo-button--icon-before" @click="showCreateForm = true">
           <IconPlus :size="20" /> Nieuw project
         </button>
       </div>
@@ -85,7 +85,7 @@ const handleCreate = async () => {
             @input="autoGrowTextarea($event.target as HTMLTextAreaElement)"
           ></textarea>
         </div>
-        <div class="utrecht-button-group">
+        <div class="rvo-action-group">
           <UiButton variant="primary" type="submit" label="Project toevoegen" />
           <UiButton variant="secondary" label="Annuleren" @click="showCreateForm = false" />
         </div>

--- a/apps/boekhouding-frontend/src/views/ProjectMembers.vue
+++ b/apps/boekhouding-frontend/src/views/ProjectMembers.vue
@@ -133,7 +133,7 @@ const whoLabel = (member: Member) => {
           <span class="member-col--action">
             <button
               v-if="!isOnlyOwner(member)"
-              class="utrecht-button utrecht-button--primary-action confirm-dialog__delete member-delete"
+              class="rvo-button rvo-button--primary confirm-dialog__delete member-delete"
               @click="openDeleteModal(member)"
             >
               Verwijderen
@@ -157,7 +157,7 @@ const whoLabel = (member: Member) => {
             <option value="viewer">Lezer</option>
           </select>
         </div>
-        <button class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" type="submit">Toevoegen</button>
+        <button class="rvo-button rvo-button--primary rvo-button--size-md" type="submit">Toevoegen</button>
       </form>
     </template>
   </div>
@@ -169,12 +169,12 @@ const whoLabel = (member: Member) => {
       <p>Weet je zeker dat je <strong>{{ memberToDelete ? whoLabel(memberToDelete) : '' }}</strong> wilt verwijderen uit dit project?</p>
       <div class="confirm-dialog__actions">
         <button
-          class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md confirm-dialog__delete"
+          class="rvo-button rvo-button--primary rvo-button--size-md confirm-dialog__delete"
           @click="confirmRemove"
         >
           Verwijderen
         </button>
-        <button class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md" @click="closeDeleteModal">
+        <button class="rvo-button rvo-button--secondary rvo-button--size-md" @click="closeDeleteModal">
           Annuleer
         </button>
       </div>

--- a/apps/boekhouding-frontend/src/views/VersionHistory.vue
+++ b/apps/boekhouding-frontend/src/views/VersionHistory.vue
@@ -833,11 +833,11 @@ function mapEditsToDiffFields(
         ></textarea>
         <div class="confirm-dialog__actions">
           <button
-            class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+            class="rvo-button rvo-button--primary rvo-button--size-md"
             @click="saveDescription"
           >Opslaan</button>
           <button
-            class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md"
+            class="rvo-button rvo-button--secondary rvo-button--size-md"
             @click="descModalOpen = false"
           >Annuleren</button>
         </div>
@@ -863,13 +863,13 @@ function mapEditsToDiffFields(
         </label>
         <div class="confirm-dialog__actions">
           <button
-            class="utrecht-button utrecht-button--rvo-md confirm-dialog__delete"
-            :class="restoreConfirmed ? 'utrecht-button--primary-action' : 'confirm-dialog__delete--disabled'"
+            class="rvo-button rvo-button--size-md confirm-dialog__delete"
+            :class="restoreConfirmed ? 'rvo-button--primary' : 'confirm-dialog__delete--disabled'"
             :disabled="!restoreConfirmed"
             @click="handleRestore"
           >Herstellen</button>
           <button
-            class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md"
+            class="rvo-button rvo-button--secondary rvo-button--size-md"
             @click="restoreModalOpen = false; restoreConfirmText = ''"
           >Annuleren</button>
         </div>
@@ -886,11 +886,11 @@ function mapEditsToDiffFields(
         </p>
         <div class="confirm-dialog__actions">
           <button
-            class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+            class="rvo-button rvo-button--primary rvo-button--size-md"
             @click="handleFieldRestore"
           >Herstellen</button>
           <button
-            class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md"
+            class="rvo-button rvo-button--secondary rvo-button--size-md"
             @click="fieldRestoreModalOpen = false"
           >Annuleren</button>
         </div>

--- a/apps/boekhouding-frontend/test/cov/components-ConflictResolutionDialog.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/components-ConflictResolutionDialog.cov.test.ts
@@ -119,7 +119,7 @@ describe('ConflictResolutionDialog', () => {
     expect(wrapper2Rows).toHaveLength(1)
     expect(wrapper2Rows[0].find('.conflict-field').text()).toBe('Nieuw veld')
 
-    await wrapper.find('button.utrecht-button').trigger('click')
+    await wrapper.find('button.rvo-button').trigger('click')
     const resolved = wrapper.emitted('resolve')![0][0] as Map<string, string>
     expect([...resolved.keys()]).toEqual(['new'])
   })
@@ -172,7 +172,7 @@ describe('ConflictResolutionDialog', () => {
       .trigger('change')
 
     close.mockClear()
-    await wrapper.find('button.utrecht-button').trigger('click')
+    await wrapper.find('button.rvo-button').trigger('click')
 
     expect(close).toHaveBeenCalledTimes(1)
 
@@ -191,7 +191,7 @@ describe('ConflictResolutionDialog', () => {
     await wrapper.setProps({ active: true })
     await nextTick()
 
-    await wrapper.find('button.utrecht-button').trigger('click')
+    await wrapper.find('button.rvo-button').trigger('click')
 
     const map = wrapper.emitted('resolve')![0][0] as Map<string, string>
     expect(map.size).toBe(0)

--- a/apps/boekhouding-frontend/test/cov/views-AssessmentEditor.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-AssessmentEditor.cov.test.ts
@@ -779,7 +779,7 @@ describe('AssessmentEditor — delete flow', () => {
     await input.setValue('VERWIJDEREN')
     await nextTick()
     expect((deleteBtn.element as HTMLButtonElement).disabled).toBe(false)
-    expect(deleteBtn.classes()).toContain('utrecht-button--primary-action')
+    expect(deleteBtn.classes()).toContain('rvo-button--primary')
 
     await deleteBtn.trigger('click')
     await flushPromises()

--- a/apps/boekhouding-frontend/test/cov/views-LandingPage.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-LandingPage.cov.test.ts
@@ -107,8 +107,8 @@ describe('LandingPage', () => {
 
     it('makes the login button primary (blue), like the start button', () => {
       const wrapper = mountPage()
-      const button = wrapper.find('button.utrecht-button')
-      expect(button.classes()).toContain('utrecht-button--primary-action')
+      const button = wrapper.find('button.rvo-button')
+      expect(button.classes()).toContain('rvo-button--primary')
     })
   })
 
@@ -136,13 +136,13 @@ describe('LandingPage', () => {
     it('labels the button "Inloggen" when not authenticated', () => {
       authenticated.value = false
       const wrapper = mountPage()
-      expect(wrapper.find('button.utrecht-button').text()).toBe('Inloggen')
+      expect(wrapper.find('button.rvo-button').text()).toBe('Inloggen')
     })
 
     it('labels the button "Naar projecten" when authenticated', () => {
       authenticated.value = true
       const wrapper = mountPage()
-      expect(wrapper.find('button.utrecht-button').text()).toBe('Naar projecten')
+      expect(wrapper.find('button.rvo-button').text()).toBe('Naar projecten')
     })
   })
 
@@ -150,7 +150,7 @@ describe('LandingPage', () => {
     it('navigates to /projecten when authenticated and does not call login', async () => {
       authenticated.value = true
       const wrapper = mountPage()
-      await wrapper.find('button.utrecht-button').trigger('click')
+      await wrapper.find('button.rvo-button').trigger('click')
       await flushPromises()
       expect(routerPush).toHaveBeenCalledWith('/projecten')
       expect(login).not.toHaveBeenCalled()
@@ -159,7 +159,7 @@ describe('LandingPage', () => {
     it('awaits login() when not authenticated and does not navigate', async () => {
       authenticated.value = false
       const wrapper = mountPage()
-      await wrapper.find('button.utrecht-button').trigger('click')
+      await wrapper.find('button.rvo-button').trigger('click')
       await flushPromises()
       expect(login).toHaveBeenCalledTimes(1)
       expect(routerPush).not.toHaveBeenCalled()

--- a/apps/boekhouding-frontend/test/cov/views-ProjectDetail.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-ProjectDetail.cov.test.ts
@@ -796,7 +796,7 @@ describe('ProjectDetail', () => {
       await confirmInput.setValue('VERWIJDEREN')
       const deleteBtn = wrapper.find('.confirm-dialog__delete')
       expect(deleteBtn.attributes('disabled')).toBeUndefined()
-      expect(deleteBtn.classes()).toContain('utrecht-button--primary-action')
+      expect(deleteBtn.classes()).toContain('rvo-button--primary')
       await deleteBtn.trigger('click')
       await flushPromises()
       expect(projectsDelete).toHaveBeenCalledWith('p1')

--- a/apps/boekhouding-frontend/test/cov/views-VersionHistory.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-VersionHistory.cov.test.ts
@@ -133,7 +133,7 @@ async function fieldRestoreDialogConfirm(wrapper: ReturnType<typeof mountView>) 
   await item.trigger('mousedown')
   await flushPromises()
   const dialog = wrapper.findAll('dialog.confirm-dialog').find((d) => d.text().includes('Antwoord herstellen'))!
-  await dialog.find('.utrecht-button--primary-action').trigger('click')
+  await dialog.find('.rvo-button--primary').trigger('click')
   await flushPromises()
 }
 
@@ -351,7 +351,7 @@ describe('VersionHistory — description modal', () => {
     await textarea.setValue('Nieuwe beschrijving')
     await textarea.trigger('input')
 
-    await wrapper.find('.utrecht-button--primary-action').trigger('click')
+    await wrapper.find('.rvo-button--primary').trigger('click')
     await flushPromises()
 
     expect(apiUpdateVersionDescription).toHaveBeenCalledWith(ASSESSMENT_ID, 2, 'Nieuwe beschrijving')
@@ -381,14 +381,14 @@ describe('VersionHistory — description modal', () => {
     await flushPromises()
     const ta = wrapper.find('textarea#desc-input')
     await ta.setValue('')
-    await wrapper.find('.utrecht-button--primary-action').trigger('click')
+    await wrapper.find('.rvo-button--primary').trigger('click')
     await flushPromises()
     expect(apiUpdateVersionDescription).toHaveBeenLastCalledWith(ASSESSMENT_ID, 2, '')
 
     apiUpdateVersionDescription.mockClear()
     vm.openDescModal(999, 'whatever')
     await flushPromises()
-    await wrapper.find('.utrecht-button--primary-action').trigger('click')
+    await wrapper.find('.rvo-button--primary').trigger('click')
     await flushPromises()
     expect(apiUpdateVersionDescription).toHaveBeenCalledWith(ASSESSMENT_ID, 999, 'whatever')
   })
@@ -403,7 +403,7 @@ describe('VersionHistory — description modal', () => {
 
     await wrapper.find('.desc-edit-btn').trigger('click')
     await flushPromises()
-    const secondary = wrapper.findAll('.confirm-dialog .utrecht-button--secondary-action')[0]
+    const secondary = wrapper.findAll('.confirm-dialog .rvo-button--secondary')[0]
     await secondary.trigger('click')
     await flushPromises()
     expect(apiUpdateVersionDescription).not.toHaveBeenCalled()
@@ -532,7 +532,7 @@ describe('VersionHistory — restore modal & handleRestore', () => {
     const restoreDialog = wrapper
       .findAll('dialog.confirm-dialog')
       .find((d) => d.text().includes('Versie herstellen'))!
-    await restoreDialog.find('.utrecht-button--secondary-action').trigger('click')
+    await restoreDialog.find('.rvo-button--secondary').trigger('click')
     await flushPromises()
     expect((wrapper.vm as any).restoreConfirmText).toBe('')
   })
@@ -1264,7 +1264,7 @@ describe('VersionHistory — field-level restore', () => {
       .find((d) => d.text().includes('Antwoord herstellen'))!
   }
   async function confirmFieldRestore(wrapper: ReturnType<typeof mountView>) {
-    await fieldRestoreDialog(wrapper).find('.utrecht-button--primary-action').trigger('click')
+    await fieldRestoreDialog(wrapper).find('.rvo-button--primary').trigger('click')
     await flushPromises()
   }
 
@@ -1727,7 +1727,7 @@ describe('VersionHistory — field-level restore', () => {
     }, { [FormType.DPIA]: { '1.1': { id: '1.1', task: 'Naam' } }, [FormType.PRE_SCAN]: {} })
     await openFieldRestore(wrapper)
     apiUpdate.mockClear()
-    await fieldRestoreDialog(wrapper).find('.utrecht-button--secondary-action').trigger('click')
+    await fieldRestoreDialog(wrapper).find('.rvo-button--secondary').trigger('click')
     await flushPromises()
     expect(apiUpdate).not.toHaveBeenCalled()
     expect((wrapper.vm as any).fieldRestoreModalOpen).toBe(false)
@@ -2188,7 +2188,7 @@ describe('VersionHistory — remaining branch coverage', () => {
       const dialog = wrapper
         .findAll('dialog.confirm-dialog')
         .find((d) => d.text().includes('Antwoord herstellen'))!
-      await dialog.find('.utrecht-button--primary-action').trigger('click')
+      await dialog.find('.rvo-button--primary').trigger('click')
       await flushPromises()
       const [, state] = apiUpdate.mock.calls[0]
       expect((state as any).answers['2.1'][0]['2.1.1'].value).toBe('oud')

--- a/apps/standalone-form/package.json
+++ b/apps/standalone-form/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@nl-rvo/assets": "^1.0.0-alpha.360",
-    "@nl-rvo/component-library-css": "4.8.0",
-    "@nl-rvo/design-tokens": "1.9.0",
+    "@nl-rvo/component-library-css": "4.20.2",
+    "@nl-rvo/design-tokens": "2.4.1",
     "@overheid-assessment/core": "workspace:*",
     "pdfmake": "^0.3.11",
     "pinia": "^3.0.3",

--- a/packages/assessment-core/src/assets/base.css
+++ b/packages/assessment-core/src/assets/base.css
@@ -291,6 +291,29 @@
   gap: 0.25rem;
 }
 
+/* RVO 4.20 stripte de standaard onder-marge van koppen (utrecht-heading-*),
+   waardoor koppen tegen de tekst eronder kleven. Herstel de 4.8-spacing waar de
+   app-layout op is gebouwd; rvo-heading--no-margins (nu door RVO verwijderd)
+   blijft de marge nullen waar dat de bedoeling is. */
+.rvo-theme .utrecht-heading-1,
+.rvo-theme .utrecht-heading-2 {
+  margin-block-end: 1rem;
+}
+.rvo-theme .utrecht-heading-3 {
+  margin-block-end: 0.75rem;
+}
+.rvo-theme .rvo-heading--no-margins {
+  margin-block: 0;
+}
+
+/* RVO 4.20 zet de accordion-chevron ~5px te laag t.o.v. de titel. Lijn de
+   chevron weer uit met de eerste tekstregel (line-height h3 = 30px). */
+.rvo-theme .rvo-accordion__item-summary .rvo-accordion__item-icon {
+  block-size: 1.5rem;
+  align-items: center;
+  margin-block-start: 0;
+}
+
 /* Fix: progress tracker connecting line should stretch to full step height
    when step text wraps to multiple lines. RVO draws the line as a 40px SVG
    in a ::before with top:20px, height:40px — this overshoots the default

--- a/packages/assessment-core/src/assets/base.css
+++ b/packages/assessment-core/src/assets/base.css
@@ -263,18 +263,18 @@
 
 /* Override RVO's :invalid styling on required empty fields — red border should only
    appear after user interaction (:user-invalid), not on page load. We reset the
-   invalid border to match the normal border (logoblauw). This includes the
+   invalid border to match the normal border (lintblauw). This includes the
    :focus:invalid compound selector that RVO uses (lines 3544-3550 of RVO's index.css). */
 .rvo-theme .utrecht-textbox--html-input:invalid,
 .rvo-theme .utrecht-textbox:invalid,
 .rvo-theme .utrecht-textbox:focus.utrecht-textbox:invalid,
 .rvo-theme .utrecht-textbox:focus.utrecht-textbox--html-input:invalid,
 .rvo-theme .utrecht-textbox--focus.utrecht-textbox:invalid {
-  --utrecht-textbox-invalid-border-color: var(--rvo-color-logoblauw, #154273);
+  --utrecht-textbox-invalid-border-color: var(--rvo-color-lintblauw, #154273);
   --utrecht-textbox-invalid-border-width: var(--utrecht-form-control-border-width, 1px);
-  --rvo-textbox-invalid-focus-border-color: var(--rvo-color-logoblauw, #154273);
+  --rvo-textbox-invalid-focus-border-color: var(--rvo-color-lintblauw, #154273);
   --rvo-textbox-invalid-focus-outline-color: var(--utrecht-focus-outline-color, var(--rvo-color-hemelblauw));
-  border-color: var(--rvo-color-logoblauw, #154273) !important;
+  border-color: var(--rvo-color-lintblauw, #154273) !important;
   border-width: 1px;
   outline-color: var(--utrecht-focus-outline-color, var(--rvo-color-hemelblauw)) !important;
 }
@@ -286,12 +286,9 @@
   outline-color: var(--rvo-color-rood) !important;
 }
 
-.rvo-theme .utrecht-button--icon-gap {
+.rvo-theme .rvo-button--icon-before,
+.rvo-theme .rvo-button--icon-after {
   gap: 0.25rem;
-}
-
-.rvo-theme .utrecht-button--align-content {
-  margin-inline-start: -12px;
 }
 
 /* Fix: progress tracker connecting line should stretch to full step height

--- a/packages/assessment-core/src/assets/base.css
+++ b/packages/assessment-core/src/assets/base.css
@@ -292,14 +292,15 @@
 }
 
 /* RVO 4.20 stripte de standaard onder-marge van koppen (utrecht-heading-*),
-   waardoor koppen tegen de tekst eronder kleven. Herstel de 4.8-spacing waar de
-   app-layout op is gebouwd; rvo-heading--no-margins (nu door RVO verwijderd)
-   blijft de marge nullen waar dat de bedoeling is. */
-.rvo-theme .utrecht-heading-1,
-.rvo-theme .utrecht-heading-2 {
+   waardoor koppen tegen de tekst eronder kleven. Herstel de 4.8-spacing, maar
+   respecteer expliciete margin-utilities (rvo-margin*, rvo-heading--no-margins)
+   die de marge bewust op 0 zetten — bv. op card-titels die hun ruimte van de
+   card-layout krijgen. */
+.rvo-theme .utrecht-heading-1:not([class*="rvo-margin"]),
+.rvo-theme .utrecht-heading-2:not([class*="rvo-margin"]) {
   margin-block-end: 1rem;
 }
-.rvo-theme .utrecht-heading-3 {
+.rvo-theme .utrecht-heading-3:not([class*="rvo-margin"]):not(.rvo-heading--no-margins) {
   margin-block-end: 0.75rem;
 }
 .rvo-theme .rvo-heading--no-margins {

--- a/packages/assessment-core/src/components/ExportMenu.vue
+++ b/packages/assessment-core/src/components/ExportMenu.vue
@@ -77,7 +77,7 @@ onBeforeUnmount(removeOutsideListener)
     <div v-if="split" class="export-menu__split">
       <button
         type="button"
-        class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md export-menu__split-main"
+        class="rvo-button rvo-button--secondary rvo-button--size-md export-menu__split-main"
         @click="choose('pdf')"
       >
         Exporteer als PDF
@@ -85,7 +85,7 @@ onBeforeUnmount(removeOutsideListener)
       <button
         ref="triggerRef"
         type="button"
-        class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-md export-menu__split-toggle"
+        class="rvo-button rvo-button--secondary rvo-button--size-md export-menu__split-toggle"
         :aria-expanded="open"
         aria-label="Meer exportopties"
         @click="toggle"
@@ -101,7 +101,7 @@ onBeforeUnmount(removeOutsideListener)
       v-else
       ref="triggerRef"
       type="button"
-      class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs utrecht-button--icon-gap"
+      class="rvo-button rvo-button--tertiary rvo-button--size-xs rvo-button--icon-after"
       :aria-expanded="open"
       @click="toggle"
     >

--- a/packages/assessment-core/src/components/LiveResults.vue
+++ b/packages/assessment-core/src/components/LiveResults.vue
@@ -61,7 +61,7 @@ const renderAssessmentExplanation = (assessment: AssessmentResult): ExplanationR
       <div class="rvo-accordion__item">
         <div class="rvo-accordion__item-summary">
           <div class="rvo-accordion__item-title-container">
-            <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--mixed">
+            <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--normal">
               Tussenresultaten pre-scan
             </h3>
             <p class="rvo-accordion-teaser">Op basis van de huidige antwoorden zijn er geen assessments vereist.</p>
@@ -85,7 +85,7 @@ const renderAssessmentExplanation = (assessment: AssessmentResult): ExplanationR
               role="img" aria-label="Delta omhoog"></span>
           </div>
           <div class="rvo-accordion__item-title-container">
-            <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--mixed">
+            <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--normal">
               Tussenresultaten pre-scan
             </h3>
             <div class="rvo-accordion-teaser">Op basis van de huidige antwoorden zijn er verplichte/aangeraden assessments.</div>

--- a/packages/assessment-core/src/components/NavHeader.vue
+++ b/packages/assessment-core/src/components/NavHeader.vue
@@ -14,7 +14,7 @@ defineProps<{
     <div class="rvo-max-width-layout rvo-max-width-layout--lg rvo-max-width-layout-inline-padding--md nav-header__bar">
       <button
         type="button"
-        class="utrecht-button utrecht-button--rvo-tertiary-action utrecht-button--rvo-xs utrecht-button--icon-gap"
+        class="rvo-button rvo-button--tertiary rvo-button--size-xs rvo-button--icon-before"
         @click="navigation.goToLanding"
       >
         <span

--- a/packages/assessment-core/src/components/PreScanPreview.vue
+++ b/packages/assessment-core/src/components/PreScanPreview.vue
@@ -68,7 +68,7 @@ const formatAnswer = (answer: AnswerValue): string => {
             role="img" aria-label="Delta omhoog"></span>
         </div>
         <div class="rvo-accordion__item-title-container">
-          <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--mixed">
+          <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--normal">
             Informatie uit pre-scan
           </h3>
           <div class="rvo-accordion-teaser">Je hebt in de pre-scan informatie ingevuld die mogelijk

--- a/packages/assessment-core/src/components/SaveForm.vue
+++ b/packages/assessment-core/src/components/SaveForm.vue
@@ -81,7 +81,7 @@ const handleSave = () => {
         </p>
       </div>
 
-      <p class="utrecht-button-group rvo-action-groul--position-right" role="group" aria-label="Formulier opslag">
+      <p class="rvo-action-group rvo-action-group--position-right" role="group" aria-label="Formulier opslag">
         <UiButton variant="secondary" label="Annuleren" @click="closeModal" />
         <UiButton variant="primary" label="Bestand maken" @click="handleSave" />
       </p>

--- a/packages/assessment-core/src/components/task/TaskSection.vue
+++ b/packages/assessment-core/src/components/task/TaskSection.vue
@@ -284,7 +284,7 @@ function shouldSkipTask(taskId: string): boolean {
                     role="img" aria-label="Inklappen"></span>
                 </div>
                 <div class="rvo-accordion__item-title-container">
-                  <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--mixed">
+                  <h3 class="rvo-accordion__item-title utrecht-heading-3 rvo-heading--no-margins rvo-heading--normal">
                     {{ taskStore.taskById(childId).task }}
                   </h3>
                 </div>

--- a/packages/assessment-core/src/components/ui/UiButton.vue
+++ b/packages/assessment-core/src/components/ui/UiButton.vue
@@ -17,11 +17,11 @@ const variantClass = computed(() => {
   switch (props.variant) {
     case 'tertiary':
     case 'quaternary':
-      return `utrecht-button--rvo-${props.variant}-action`
+      return `rvo-button--${props.variant}`
     case 'warning':
-      return 'utrecht-button--primary-action utrecht-button--warning'
+      return 'rvo-button--primary rvo-button--warning'
     default:
-      return `utrecht-button--${props.variant || 'primary'}-action`
+      return `rvo-button--${props.variant || 'primary'}`
   }
 })
 
@@ -33,10 +33,10 @@ defineEmits<{
 <template>
   <button
     :class="[
-      'utrecht-button',
+      'rvo-button',
       variantClass,
-      `utrecht-button--rvo-${size || 'md'}`,
-      fullWidth ? 'utrecht-button--rvo-full-width' : '',
+      `rvo-button--size-${size || 'md'}`,
+      fullWidth ? 'rvo-button--full-width' : '',
     ]"
     :type="type || 'button'"
     :disabled="disabled"

--- a/packages/assessment-core/test/cov/components-NavHeader.cov.test.ts
+++ b/packages/assessment-core/test/cov/components-NavHeader.cov.test.ts
@@ -16,7 +16,7 @@ describe('NavHeader rendering', () => {
     const navigation = makeNavigation()
     const wrapper = mount(NavHeader, { props: { navigation } })
 
-    const button = wrapper.find('button.utrecht-button--rvo-tertiary-action')
+    const button = wrapper.find('button.rvo-button--tertiary')
     expect(button.exists()).toBe(true)
     expect(button.text()).toContain('Terug naar overzicht')
 
@@ -31,7 +31,7 @@ describe('NavHeader rendering', () => {
     expect(
       wrapper.find('.rvo-menubar__background--horizontal-rule').exists(),
     ).toBe(true)
-    expect(wrapper.find('button.utrecht-button').exists()).toBe(true)
+    expect(wrapper.find('button.rvo-button').exists()).toBe(true)
   })
 })
 
@@ -40,7 +40,7 @@ describe('NavHeader navigation interaction', () => {
     const navigation = makeNavigation()
     const wrapper = mount(NavHeader, { props: { navigation } })
 
-    await wrapper.find('button.utrecht-button--rvo-tertiary-action').trigger('click')
+    await wrapper.find('button.rvo-button--tertiary').trigger('click')
 
     expect(navigation.goToLanding).toHaveBeenCalledTimes(1)
     expect(navigation.goToPreScanDPIA).not.toHaveBeenCalled()

--- a/packages/assessment-core/test/cov/components-ui-UiButton.cov.test.ts
+++ b/packages/assessment-core/test/cov/components-ui-UiButton.cov.test.ts
@@ -6,59 +6,59 @@ describe('UiButton variantClass computed', () => {
   it('uses primary-action by default when no variant is given', () => {
     const wrapper = mount(UiButton)
     const button = wrapper.find('button')
-    expect(button.classes()).toContain('utrecht-button')
-    expect(button.classes()).toContain('utrecht-button--primary-action')
+    expect(button.classes()).toContain('rvo-button')
+    expect(button.classes()).toContain('rvo-button--primary')
   })
 
   it('uses primary-action when variant is explicitly primary', () => {
     const wrapper = mount(UiButton, { props: { variant: 'primary' } })
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--primary-action')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--primary')
   })
 
   it('uses secondary-action for the secondary variant', () => {
     const wrapper = mount(UiButton, { props: { variant: 'secondary' } })
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--secondary-action')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--secondary')
   })
 
   it('uses rvo tertiary-action for the tertiary variant', () => {
     const wrapper = mount(UiButton, { props: { variant: 'tertiary' } })
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--rvo-tertiary-action')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--tertiary')
   })
 
   it('uses rvo quaternary-action for the quaternary variant', () => {
     const wrapper = mount(UiButton, { props: { variant: 'quaternary' } })
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--rvo-quaternary-action')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--quaternary')
   })
 
   it('uses primary-action plus warning modifier for the warning variant', () => {
     const wrapper = mount(UiButton, { props: { variant: 'warning' } })
     const classes = wrapper.find('button').classes()
-    expect(classes).toContain('utrecht-button--primary-action')
-    expect(classes).toContain('utrecht-button--warning')
+    expect(classes).toContain('rvo-button--primary')
+    expect(classes).toContain('rvo-button--warning')
   })
 })
 
 describe('UiButton size class', () => {
   it('defaults to rvo-md size when no size prop is given', () => {
     const wrapper = mount(UiButton)
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--rvo-md')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--size-md')
   })
 
   it('applies the given size', () => {
     const wrapper = mount(UiButton, { props: { size: 'xs' } })
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--rvo-xs')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--size-xs')
   })
 })
 
 describe('UiButton fullWidth', () => {
   it('does not add the full-width class by default', () => {
     const wrapper = mount(UiButton)
-    expect(wrapper.find('button').classes()).not.toContain('utrecht-button--rvo-full-width')
+    expect(wrapper.find('button').classes()).not.toContain('rvo-button--full-width')
   })
 
   it('adds the full-width class when fullWidth is true', () => {
     const wrapper = mount(UiButton, { props: { fullWidth: true } })
-    expect(wrapper.find('button').classes()).toContain('utrecht-button--rvo-full-width')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--full-width')
   })
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,11 +74,11 @@ importers:
         specifier: ^1.0.0-alpha.360
         version: 1.0.0
       '@nl-rvo/component-library-css':
-        specifier: 4.8.0
-        version: 4.8.0
+        specifier: 4.20.2
+        version: 4.20.2
       '@nl-rvo/design-tokens':
-        specifier: 1.9.0
-        version: 1.9.0
+        specifier: 2.4.1
+        version: 2.4.1
       '@overheid-assessment/core':
         specifier: workspace:*
         version: link:../../packages/assessment-core
@@ -138,11 +138,11 @@ importers:
         specifier: ^1.0.0-alpha.360
         version: 1.0.0
       '@nl-rvo/component-library-css':
-        specifier: 4.8.0
-        version: 4.8.0
+        specifier: 4.20.2
+        version: 4.20.2
       '@nl-rvo/design-tokens':
-        specifier: 1.9.0
-        version: 1.9.0
+        specifier: 2.4.1
+        version: 2.4.1
       '@overheid-assessment/core':
         specifier: workspace:*
         version: link:../../packages/assessment-core
@@ -1175,11 +1175,11 @@ packages:
   '@nl-rvo/assets@1.0.0':
     resolution: {integrity: sha512-YEhM9bzgtsTFU1rbDhjm9oraHHCdeC9DqhiB473y4/NYaaENW8eP7ZCJYcEdG4ax/1tyDoC5e0FSkZNIgz4gJA==}
 
-  '@nl-rvo/component-library-css@4.8.0':
-    resolution: {integrity: sha512-9mTYqf1JJiaRW7+R0dKNG44FoBOVmj6+UHcTv/ONFmkmmN9QmfzSiXouDlfI/O7E3fcBQuPIVzSlwRlAxuWtwg==}
+  '@nl-rvo/component-library-css@4.20.2':
+    resolution: {integrity: sha512-BiFN67cQfPy3gqniXln7AmHGYEltF2FK8pysl07gVHqfIQjp9k7P2xRUb+Kn1pd+iU1ueafJwL7m8U7m6jjgXA==}
 
-  '@nl-rvo/design-tokens@1.9.0':
-    resolution: {integrity: sha512-dkBtuj0JcBbTNLlkaZZfNPxFTzoQNWpSe9jdUCNJkPSgHCSI1V1TEyN2y0eJXlpufJRC39uAHZUaHn3Bvx0Ebw==}
+  '@nl-rvo/design-tokens@2.4.1':
+    resolution: {integrity: sha512-6niaHcxA8MESqnIsuZ87C1ubUO1lC9HfqvrvCORceufKYOXzcKNpCBnFo+IVpGN41ISbLNaM7oiNeMIvWZBN+A==}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -4306,11 +4306,11 @@ snapshots:
 
   '@nl-rvo/assets@1.0.0': {}
 
-  '@nl-rvo/component-library-css@4.8.0':
+  '@nl-rvo/component-library-css@4.20.2':
     dependencies:
       modern-normalize: 3.0.1
 
-  '@nl-rvo/design-tokens@1.9.0': {}
+  '@nl-rvo/design-tokens@2.4.1': {}
 
   '@noble/ciphers@1.3.0': {}
 


### PR DESCRIPTION
Vervangt de kale Dependabot-bump #381 en sluit onderzoek-issue #377 af.

## Waarom dit een aparte PR is
`@nl-rvo/component-library-css` 4.16 heeft de **Button** van `.utrecht-button` naar `.rvo-button` verplaatst met een **nieuw modifier-schema**. Een kale versie-bump (zoals #381) zou daardoor **alle buttons in beide apps ongestyled** (native) maken. Deze PR doet de bump én de bijbehorende class-migratie. `design-tokens` gaat van 1.9.0 → 2.4.1 (een MAJOR; enige harde rename `logoblauw`→`lintblauw`).

## Wat er is gemigreerd
**Button-classes** (`utrecht-button*` → `rvo-button*`), o.a.:
`--primary-action`→`--primary`, `--secondary-action`→`--secondary`, `--rvo-tertiary-action`→`--tertiary`, `--rvo-quaternary-action`→`--quaternary`, `--rvo-md`/`--rvo-xs`→`--size-md`/`--size-xs`, `--rvo-full-width`→`--full-width`, `--icon-gap`→`--icon-before`/`--icon-after` (per icon-positie), `utrecht-button-group`→`rvo-action-group`.

**Andere in 4.20.2 verwijderde classes die wij gebruikten** (gevonden door een adversariële review, gefixt):
- `a.rvo-button { color: var(--_utrecht-button-color) }` → `var(--rvo-button-color)` — anders donker-op-donker op de "Start zonder account"-knop (anchor-als-primary).
- `rvo-heading--mixed` → `rvo-heading--normal` (4 accordion-titels) — anders vet i.p.v. normaal. Beide zetten `font-weight: var(--rvo-font-weight-normal)` (exacte equivalent).

**Overig:** UiButton.vue dynamische classes, `base.css`/`app.css` selectors, dode `utrecht-button--align-content` regel weg, `logoblauw`→`lintblauw` (fallback was al `#154273`), pre-existing typo `rvo-action-groul`→`rvo-action-group`, tests in `test/cov/*` op de nieuwe classes, en de button-conventie in `.claude/CLAUDE.md`.

## Geaccepteerde upstream-drift (klein, bewust niet gepind)
- `--rvo-border-radius-xl` 10px → **20px** → rondere hoeken op de begrippenkader-tooltip en de image-dropzone.
- Alert-error achtergrond `rood-300` → **`rood-150`** (lichter rood).
- `.rvo-card` default-padding → 0 (geen effect: onze cards dragen altijd `--padding-md`/`--full-colour`).

## Verificatie
- ✅ Build standalone, type-check clean.
- ✅ 100% coverage behouden (core 1174, frontend 800, standalone 67 tests).
- ✅ Adversariële 4-dimensie review (volledigheid / mapping / tests / neveneffecten).
- ✅ Live in de **standalone** vergeleken met productie `invulhulpen.rijksapp.nl`: primary buttons **pixel-identiek** (`rgb(0,123,199)`, padding 8/16, radius 3px), tertiary/secondary/icon-knoppen correct gestyled, `--icon-after` op Exporteer, anchor-button rendert **wit op blauw**, **0 `utrecht-button` in de DOM**.

## 🔎 Testgids (vooral de frontend — die kon ik niet zonder de volledige stack live testen)
Start lokaal: `podman compose -f containers/compose.dev.yaml up -d` (+ `pnpm db:seed`), of standalone-only met `pnpm dev`.

**Standalone (`:5175`)** — laag risico, al live geverifieerd:
- [ ] Startscherm: 3 primary "Start ..."-knoppen blauw/wit.
- [ ] In een formulier: "Volgende stap" (primary), "Terug naar overzicht" (tertiary + pijl-icon links), "Exporteer" (tertiary + icon **rechts**), nav back-knoppen.
- [ ] Open een **accordion**-resultaat (Tussenresultaten pre-scan / live-resultaten): titels in **normale** dikte (niet vet).

**Boekhouding-frontend (`:5174`)** — graag extra aandacht (niet door mij live getest):
- [ ] **LandingPage**: knop **"Start zonder account"** (een `<a>` als primary button) → tekst **wit op blauw**, niet donker/onleesbaar.
- [ ] **ProjectList / ProjectDetail**: "Nieuw project" (primary + plus-icon), "Leden beheren" (tertiary + icon), kebab-menu's, kaart-headings.
- [ ] **ProjectMembers**: knoppen voor uitnodigen/verwijderen (incl. `--warning`/secondary varianten).
- [ ] **VersionHistory**: primary/secondary knoppen in de dialoog.
- [ ] **ConflictResolutionDialog** en **SessionExpiredDialog**: knoppen in de native `<dialog>`.
- [ ] **AssessmentEditor**: "Terug naar project" (tertiary+icon), en de **verwijder-bevestiging** (knop wordt pas primary na het typen van "VERWIJDEREN").

Een klein visueel verschil t.o.v. nu is verwacht (zie geaccepteerde drift) en geen probleem.

## Niet in scope (pre-existing, gemeld door de review)
- `UiButton.vue` icon-spacing leunt op `rvo-icon--with-spacing-*` die in géén RVO-versie bestaan (al zo vóór deze PR; gap komt nu van onze flex-`gap`-regel).
- `ExportPdfInfo.vue` heeft `rvo-card--full-colour-wit` (enkele streep i.p.v. `--full-colour--wit`); witte achtergrond werkte al nooit. Bewust niet gefixt om geen onverwachte visuele wijziging te introduceren.

Closes #377.