### PR TITLE
fix(rvo): UiButton icon-positieclasses + card-colour-typo (review-followups #382)

### DIFF
--- a/packages/assessment-core/src/components/ExportPdfInfo.vue
+++ b/packages/assessment-core/src/components/ExportPdfInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour-wit">
+  <div class="rvo-card rvo-card--outline rvo-card--padding-md rvo-card--full-colour--wit">
     <div class="rvo-layout-row rvo-layout-gap--xs export-pdf-info__heading-row">
       <span class="utrecht-icon rvo-icon rvo-icon-info rvo-icon--xl rvo-status-icon-info" role="img" aria-label="Info"></span>
       <strong>Opslaan en delen van je werk</strong>

--- a/packages/assessment-core/src/components/ui/UiButton.vue
+++ b/packages/assessment-core/src/components/ui/UiButton.vue
@@ -37,6 +37,7 @@ defineEmits<{
       variantClass,
       `rvo-button--size-${size || 'md'}`,
       fullWidth ? 'rvo-button--full-width' : '',
+      icon ? (showIconAfter ? 'rvo-button--icon-after' : 'rvo-button--icon-before') : '',
     ]"
     :type="type || 'button'"
     :disabled="disabled"
@@ -54,7 +55,6 @@ defineEmits<{
         `rvo-icon-${icon}`,
         'rvo-icon--md',
         'rvo-icon--hemelblauw',
-        'rvo-icon--with-spacing-left',
       ]"
       role="img"
       aria-label="icon"
@@ -69,7 +69,6 @@ defineEmits<{
         `rvo-icon-${icon}`,
         'rvo-icon--md',
         'rvo-icon--hemelblauw',
-        'rvo-icon--with-spacing-right',
       ]"
       role="img"
       aria-label="icon"

--- a/packages/assessment-core/test/cov/components-ui-UiButton.cov.test.ts
+++ b/packages/assessment-core/test/cov/components-ui-UiButton.cov.test.ts
@@ -113,12 +113,12 @@ describe('UiButton icon and label rendering (showIconAfter=false branch)', () =>
     expect(wrapper.find('.rvo-icon').exists()).toBe(false)
   })
 
-  it('renders the icon before the label with the spacing-right modifier', () => {
+  it('renders the icon before the label with rvo-button--icon-before on the button', () => {
     const wrapper = mount(UiButton, { props: { icon: 'pijl-naar-rechts', label: 'Verder' } })
     const icon = wrapper.find('.rvo-icon')
     expect(icon.exists()).toBe(true)
     expect(icon.classes()).toContain('rvo-icon-pijl-naar-rechts')
-    expect(icon.classes()).toContain('rvo-icon--with-spacing-right')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--icon-before')
     expect(icon.attributes('role')).toBe('img')
     expect(wrapper.text()).toContain('Verder')
   })
@@ -137,14 +137,14 @@ describe('UiButton icon and label rendering (showIconAfter=true branch)', () => 
     expect(wrapper.find('.rvo-icon').exists()).toBe(false)
   })
 
-  it('renders the icon after the label with the spacing-left modifier', () => {
+  it('renders the icon after the label with rvo-button--icon-after on the button', () => {
     const wrapper = mount(UiButton, {
       props: { showIconAfter: true, icon: 'pijl-naar-links', label: 'Terug' },
     })
     const icon = wrapper.find('.rvo-icon')
     expect(icon.exists()).toBe(true)
     expect(icon.classes()).toContain('rvo-icon-pijl-naar-links')
-    expect(icon.classes()).toContain('rvo-icon--with-spacing-left')
+    expect(wrapper.find('button').classes()).toContain('rvo-button--icon-after')
     expect(icon.attributes('aria-label')).toBe('icon')
     expect(wrapper.find('span').html()).toContain('Terug')
   })


### PR DESCRIPTION
Twee pre-existing hygiene-issues die de adversariële review van #382 opdook (en daar bewust buiten scope bleven). Nu opgepakt.

## 1. UiButton — niet-bestaande icon-spacing-classes
`UiButton.vue` zette `rvo-icon--with-spacing-left/right` op de icon-span, maar die classes bestaan in **geen enkele** RVO-versie (4.8 én 4.20.2: 0 voorkomens). De spacing leunde dus op niet-bestaande regels.

**Fix:** `rvo-button--icon-before` / `--icon-after` op de knop (afhankelijk van `showIconAfter`), net als de handgeschreven icon-knoppen (NavHeader, ExportMenu). De spacing loopt nu via de officiële RVO-regels + onze `base.css` `gap`-override.

Live gemeten op de standalone: UiButton "Volgende stap" (icon-after) heeft **gap 4px**, identiek aan de handgeschreven "Exporteer"-knop — consistent, geen dubbele spatie. Raakt o.a. Volgende/Vorige stap, de "+ toevoegen"-knoppen en de verwijder-bevestiging.

## 2. ExportPdfInfo — card-colour typo
`rvo-card--full-colour-wit` (enkele streep) → `rvo-card--full-colour--wit` (de echte class, dubbele streep). De bedoelde **witte achtergrond** op de "Opslaan en delen van je werk"-infokaart werkte nooit en werkt nu wel.

⚠️ **Zichtbare wijziging:** die infokaart krijgt nu een witte achtergrond (i.p.v. de huidige transparante/grijze). Was duidelijk de bedoeling van de auteur, maar even bevestigen dat dit gewenst is.

## Verificatie
- UiButton.vue **100% coverage** (focused, 23 tests); cov-tests bijgewerkt naar de nieuwe button-classes.
- Volledige assessment-core suite groen (1174 tests), standalone build OK.
- Live gecheckt: icon-knoppen renderen schoon met 4px gap, consistent met de overige knoppen.

Volgt op de nl-rvo-upgrade (#382). Geen functionele wijziging behalve de bewuste witte-kaart-achtergrond.