### PR TITLE
Mobiele toegankelijkheid (P2): databeheer-tabellen → kaarten op telefoon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ containers/compose.override.yaml
 containers/compose-dev-keycloak.local.json
 containers/Caddyfile.local
 containers/certs/
+.superpowers/

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -89,6 +89,8 @@ dialog::backdrop {
   padding: 2rem;
   max-width: 36rem;
   width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
 }
 
@@ -104,6 +106,7 @@ dialog::backdrop {
 
 .confirm-dialog__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   margin-top: 1.5rem;
 }
@@ -415,6 +418,7 @@ a.card-link:hover {
 
 .start-dialog__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
@@ -1430,4 +1434,53 @@ a.card-link:hover {
 .value-list {
   margin: 0;
   padding-left: 1.25rem;
+}
+
+/* PR1 mobile conformance — keep controls within the viewport and at >=44px on
+   phones (WCAG 1.4.10 Reflow, 2.5.5 Target Size AAA). Placed at end of file so
+   these overrides win over the base rules they target by source order. */
+@media (max-width: 560px) {
+  /* Kebab dropdown must not overflow the right viewport edge */
+  .kebab-menu__dropdown {
+    min-width: auto;
+    max-width: calc(100vw - 1rem);
+  }
+
+  /* Member-row controls to 44px; let "Verwijderen" wrap instead of clipping */
+  .member-select,
+  .member-delete {
+    height: 2.75rem;
+  }
+
+  .member-delete {
+    white-space: normal;
+  }
+
+  /* Comment-thread action buttons and the sync-toast action to 44px */
+  .comment-action-btn,
+  .sync-toast__action {
+    min-height: 44px;
+  }
+
+  .sync-toast__action {
+    white-space: normal;
+  }
+
+  /* "Leden beheren" (rvo-xs, ~32px) up to 44px like the other touch controls */
+  .project-actions .utrecht-button {
+    min-height: 44px;
+  }
+
+  /* Sync toast spans the width and stacks its action below the message */
+  .sync-toast {
+    flex-direction: column;
+    align-items: stretch;
+    max-width: calc(100vw - 1rem);
+  }
+
+  /* Reclaim dialog padding on narrow screens */
+  .confirm-dialog__content,
+  .start-dialog__content {
+    padding: 1.25rem;
+  }
 }

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -1484,3 +1484,194 @@ a.card-link:hover {
     padding: 1.25rem;
   }
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+   PR2: data tables reflow to cards on phones (WCAG 1.4.10 Reflow). Column
+   headers are hidden and each value gets an inline ::before label so no
+   information is lost. Desktop is untouched (rules scoped to <=560px).
+   ─────────────────────────────────────────────────────────────────────────── */
+@media (max-width: 560px) {
+  /* Members → card per row: name on top, role select + delete stacked below */
+  .member-row--header {
+    display: none;
+  }
+
+  .member-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .member-col--who {
+    font-weight: 600;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+  }
+
+  .member-col--role,
+  .member-col--action {
+    width: 100%;
+  }
+
+  .member-delete {
+    width: 100%;
+  }
+
+  /* Version history → card per row with labelled fields */
+  .version-row--header {
+    display: none;
+  }
+
+  .version-row {
+    flex-wrap: wrap;
+    align-items: center;
+    column-gap: 0.5rem;
+    row-gap: 0.25rem;
+    padding: 0.75rem;
+  }
+
+  .version-col--nr {
+    width: auto;
+    font-weight: 700;
+  }
+
+  .version-col--nr::before {
+    content: "Versie ";
+    font-weight: 400;
+  }
+
+  .version-col--date,
+  .version-col--who {
+    width: auto;
+    font-size: 0.875rem;
+    color: var(--rvo-color-grijs-600, #666);
+  }
+
+  .version-col--who::before {
+    content: "· ";
+  }
+
+  .version-col--action {
+    margin-left: auto;
+  }
+
+  .version-col--desc {
+    flex-basis: 100%;
+    min-width: 0;
+  }
+
+  /* Version diff table → stacked card per changed field ("Was" / "Wordt") */
+  .diff-table,
+  .diff-table tbody,
+  .diff-table tr,
+  .diff-table td {
+    display: block;
+    width: auto;
+  }
+
+  .diff-table colgroup,
+  .diff-table thead {
+    display: none;
+  }
+
+  .diff-table tr {
+    border: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+    border-radius: 6px;
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+  }
+
+  .diff-table td {
+    border-bottom: none;
+  }
+
+  .diff-field__group,
+  .diff-old,
+  .diff-new {
+    height: auto;
+  }
+
+  .diff-old::before,
+  .diff-new::before {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--rvo-color-grijs-600, #666);
+    margin-bottom: 0.25rem;
+  }
+
+  .diff-old::before {
+    content: "Was";
+  }
+
+  .diff-new::before {
+    content: "Wordt";
+  }
+
+  /* Conflict resolution → stacked comparison card (your value above theirs) */
+  .conflict-table,
+  .conflict-table tbody,
+  .conflict-table tr,
+  .conflict-table td {
+    display: block;
+    width: auto;
+  }
+
+  .conflict-table thead {
+    display: none;
+  }
+
+  .conflict-table tr {
+    border: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .conflict-table td {
+    border-bottom: none;
+    padding: 0.25rem 0;
+  }
+
+  .conflict-field {
+    font-weight: 600;
+  }
+
+  .conflict-value--mine,
+  .conflict-value--theirs {
+    border-radius: 6px;
+    padding: 0.5rem;
+  }
+
+  .conflict-value--mine {
+    background-color: rgba(0, 123, 199, 0.08);
+  }
+
+  .conflict-value--theirs {
+    background-color: rgba(224, 134, 0, 0.08);
+  }
+
+  .conflict-value--mine::before,
+  .conflict-value--theirs::before {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  .conflict-value--mine::before {
+    content: "Jouw waarde";
+    color: #007bc7;
+  }
+
+  .conflict-value--theirs::before {
+    content: "Andere waarde";
+    color: #b35a00;
+  }
+
+  /* Selected choice keeps the green highlight over the side tint */
+  .conflict-value--selected {
+    background-color: #e6f4ea;
+  }
+}

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -19,6 +19,11 @@
   background-color: var(--rvo-color-grijs-100);
 }
 
+.kebab-menu__trigger:focus-visible {
+  outline: 2px solid var(--rvo-color-hemelblauw);
+  outline-offset: -2px;
+}
+
 .kebab-menu__dropdown {
   position: absolute;
   top: 100%;
@@ -249,6 +254,7 @@ a.card-link:hover {
   align-items: center;
   gap: 0.75rem;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
 .app-header__right {
@@ -256,6 +262,7 @@ a.card-link:hover {
   align-items: center;
   gap: 0.75rem;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .app-header__back {
@@ -264,6 +271,29 @@ a.card-link:hover {
 
 .app-header__user {
   white-space: nowrap;
+}
+
+/* Phone portrait: tighten header gaps. The username stays visible — flex-wrap
+   lets it drop to its own line instead of overlapping — and is truncated with
+   an ellipsis so a long display name can never overflow. Keeping it rendered
+   preserves the logged-in identity for everyone, including screen-reader users
+   (a shared/multi-user civil-service context relies on this). */
+@media (max-width: 480px) {
+  .app-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .app-header__left,
+  .app-header__right {
+    gap: 0.5rem;
+  }
+
+  .app-header__user {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 18ch;
+  }
 }
 
 /* ProjectDetail */
@@ -460,6 +490,19 @@ a.card-link:hover {
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
+}
+
+/* Stack title above actions (badge + kebab) on narrow screens */
+@media (max-width: 560px) {
+  .form-subheader {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .form-subheader__right {
+    justify-content: flex-end;
+  }
 }
 
 .form-name {
@@ -1257,6 +1300,35 @@ a.card-link:hover {
 
   .comment-field-group__label {
     display: block;
+  }
+}
+
+/* Large phone / small tablet portrait: reclaim horizontal space on forms and
+   bring touch targets up to 44x44 (WCAG 2.5.5 AAA). The RVO --rvo-xs header
+   buttons are only ~32px tall (min-block-size: auto) — above the 24px AA
+   minimum but below the 44px AAA target — so we raise them here to match the
+   icon controls and keep the whole mobile header uniformly comfortable. */
+@media (max-width: 560px) {
+  .rvo-form-fieldset,
+  fieldset.rvo-form-fieldset {
+    padding-inline: var(--rvo-space-sm, 12px);
+    padding-block: var(--rvo-space-md, 16px);
+    margin-inline-start: 0;
+  }
+
+  .kebab-menu__trigger,
+  .comment-badge,
+  .comment-panel__close,
+  .app-header__left .utrecht-button,
+  .app-header__right .utrecht-button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Center the icon once the close control is sized up to 44x44 (the RVO
+     buttons already center their own content via .utrecht-button). */
+  .comment-panel__close {
+    justify-content: center;
   }
 }
 

--- a/apps/boekhouding-frontend/src/components/ConflictResolutionDialog.vue
+++ b/apps/boekhouding-frontend/src/components/ConflictResolutionDialog.vue
@@ -58,7 +58,7 @@ function handleResolve() {
         <tbody>
           <tr v-for="field in fields" :key="field.fieldId">
             <td class="conflict-field">{{ field.label }}</td>
-            <td class="conflict-value" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'mine' }">
+            <td class="conflict-value conflict-value--mine" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'mine' }">
               <label class="conflict-radio">
                 <input
                   type="radio"
@@ -69,7 +69,7 @@ function handleResolve() {
                 <span v-html="field.myFormatted"></span>
               </label>
             </td>
-            <td class="conflict-value" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'theirs' }">
+            <td class="conflict-value conflict-value--theirs" :class="{ 'conflict-value--selected': selections[field.fieldId] === 'theirs' }">
               <label class="conflict-radio">
                 <input
                   type="radio"

--- a/docs/superpowers/specs/2026-06-14-mobile-ux-design.md
+++ b/docs/superpowers/specs/2026-06-14-mobile-ux-design.md
@@ -63,7 +63,17 @@ Doel: de goedkope, geverifieerde WCAG-fouten wegnemen zonder template-wijziginge
 6. **sync-toast mobiel** — `@media (max-width:560px){ .sync-toast{ flex-direction:column; align-items:stretch; max-width:calc(100vw - 1rem); } }`. *WCAG 1.4.10.*
 7. **iOS zoom-on-focus** — selects die nu `sm` (14px) zijn → `font-size:16px` op mobiel (bv. `.member-select` en de form-selects via hun app.css-selector). RVO text-inputs zijn al `md` (16px) en blijven ongemoeid; alleen de sub-16px selects worden gelijkgetrokken. *UX (iOS Safari).*
 
-**Bewust NIET in PR1** (→ PR2, want template-werk): de ledentabel en versiegeschiedenis-tabel zelf (kaart-per-rij vergt kleine template-aanpassingen zoals naam/e-mail splitsen en rol-label), de conflict/diff-tabellen, en het comment-bottom-sheet. PR1 brengt deze surfaces dus op tap-target- en grid-niveau op orde, maar de volledige tabel-reflow volgt in PR2. Dit is een bewuste, gecommuniceerde afbakening.
+**Bewust NIET in PR1** (→ PR2, want template-werk): de ledentabel en versiegeschiedenis-tabel zelf (kaart-per-rij vergt kleine template-aanpassingen zoals naam/e-mail splitsen en rol-label), de conflict/diff-tabellen, en het comment-bottom-sheet. PR1 brengt deze surfaces dus op tap-target-niveau op orde, maar de volledige tabel-reflow volgt in PR2. Dit is een bewuste, gecommuniceerde afbakening.
+
+### Implementatie-notitie (empirisch geverifieerd tegen RVO-tokens + harness)
+
+Tijdens implementatie zijn drie geplande items **vervallen** omdat meting aantoonde dat ze al voldoen — false positives in de audit:
+
+- **Punt 3 (RVO 2-koloms grid → 1 kolom):** RVO's `.rvo-layout-grid-columns--two` krijgt `repeat(2,1fr)` pas vanaf `min-width:552px`; eronder is er géén template → al 1 kolom op telefoon. Harness bevestigt 1 kolom @360px zonder override. Regel **niet toegevoegd**. (Geldt vermoedelijk ook voor de LandingPage `--three` grid — in PR2 verifiëren vóór actie.)
+- **Punt 4, deelitem "Nieuw project"/dialog-knoppen:** `--rvo-md` heeft geen `min-block-size`-override en valt terug op de base 44px → die knoppen zijn al 44px. Alleen `--rvo-xs` ("Leden beheren") en de custom controls (`member-select/delete`, `comment-action-btn`, `sync-toast__action`) waren <44px en zijn gefixt.
+- **Punt 7 (iOS-zoom selects):** `--utrecht-form-control-font-size` = `--rvo-font-size-md` = 16px → alle selects zijn al 16px. Geen fix nodig.
+
+**Daadwerkelijk geïmplementeerd in PR1** (geverifieerd @320/360/800px met de echte RVO-CSS + `body.rvo-theme`): kebab-dropdown overflow-cap, aiv-tooltip-cap (base.css), tap-targets ≥44px (member-select/delete + nowrap-verwijdering, comment-action-btn, sync-toast__action, "Leden beheren"), dialog wrap/scroll/padding, sync-toast mobiel stacken. Het PR1-mediablok staat aan het **einde** van `app.css` zodat het qua bronvolgorde wint van de base-regels die het target (de `.sync-toast`-base staat verderop in de file).
 
 ## 6. Verificatie
 

--- a/docs/superpowers/specs/2026-06-14-mobile-ux-design.md
+++ b/docs/superpowers/specs/2026-06-14-mobile-ux-design.md
@@ -1,0 +1,82 @@
+# Mobile-UX voor de boekhouding-frontend — ontwerp
+
+- **Datum:** 2026-06-14
+- **Status:** goedgekeurd (brainstorm), klaar voor implementatieplan PR1
+- **Branch:** `worktree-feat+48-mobile-ux` (P1); P2/P3 op nieuwe branches
+- **Voorgeschiedenis:** voortzetting van de Forgejo-branch `feat/48-mobile-ux`. Het netto CSS-werk daarvan (responsive header + 44px tap-targets, NeRDS-geverifieerd) is al gecommit op deze branch (`feat(mobile-ux): responsive header/form-layout met toegankelijke tap-targets`). De oudere backend-/tooling-commits van die branch zaten al op main via #283 en zijn bewust niet overgenomen.
+
+## 1. Doel en context
+
+De app (Pre-scan/DPIA/IAMA-invulhulpen, Vue 3 + RVO component library) is desktop-first gebouwd met een dunne mobiele retrofit. Ambtenaren gebruiken hem steeds vaker op tablet/telefoon. Doel: de app **mobiel-gereed** maken — eerst de echte WCAG-conformiteitsfouten wegnemen, daarna de lay-out-patronen die een telefoon vragen, daarna de structurele/cross-cutting zaken.
+
+Styling-conventie van het project: **geen `<style scoped>`**; alle styling staat in `apps/boekhouding-frontend/src/assets/app.css` (frontend) en `packages/assessment-core/src/assets/base.css` (gedeeld met de standalone, wordt geïnlined). RVO design-tokens zijn gescoped op `body.rvo-theme`.
+
+## 2. Audit-samenvatting
+
+Een statische audit (10 surfaces, 58 bevindingen, NeRDS-/WCAG-gegrond, adversarieel geverifieerd) gaf als verdict: niet mobiel-gereed, maar de ergste gaten clusteren in een handvol gedeelde regels. Dominante problemen:
+
+- **WCAG 1.4.10 Reflow (horizontale overflow @360px):** vaste-breedte tabellen (leden, versiegeschiedenis, diff, conflict) en RVO multi-koloms grids die op telefoon geforceerd meerdere kolommen blijven; de kebab-dropdown loopt over de rechterrand (één gedeelde oorzaak, 4 plekken); de aiv-begrip-tooltip heeft `min-width:500px`.
+- **WCAG 2.5.5 Target Size (AAA, het doel dat het team elders al koos):** diverse bedieningselementen <44px (member-select/delete, comment-acties, sync-toast, "Nieuw project", "Leden beheren").
+- **Dialogs** wrappen/scrollen niet en verspillen ruimte op telefoon.
+- **iOS zoom-on-focus** bij selects met font <16px.
+
+De completeness-critic vond bovendien cross-cutting gaten buiten de 10 surfaces (zie §6, PR3): geen 404-route, geen skip-link, FileUpload/ImageField leunen op drag-drop (bestaat niet op touch), `100vh` i.p.v. `100dvh`, globale input-font, en de formele 200%/400% zoom-reflow test.
+
+## 3. Vastgelegde responsive-patronen (huisstijl, geldt over alle PR's)
+
+Deze keuzes zijn met de visuele companion gemaakt en gelden consistent waar het patroon terugkeert:
+
+| Surface | Patroon | Toelichting |
+|---|---|---|
+| Databeheer-tabellen (leden, versiegeschiedenis) | **Kaart per rij** | Elke rij → kaart; primaire waarde prominent, rol/actie eronder. Sluit aan op het bestaande `AssessmentCard`-idioom. |
+| Vergelijkingstabellen (conflict, diff) | **Gestapelde vergelijkingskaart** | Per veld een kaart: "jouw versie" (blauw) bóven "hun versie" (oranje), met twee grote keuzeknoppen. Geen zijscroll; kleur onderscheidt de bron. |
+| Comments op telefoon | **Bottom-sheet per veld** | Tik de comment-badge van een veld → sheet schuift omhoog met júist die thread; het veld blijft zichtbaar erboven. Vervangt de huidige "platte lijst onder het formulier". |
+| RVO multi-koloms grids | **1 kolom op telefoon** | `--two` en (in P2) `--three` collapsen op smalle viewports. |
+
+## 4. Routekaart (3 PR's)
+
+Elke PR krijgt een eigen spec → plan → implementatie-cyclus. P1 → P2 → P3.
+
+- **PR1 — CSS-only conformiteit** (deze branch). Alleen `app.css` + `base.css`, geen template-wijzigingen. Detail in §5.
+- **PR2 — Responsive patronen** (nieuwe branch, component/template-werk). De vastgelegde patronen implementeren: ledentabel + versiegeschiedenis → kaart per rij; conflict/diff → gestapelde vergelijkingskaart; **comment-panel → bottom-sheet per veld**; LandingPage `--three` grid; kebab JS edge-detection (links uitlijnen i.p.v. de CSS-mitigatie uit P1); empty-states; FRIA-tag/toggle-herschikking; repeatable add/delete-knopgroottes.
+- **PR3 — Structureel/cross-cutting** (nieuwe branch). 404-route; skip-link (WCAG 2.4.1); FileUpload/ImageField touch-affordance (drag-drop → tikbare knop + camera-capture); `100vh`→`100dvh`; PDF-export feedback/haalbaarheid op telefoon; formele 200%/400% zoom-reflow testronde en fixes.
+
+## 5. PR1 — detailspec (CSS-only conformiteit)
+
+Doel: de goedkope, geverifieerde WCAG-fouten wegnemen zonder template-wijzigingen. Alle wijzigingen in `apps/boekhouding-frontend/src/assets/app.css` tenzij anders vermeld. Bestaande breakpoints in de file: 480px (header), 551/552px (RVO grid-grens), 560px (tap-targets/fieldset), 768px (comment-panel/editor-kolom). We sluiten daarbij aan i.p.v. nieuwe breakpoints te verzinnen.
+
+1. **Kebab-dropdown overflow** — `.kebab-menu__dropdown` (`right:0; min-width:14rem`). Voeg toe: `@media (max-width:560px){ .kebab-menu__dropdown{ min-width:auto; max-width:calc(100vw - 1rem); } }`. Lost de overflow in 4 surfaces tegelijk op. *WCAG 1.4.10.*
+2. **aiv-begrip-tooltip** — `base.css` `.aiv-definition .aiv-definition-text` (`min-width:500px`). Cap op telefoon: `@media (max-width:560px){ min-width:auto; max-width:calc(100vw - 2rem); }`. Gedeeld → werkt ook in de standalone (geïnlined). *WCAG 1.4.10 / 1.4.4.*
+3. **RVO 2-koloms grids → 1 kolom** — globale regel in app.css: `@media (max-width:551px){ .rvo-layout-grid-columns--two{ grid-template-columns:1fr; } }`. Dekt ProjectDetail + de assessment-kaartgrids. (`--three` van de LandingPage is P2.) *WCAG 1.4.10.*
+4. **Tap-target-sweep ≥44px** — uitbreiden van het bestaande `@media (max-width:560px)`-blok (raak alleen sizing aan, geen gedrag):
+   - `.member-select` + `.member-delete`: hoogte 2rem → 2.75rem; haal `white-space:nowrap` van `.member-delete` zodat "Verwijderen" wrapt i.p.v. clipt.
+   - `.comment-action-btn`: `min-height:44px` (+ wat padding).
+   - `.sync-toast__action`: `min-height:44px; white-space:normal`.
+   - "Leden beheren"-knop: `.project-detail-header .utrecht-button { min-width:44px; min-height:44px }`.
+   - "Nieuw project"-knop (`ProjectList.vue`): via zijn class/selector naar `min-height:44px`.
+   *WCAG 2.5.5 (AAA), conform het doel dat elders in deze stylesheet al gehanteerd wordt.*
+5. **Dialogs: wrap + scroll + padding** — uitlijnen met het bestaande core-patroon (`base.css` `.confirm-delete-dialog__*`):
+   - `.confirm-dialog__actions` en `.start-dialog__actions`: `flex-wrap:wrap`.
+   - `.confirm-dialog__content`: `max-height:80vh; overflow-y:auto` (in P3 evt. → `dvh`).
+   - Dialog-padding op `@media (max-width:560px)`: 2rem → ~1.25rem voor `.confirm-dialog__content` en `.start-dialog__content`.
+   *WCAG 1.4.10.*
+6. **sync-toast mobiel** — `@media (max-width:560px){ .sync-toast{ flex-direction:column; align-items:stretch; max-width:calc(100vw - 1rem); } }`. *WCAG 1.4.10.*
+7. **iOS zoom-on-focus** — selects die nu `sm` (14px) zijn → `font-size:16px` op mobiel (bv. `.member-select` en de form-selects via hun app.css-selector). RVO text-inputs zijn al `md` (16px) en blijven ongemoeid; alleen de sub-16px selects worden gelijkgetrokken. *UX (iOS Safari).*
+
+**Bewust NIET in PR1** (→ PR2, want template-werk): de ledentabel en versiegeschiedenis-tabel zelf (kaart-per-rij vergt kleine template-aanpassingen zoals naam/e-mail splitsen en rol-label), de conflict/diff-tabellen, en het comment-bottom-sheet. PR1 brengt deze surfaces dus op tap-target- en grid-niveau op orde, maar de volledige tabel-reflow volgt in PR2. Dit is een bewuste, gecommuniceerde afbakening.
+
+## 6. Verificatie
+
+- **PR1:** Playwright-CSS-harness (echte RVO-CSS + `body.rvo-theme`) op 320/360/390px, zoals bij de header-fix — meet computed waarden (geen horizontale overflow, controls ≥44px, dropdown binnen viewport, dialog scrollt). `app.css`/`base.css` vallen onder `src/assets/**` → uitgesloten van de coverage-gate; geen testwijzigingen nodig.
+- **PR2/PR3:** naast de harness ook tegen de draaiende stack (boekhouding-frontend + standalone) waar component-gedrag telt (bottom-sheet open/dicht, touch-upload, focus-volgorde). Component-/template-wijzigingen moeten de **100%-coverage-gate** houden — nieuwe of gewijzigde TS/Vue-code volledig dekken.
+
+## 7. Risico's en aandachtspunten
+
+- **Gedeelde `base.css`** raakt ook de standalone (single-file, offline). Wijzigingen daar (aiv-tooltip) verifiëren in beide builds.
+- **Globale grid-regel** (`--two → 1fr`): controleren dat geen desktop-only grid onbedoeld op smalle desktop-vensters collapst (de 551px-grens sluit aan op de RVO-grid-grens).
+- **`min-width:auto` op de kebab-dropdown**: bij heel smalle schermen kan de dropdown smal worden; `max-width:calc(100vw - 1rem)` voorkomt overflow, leesbaarheid checken in de harness.
+- **PR-afbakening:** na PR1 blijft de ledentabel/versiegeschiedenis-tabel nog overlopen tot PR2 die landt; dit is bekend en geaccepteerd.
+
+## 8. Uit scope
+
+Niet-mobiele wijzigingen, backend, en de in §6 genoemde coverage zijn buiten dit ontwerp. P2 en P3 krijgen elk een eigen detailspec wanneer we ze oppakken.

--- a/packages/assessment-core/src/assets/base.css
+++ b/packages/assessment-core/src/assets/base.css
@@ -146,6 +146,15 @@
   display: block;
 }
 
+/* On phones the 500px min-width overflows the viewport (WCAG 1.4.10 Reflow);
+   cap it to the available width instead. */
+@media (max-width: 560px) {
+  .aiv-definition .aiv-definition-text {
+    min-width: auto;
+    max-width: calc(100vw - 2rem);
+  }
+}
+
 .rvo-theme .rvo-icon--with-spacing-left {
   margin-left: 0.5rem;
 }


### PR DESCRIPTION
Tweede PR van de mobiele reeks (gestapeld op #389 / P1). Implementeert de in de routekaart vastgelegde responsive-patronen voor de tabellen. Zie `docs/superpowers/specs/2026-06-14-mobile-ux-design.md`.

> Base = `feat/48-mobile-ux` (P1). Rebase naar `main` zodra P1 gemerged is.

## Probleem

Vaste-breedte tabellen lopen op telefoon over de viewport (WCAG 1.4.10 Reflow):
- ledentabel: rol (10rem) + actie (8rem) laten ~32px over voor de naam @360px
- versiegeschiedenis-rij (~28rem vaste kolommen) en diff-tabel (30/35/35%)
- conflict-resolutie: 3-koloms tabel in een 324px-dialoog

## Oplossing — kaart per rij (CSS-only, op ≤560px)

Vrijwel volledig CSS via bestaande kolom-classes; kolomkoppen verborgen, elke waarde krijgt een inline `::before`-label zodat geen informatie verdwijnt. Desktop ongemoeid.

- **Ledentabel** → kaart per rij: naam vet bovenaan, rol-select + verwijderknop full-width eronder
- **Versiegeschiedenis** → kaart per rij met gelabelde velden (Versie / datum / door / beschrijving)
- **Diff-tabel** → gestapelde kaart per veld met "Was" (rood) / "Wordt" (groen)
- **Conflict-resolutie** → gestapelde vergelijkingskaart: "Jouw waarde" (blauw) boven "Andere waarde" (oranje). Enige template-wijziging: twee class-attributen (`conflict-value--mine`/`--theirs`) — geen logica.

## Verificatie

Gemeten met de echte RVO-CSS + `body.rvo-theme`:
- **360px**: geen horizontale overflow, headers verborgen, labels aanwezig, vergelijkingskleuren correct
- **900px**: desktop identiek (tabellen + headers ongewijzigd, geen mobiele labels)
- **Coverage**: frontend 100% (800 tests) — de conflict-class-toevoeging breekt niets

LandingPage `--three` grid bleek al vanzelf 1 kolom <552px → geen actie.

## Vervolg

- **P3** — comment-panel bottom-sheet (component + tests), 404-route, skip-link, FileUpload touch, `dvh`