### PR TITLE
Mobiele toegankelijkheid: CSS voor de boekhouding-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 coverage
 **/coverage/
 *.local
-.claude/settings.local.json
 reports/
 
 # Build output
@@ -53,6 +52,11 @@ sources/generated/
 
 # Playwright
 .playwright-mcp
+
+# Claude (local-only, never commit)
+.claude/settings.local.json
+.claude/worktrees/
+.superpowers/
 
 # Local podman compose overrides (per-machine port shifts etc.)
 containers/compose.override.yaml

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -19,6 +19,11 @@
   background-color: var(--rvo-color-grijs-100);
 }
 
+.kebab-menu__trigger:focus-visible {
+  outline: 2px solid var(--rvo-color-hemelblauw);
+  outline-offset: -2px;
+}
+
 .kebab-menu__dropdown {
   position: absolute;
   top: 100%;
@@ -84,6 +89,8 @@ dialog::backdrop {
   padding: 2rem;
   max-width: 36rem;
   width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
 }
 
@@ -99,6 +106,7 @@ dialog::backdrop {
 
 .confirm-dialog__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   margin-top: 1.5rem;
 }
@@ -249,6 +257,7 @@ a.card-link:hover {
   align-items: center;
   gap: 0.75rem;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
 .app-header__right {
@@ -256,6 +265,7 @@ a.card-link:hover {
   align-items: center;
   gap: 0.75rem;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .app-header__back {
@@ -264,6 +274,26 @@ a.card-link:hover {
 
 .app-header__user {
   white-space: nowrap;
+}
+
+/* Keep the username visible (truncated) on phones, not hidden — hiding it
+   drops the logged-in identity for screen-reader users. */
+@media (max-width: 480px) {
+  .app-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .app-header__left,
+  .app-header__right {
+    gap: 0.5rem;
+  }
+
+  .app-header__user {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 18ch;
+  }
 }
 
 /* ProjectDetail */
@@ -385,6 +415,7 @@ a.card-link:hover {
 
 .start-dialog__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
@@ -460,6 +491,18 @@ a.card-link:hover {
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
+}
+
+@media (max-width: 560px) {
+  .form-subheader {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .form-subheader__right {
+    justify-content: flex-end;
+  }
 }
 
 .form-name {
@@ -1260,6 +1303,28 @@ a.card-link:hover {
   }
 }
 
+@media (max-width: 560px) {
+  .rvo-form-fieldset,
+  fieldset.rvo-form-fieldset {
+    padding-inline: var(--rvo-space-sm, 12px);
+    padding-block: var(--rvo-space-md, 16px);
+    margin-inline-start: 0;
+  }
+
+  .kebab-menu__trigger,
+  .comment-badge,
+  .comment-panel__close,
+  .app-header__left .utrecht-button,
+  .app-header__right .utrecht-button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .comment-panel__close {
+    justify-content: center;
+  }
+}
+
 /* Sync toast (collaboration notifications) */
 
 .sync-toast {
@@ -1358,4 +1423,229 @@ a.card-link:hover {
 .value-list {
   margin: 0;
   padding-left: 1.25rem;
+}
+
+/* At end of file so these phone overrides win over the base rules they target
+   by source order (e.g. .sync-toast). */
+@media (max-width: 560px) {
+  .kebab-menu__dropdown {
+    min-width: auto;
+    max-width: calc(100vw - 1rem);
+  }
+
+  .member-select,
+  .member-delete {
+    height: 2.75rem;
+  }
+
+  .member-delete {
+    white-space: normal;
+  }
+
+  .comment-action-btn,
+  .sync-toast__action {
+    min-height: 44px;
+  }
+
+  .sync-toast__action {
+    white-space: normal;
+  }
+
+  .project-actions .utrecht-button {
+    min-height: 44px;
+  }
+
+  .sync-toast {
+    flex-direction: column;
+    align-items: stretch;
+    max-width: calc(100vw - 1rem);
+  }
+
+  .confirm-dialog__content,
+  .start-dialog__content {
+    padding: 1.25rem;
+  }
+}
+
+/* Data tables reflow to cards on phones; the column header row is hidden, so
+   each value carries its label in a ::before. */
+@media (max-width: 560px) {
+  .member-row--header {
+    display: none;
+  }
+
+  .member-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .member-col--who {
+    font-weight: 600;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+  }
+
+  .member-col--role,
+  .member-col--action {
+    width: 100%;
+  }
+
+  .member-delete {
+    width: 100%;
+  }
+
+  .version-row--header {
+    display: none;
+  }
+
+  .version-row {
+    flex-wrap: wrap;
+    align-items: center;
+    column-gap: 0.5rem;
+    row-gap: 0.25rem;
+    padding: 0.75rem;
+  }
+
+  .version-col--nr {
+    width: auto;
+    font-weight: 700;
+  }
+
+  .version-col--nr::before {
+    content: "Versie ";
+    font-weight: 400;
+  }
+
+  .version-col--date,
+  .version-col--who {
+    width: auto;
+    font-size: 0.875rem;
+    color: var(--rvo-color-grijs-600, #666);
+  }
+
+  .version-col--who::before {
+    content: "· ";
+  }
+
+  .version-col--action {
+    margin-left: auto;
+  }
+
+  .version-col--desc {
+    flex-basis: 100%;
+    min-width: 0;
+  }
+
+  .diff-table,
+  .diff-table tbody,
+  .diff-table tr,
+  .diff-table td {
+    display: block;
+    width: auto;
+  }
+
+  .diff-table colgroup,
+  .diff-table thead {
+    display: none;
+  }
+
+  .diff-table tr {
+    border: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+    border-radius: 6px;
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+  }
+
+  .diff-table td {
+    border-bottom: none;
+  }
+
+  .diff-field__group,
+  .diff-old,
+  .diff-new {
+    height: auto;
+  }
+
+  .diff-old::before,
+  .diff-new::before {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--rvo-color-grijs-600, #666);
+    margin-bottom: 0.25rem;
+  }
+
+  .diff-old::before {
+    content: "Was";
+  }
+
+  .diff-new::before {
+    content: "Wordt";
+  }
+
+  .conflict-table,
+  .conflict-table tbody,
+  .conflict-table tr,
+  .conflict-table td {
+    display: block;
+    width: auto;
+  }
+
+  .conflict-table thead {
+    display: none;
+  }
+
+  .conflict-table tr {
+    border: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .conflict-table td {
+    border-bottom: none;
+    padding: 0.25rem 0;
+  }
+
+  .conflict-field {
+    font-weight: 600;
+  }
+
+  .conflict-value--mine,
+  .conflict-value--theirs {
+    border-radius: 6px;
+    padding: 0.5rem;
+  }
+
+  .conflict-value--mine {
+    background-color: rgba(0, 123, 199, 0.08);
+  }
+
+  .conflict-value--theirs {
+    background-color: rgba(224, 134, 0, 0.08);
+  }
+
+  .conflict-value--mine::before,
+  .conflict-value--theirs::before {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  .conflict-value--mine::before {
+    content: "Jouw waarde";
+    color: #007bc7;
+  }
+
+  .conflict-value--theirs::before {
+    content: "Andere waarde";
+    color: #b35a00;
+  }
+
+  .conflict-value--selected {
+    background-color: #e6f4ea;
+  }
 }

--- a/apps/boekhouding-frontend/src/components/ConflictResolutionDialog.vue
+++ b/apps/boekhouding-frontend/src/components/ConflictResolutionDialog.vue
@@ -58,7 +58,7 @@ function handleResolve() {
         <tbody>
           <tr v-for="field in fields" :key="field.fieldId">
             <td class="conflict-field">{{ field.label }}</td>
-            <td class="conflict-value" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'mine' }">
+            <td class="conflict-value conflict-value--mine" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'mine' }">
               <label class="conflict-radio">
                 <input
                   type="radio"
@@ -69,7 +69,7 @@ function handleResolve() {
                 <span v-html="field.myFormatted"></span>
               </label>
             </td>
-            <td class="conflict-value" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'theirs' }">
+            <td class="conflict-value conflict-value--theirs" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'theirs' }">
               <label class="conflict-radio">
                 <input
                   type="radio"

--- a/packages/assessment-core/src/assets/base.css
+++ b/packages/assessment-core/src/assets/base.css
@@ -146,6 +146,20 @@
   display: block;
 }
 
+/* On phones the term-anchored tooltip overflows the viewport edges, so pin it
+   to the bottom of the screen as a full-width sheet instead. */
+@media (max-width: 560px) {
+  .aiv-definition .aiv-definition-text {
+    position: fixed;
+    inset: auto 0.75rem 0.75rem;
+    min-width: 0;
+    max-width: none;
+    max-height: 60vh;
+    overflow-y: auto;
+    margin-top: 0;
+  }
+}
+
 .rvo-theme .rvo-icon--with-spacing-left {
   margin-left: 0.5rem;
 }


### PR DESCRIPTION
Eerste van drie gestapelde PR's die de app mobiel-gereed maken. Voortzetting van de Forgejo-branch `feat/48-mobile-ux`; alleen het netto, geverifieerde CSS-werk is overgenomen (de backend-/tooling-commits zaten al op `main` via #283).

Deze PR bundelt **alle mobiele CSS voor de boekhouding-frontend** in één geheel, zodat geen enkel scherm halverwege kapot is. (Eerder opgesplitst in conformiteit + tabel-reflows; samengevoegd na test-feedback — #390 is hierin opgegaan.)

## Wat zit erin (CSS-only, WCAG 1.4.10 Reflow + 2.5.5 Target Size)

**Layout & conformiteit** (`app.css`)
- `app-header`: username-chip wrapt en blijft zichtbaar (was `display:none` < 480px) met ellipsis; header-knoppen en form-subheader responsive; kebab-trigger krijgt een zichtbare `:focus-visible`-outline
- kebab-dropdown blijft binnen de viewport
- tap-targets ≥ 44px: member-select/delete, comment-action-btn, sync-toast__action, "Leden beheren"
- dialogs scrollen/wrappen en krimpen qua padding; sync-toast stapelt full-width

**aiv-begrip-tooltip** (`base.css`, ook standalone)
- op telefoon een **vaste onderbalk** i.p.v. een term-anker dat buiten beeld loopt

**Tabellen → kaart per rij** op ≤560px (kolomkoppen verborgen, labels via `::before`)
- ledentabel en versiegeschiedenis → kaart per rij
- diff-tabel → gestapelde kaart met "Was"/"Wordt"
- conflict-resolutie → gestapelde vergelijkingskaart ("Jouw waarde" blauw boven "Andere waarde" oranje); enige template-wijziging: twee class-attributen, geen logica

## Verificatie

Gemeten met de echte RVO-CSS + `body.rvo-theme` op 320/360/800px: geen horizontale overflow, controls ≥44px, dropdown/tooltip binnen beeld, tabellen reflowen, desktop ongemoeid. Frontend-coverage 100%. `app.css`/`base.css` vallen onder `src/assets/**` (uitgesloten van de gate).

## Handmatig testen (DevTools device-toolbar ±360px, of een telefoon)

| Pagina | Element | Verwacht |
|---|---|---|
| Elk scherm met **AppHeader** | header < 480px | Username blijft zichtbaar (afgekapt), mag wrappen; "Terug"/"Uitloggen" ≥44px |
| idem | kebab (⋮) | Tab → blauwe focus-ring |
| **AssessmentEditor** | form-subheader; kebab-dropdown | Titel/acties stapelen ≤560px; dropdown blijft binnen het scherm |
| Assessment met **begrip-term** (stippel) | aiv-tooltip | Verschijnt als onderbalk, volledig in beeld (ook standalone) |
| **Leden beheren** | ledenlijst | **Kaart per rij**: naam vet boven, rol-select + "Verwijderen" eronder; geen overlap |
| **Versiegeschiedenis** (kebab → versies) | lijst + diff | Kaart per rij; diff met "Was"/"Wordt" |
| **Samenwerken** | comment-acties; sync-toast | Knoppen ≥44px; toast stapelt full-width |
| Bij gelijktijdig bewerken | conflict-dialoog | Gestapelde vergelijkingskaart (jouw/andere waarde) |

Kerncontrole: geen horizontaal scrollen op 360px.

## Vervolg (gestapeld)

- **#391** — comment-panel als bottom-sheet op telefoon
- **#392** — skip-link, 404-route, `dvh`