### PR TITLE
Mobiele toegankelijkheid: comment-panel als bottom-sheet op telefoon

### DIFF
--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -1276,17 +1276,26 @@ a.card-link:hover {
   outline-offset: -1px;
 }
 
-
-/* Responsive: stack panel below on small screens */
+/* On phones the comment panel becomes a bottom-sheet, closed with its X button. */
 @media (max-width: 768px) {
-  .assessment-editor__content {
-    flex-direction: column;
-  }
-
   .comment-panel {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
     width: 100%;
     max-width: 100%;
+    max-height: 75vh;
+    overflow-y: auto;
+    z-index: 90;
+    transform: none;
     border-top: 1px solid var(--rvo-color-grijs-200, #e0e0e0);
+    border-radius: 12px 12px 0 0;
+    /* sheet elevation + dim scrim over the rest of the screen */
+    box-shadow:
+      0 -2px 12px rgba(0, 0, 0, 0.2),
+      0 0 0 100vmax rgba(0, 0, 0, 0.4);
+    animation: comment-sheet-up 0.2s ease-out;
   }
 
   .comment-panel__body {
@@ -1303,6 +1312,15 @@ a.card-link:hover {
   }
 }
 
+@keyframes comment-sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
 @media (max-width: 560px) {
   .rvo-form-fieldset,
   fieldset.rvo-form-fieldset {

--- a/apps/boekhouding-frontend/src/components/CommentPanel.vue
+++ b/apps/boekhouding-frontend/src/components/CommentPanel.vue
@@ -57,10 +57,15 @@ function updateFieldPositions() {
     if (parts.length < 2) continue
     const fieldId = parts.slice(1).join('-')
     positions.set(fieldId, label.getBoundingClientRect().top - bodyRect.top)
-    const text = label.querySelector('.rvo-form-field__label > :first-child')?.textContent?.trim()
-      || label.textContent?.trim().split('\n')[0]?.trim()
-      || fieldId
-    labels.set(fieldId, text)
+    const titleEl = label.querySelector('.rvo-form-field__label > :first-child')
+    let text: string | undefined
+    if (titleEl) {
+      // Exclude any begrip-definition tooltip text nested in the title.
+      const clone = titleEl.cloneNode(true) as HTMLElement
+      clone.querySelectorAll('.aiv-definition-text').forEach((el) => el.remove())
+      text = clone.textContent?.trim()
+    }
+    labels.set(fieldId, text || label.textContent?.trim().split('\n')[0]?.trim() || fieldId)
   }
 
   fieldPositions.value = positions

--- a/apps/boekhouding-frontend/test/cov/components-CommentPanel.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/components-CommentPanel.cov.test.ts
@@ -83,7 +83,12 @@ function thread(
 // Builds a fake form container with `label-*` elements so
 // updateFieldPositions() can resolve positions and labels.
 function buildFormContainer(
-  specs: Array<{ id: string; rvoLabel?: string; textLabel?: string }>,
+  specs: Array<{
+    id: string
+    rvoLabel?: string
+    textLabel?: string
+    aivLabel?: { title: string; term: string; definition: string }
+  }>,
 ): HTMLElement {
   const form = document.createElement('div')
   for (const spec of specs) {
@@ -94,6 +99,21 @@ function buildFormContainer(
       wrap.className = 'rvo-form-field__label'
       const span = document.createElement('span')
       span.textContent = spec.rvoLabel
+      wrap.appendChild(span)
+      label.appendChild(wrap)
+    } else if (spec.aivLabel !== undefined) {
+      const wrap = document.createElement('div')
+      wrap.className = 'rvo-form-field__label'
+      const span = document.createElement('span')
+      span.textContent = `${spec.aivLabel.title} `
+      const aiv = document.createElement('span')
+      aiv.className = 'aiv-definition'
+      aiv.textContent = spec.aivLabel.term
+      const def = document.createElement('span')
+      def.className = 'aiv-definition-text'
+      def.textContent = spec.aivLabel.definition
+      aiv.appendChild(def)
+      span.appendChild(aiv)
       wrap.appendChild(span)
       label.appendChild(wrap)
     } else if (spec.textLabel !== undefined) {
@@ -218,6 +238,25 @@ describe('CommentPanel', () => {
       expect(group.attributes('data-field-group')).toBe('1.1')
       expect(group.get('.comment-field-group__label').text()).toBe(
         'Opmerking voor: Naam van veld',
+      )
+    })
+
+    it('excludes the begrip-definition tooltip text from the field label', async () => {
+      const form = buildFormContainer([{
+        id: 'label-dpia-1.1',
+        aivLabel: {
+          title: 'Aanvullende informatie over de',
+          term: 'verwerkingsdoeleinden',
+          definition: 'Het verwerkingsdoeleinde is het resultaat dat wordt beoogd.',
+        },
+      }])
+      const t = thread({ id: 'root', fieldId: '1.1' })
+      const { wrapper } = mountPanel({ formContainerRef: form, threads: [t] })
+      await flushRaf()
+      await nextTick()
+
+      expect(wrapper.get('.comment-field-group__label').text()).toBe(
+        'Opmerking voor: Aanvullende informatie over de verwerkingsdoeleinden',
       )
     })
 


### PR DESCRIPTION
Tweede van drie gestapelde PR's (op #389). Op telefoon werd het comment-panel als platte lijst ónder het formulier gestapeld — bij lange formulieren moet je dan langs alles scrollen. Deze PR maakt er een bottom-sheet van.

> Base = `feat/48-mobile-ux` (#389). Rebase naar `main` zodra #389 gemerged is.

## Oplossing — bottom-sheet (CSS-only)

Het panel schuift op telefoon vanaf de onderkant omhoog over het formulier (dat zichtbaar blijft, gedimd door een `box-shadow`-scrim), met sticky header en de bestaande X-knop om te sluiten. Het per-veld-gedrag blijft intact: een veld-badge zet `activeFieldId` en de bestaande watcher scrollt dat veld in beeld binnen de sheet.

**Geen nieuwe component-logica** — `CommentPanel.vue` wordt ongewijzigd hergebruikt (alle thread-/reply-/edit-/resolve-logica). Geen coverage-impact.

## Verificatie (echte RVO-CSS + `body.rvo-theme`)

- **375px**: `position: fixed`, vastgepind onderaan, `max-height: 75vh`, scrollbaar, scrim, sticky header
- **1280px**: desktop-zijpaneel volledig ongewijzigd (anchoring, geen scrim)

## Bewuste afbakening (latere uitbreiding, vergt JS/matchMedia)

- Sluiten via de X-knop, niet tap-op-scrim
- Alle veld-threads in de scrollbare sheet (scrollt naar het actieve veld) i.p.v. strikt één veld

## Vervolg

- **#392** — skip-link, 404-route, `dvh`