### PR TITLE
Mobiele toegankelijkheid: skip-link, 404, dvh + RVO-/review-fixes

### DIFF
--- a/apps/boekhouding-frontend/src/App.vue
+++ b/apps/boekhouding-frontend/src/App.vue
@@ -10,8 +10,11 @@ const homeUrl = computed(() => isAuthenticated.value ? '/projecten' : '/')
 
 <template>
   <div class="app-layout">
+    <a class="skip-link" href="#main-content">Naar hoofdinhoud</a>
     <AppBanner :homeUrl="homeUrl" />
-    <router-view :key="$route.path" class="app-main" />
+    <main id="main-content" tabindex="-1" class="app-main">
+      <router-view :key="$route.path" />
+    </main>
     <SessionExpiredDialog />
     <footer class="app-footer">
       <nav aria-label="Juridische informatie">

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -90,6 +90,7 @@ dialog::backdrop {
   max-width: 36rem;
   width: 90vw;
   max-height: 80vh;
+  max-height: 80dvh;
   overflow-y: auto;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
 }
@@ -210,11 +211,30 @@ a.card-link:hover {
   white-space: pre-line;
 }
 
+/* Skip-link: hidden until focused (WCAG 2.4.1 Bypass Blocks). */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: -3rem;
+  z-index: 200;
+  padding: 0.5rem 1rem;
+  background: var(--rvo-color-hemelblauw, #007bc7);
+  color: #fff;
+  border-radius: 0 0 4px 4px;
+  text-decoration: none;
+  transition: top 0.15s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 /* App layout: sticky footer */
 .app-layout {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .app-main {
@@ -374,6 +394,7 @@ a.card-link:hover {
   border-radius: 8px;
   padding: 2rem;
   max-height: 80vh;
+  max-height: 80dvh;
   overflow-y: auto;
 }
 
@@ -1286,6 +1307,7 @@ a.card-link:hover {
     width: 100%;
     max-width: 100%;
     max-height: 75vh;
+    max-height: 75dvh;
     overflow-y: auto;
     z-index: 90;
     transform: none;
@@ -1332,8 +1354,8 @@ a.card-link:hover {
   .kebab-menu__trigger,
   .comment-badge,
   .comment-panel__close,
-  .app-header__left .utrecht-button,
-  .app-header__right .utrecht-button {
+  .app-header__left .rvo-button,
+  .app-header__right .rvo-button {
     min-width: 44px;
     min-height: 44px;
   }
@@ -1431,7 +1453,8 @@ a.card-link:hover {
 
 .project-detail-header {
   justify-content: space-between;
-  align-items: center;
+  align-items: baseline;
+  margin-block-end: var(--rvo-space-2xs);
 }
 
 .project-detail-description {
@@ -1460,16 +1483,12 @@ a.card-link:hover {
     white-space: normal;
   }
 
-  .comment-action-btn,
   .sync-toast__action {
     min-height: 44px;
-  }
-
-  .sync-toast__action {
     white-space: normal;
   }
 
-  .project-actions .utrecht-button {
+  .project-actions .rvo-button {
     min-height: 44px;
   }
 

--- a/apps/boekhouding-frontend/src/router.ts
+++ b/apps/boekhouding-frontend/src/router.ts
@@ -61,6 +61,14 @@ const routes: RouteRecordRaw[] = [
     component: () => import('./views/StatusPage.vue'),
     meta: { public: true },
   },
+  {
+    // Catch-all 404; public so it doesn't trigger the login redirect.
+    // Must stay last so it only matches when no other route does.
+    path: '/:pathMatch(.*)*',
+    name: 'not-found',
+    component: () => import('./views/NotFound.vue'),
+    meta: { public: true },
+  },
 ]
 
 export const router = createRouter({

--- a/apps/boekhouding-frontend/src/views/NotFound.vue
+++ b/apps/boekhouding-frontend/src/views/NotFound.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="rvo-max-width-layout rvo-max-width-layout--md rvo-max-width-layout-inline-padding--md">
+    <h1 class="utrecht-heading-1">Pagina niet gevonden</h1>
+    <p>
+      De pagina die je zoekt bestaat niet (meer). Controleer de link, of ga
+      terug naar het overzicht.
+    </p>
+    <p>
+      <router-link
+        to="/"
+        class="rvo-button rvo-button--primary rvo-button--size-md"
+      >Naar de startpagina</router-link>
+    </p>
+  </div>
+</template>

--- a/apps/boekhouding-frontend/test/cov/router.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/router.cov.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../src/views/PrivacyStatement.vue', () => stub('PrivacyStatement'))
 vi.mock('../../src/views/AccessibilityStatement.vue', () => stub('AccessibilityStatement'))
 vi.mock('../../src/views/AboutAssessments.vue', () => stub('AboutAssessments'))
 vi.mock('../../src/views/StatusPage.vue', () => stub('StatusPage'))
+vi.mock('../../src/views/NotFound.vue', () => stub('NotFound'))
 
 let router: typeof import('../../src/router').router
 
@@ -63,6 +64,7 @@ describe('router route table', () => {
     expect(paths.get('accessibility')).toBe('/toegankelijkheid')
     expect(paths.get('about')).toBe('/over')
     expect(paths.get('status')).toBe('/status')
+    expect(paths.get('not-found')).toBe('/:pathMatch(.*)*')
   })
 
   it('marks the public routes with meta.public and leaves the rest unset', () => {
@@ -71,6 +73,7 @@ describe('router route table', () => {
     expect(byName('accessibility').meta?.public).toBe(true)
     expect(byName('about').meta?.public).toBe(true)
     expect(byName('status').meta?.public).toBe(true)
+    expect(byName('not-found').meta?.public).toBe(true)
 
     expect(byName('projects').meta?.public).toBeUndefined()
     expect(byName('project').meta?.public).toBeUndefined()
@@ -89,6 +92,7 @@ describe('router route table', () => {
       accessibility: 'AccessibilityStatement',
       about: 'AboutAssessments',
       status: 'StatusPage',
+      'not-found': 'NotFound',
     }
 
     for (const [name, componentName] of Object.entries(expected)) {

--- a/apps/boekhouding-frontend/test/cov/views-NotFound.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-NotFound.cov.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import NotFound from '../../src/views/NotFound.vue'
+
+const routerLinkStub = {
+  props: ['to'],
+  template: '<a class="router-link-stub" :href="to"><slot /></a>',
+}
+
+function mountNotFound() {
+  return mount(NotFound, {
+    global: { stubs: { 'router-link': routerLinkStub } },
+  })
+}
+
+describe('NotFound.vue', () => {
+  it('renders the 404 heading and explanation', () => {
+    const wrapper = mountNotFound()
+    expect(wrapper.find('h1').text()).toBe('Pagina niet gevonden')
+    expect(wrapper.text()).toContain('bestaat niet')
+  })
+
+  it('links back to the start page', () => {
+    const wrapper = mountNotFound()
+    const link = wrapper.find('.router-link-stub')
+    expect(link.attributes('href')).toBe('/')
+    expect(link.text()).toBe('Naar de startpagina')
+  })
+})

--- a/packages/assessment-core/src/assets/base.css
+++ b/packages/assessment-core/src/assets/base.css
@@ -305,6 +305,16 @@
   gap: 0.25rem;
 }
 
+/* RVO 4.20 spaces the button icon twice: a flex `gap` (tamed above) plus an
+   extra margin on the icon itself (--rvo-space-sm ≈ 12px). Drop that margin so
+   the 0.25rem gap is the only spacing, matching the pre-4.20 button look. */
+.rvo-theme .rvo-button--icon-before .utrecht-icon {
+  margin-inline-end: 0;
+}
+.rvo-theme .rvo-button--icon-after .utrecht-icon {
+  margin-inline-start: 0;
+}
+
 /* RVO 4.20 stripte de standaard onder-marge van koppen (utrecht-heading-*),
    waardoor koppen tegen de tekst eronder kleven. Herstel de 4.8-spacing, maar
    respecteer expliciete margin-utilities (rvo-margin*, rvo-heading--no-margins)


### PR DESCRIPTION
Laatste PR van de mobiele toegankelijkheidsreeks (#389 en #391 zijn gemerged). Gerebaset op de actuele `main`.

## Wijzigingen

**Structureel / a11y**
- **Skip-link (WCAG 2.4.1 Bypass Blocks):** "Naar hoofdinhoud" als eerste element, verborgen tot focus; `router-view` in een `<main id="main-content" tabindex="-1">` landmark.
- **404-route:** catch-all (`/:pathMatch(.*)*`) → gestylde `NotFound.vue` i.p.v. een blanco scherm.
- **`dvh`:** `100vh`→`100dvh` (`.app-layout`), `80/75vh`→`dvh` (dialogs/comment-sheet), met `vh`-fallback — voorkomt dat de iOS-URL-balk dialogen/sheet afknipt.

**Na de RVO 4.20.2-migratie (#382, `utrecht-button`→`rvo-button`)**
- Tap-target-selectors voor de header-knoppen en "Leden beheren" naar `.rvo-button` (`rvo-button--size-xs` is ~32px → 44px op telefoon). `NotFound.vue` gebruikt nu `rvo-button`-classes.

**Review-fixes (projectpagina / comments)**
- Projectpagina-header: "Leden beheren" lijnt nu op de **titel-baseline** uit (i.p.v. te hoog gecentreerd) en de beschrijving staat dichter onder de titel.
- Comment-thread-knoppen (Reageren/Verwijderen/Oplossen) krijgen **niet langer 44px** op telefoon — ze blijven compact zoals in desktopweergave.

## Verificatie

Geverifieerd met de echte RVO 4.20.2 + `body.rvo-theme`: skip-link (verborgen→focus, focust `<main>`), header-knoppen 44px op 375px, project-header-baseline en comment-knoppen ~20px. Frontend-coverage 100% (NotFound-view + router-route gedekt). De `views-AssessmentEditor`-faler die ik lokaal zag was env-specifiek — die testjob is groen in CI (#391 is ermee gemerged).