### PR TITLE
docs(changelog): release 2026.6.20 (eerste CalVer-release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ build) staan kort onder "Onder de motorkap".
 
 ## [Unreleased]
 
+## [2026.6.20] - 2026-06-20
+
 ### Toegevoegd
 
 * Samenwerkomgeving: log in en werk met meerdere mensen aan dezelfde
@@ -34,6 +36,11 @@ build) staan kort onder "Onder de motorkap".
 * De invulhulp blijft zonder account te gebruiken via `/zonder-account/`:
   formulieren invullen zonder in te loggen, met opslag in de browser en
   import/export via JSON en PDF.
+* Mobiele weergave: de invulhulp is geoptimaliseerd voor telefoons met een
+  responsieve lay-out; het opmerkingen-paneel verschijnt als bottom-sheet en
+  er is een skip-link toegevoegd voor toetsenbord- en screenreadergebruik.
+* Versie-informatie en statuspagina: in de interface is zichtbaar welke versie
+  draait en een statuspagina toont de beschikbaarheid van de dienst.
 
 ### Opgelost
 
@@ -54,13 +61,23 @@ build) staan kort onder "Onder de motorkap".
   release hangt ook het standalone formulier (offline single-file) als
   downloadbare asset aan.
 * Testdekking van 100% afgedwongen in CI voor alle workspaces.
+* Beveiliging aangescherpt: de server valideert de begintoestand bij het
+  aanmaken én de volledige assessment-state server-side, geüploade
+  afbeeldingen worden tegen een allowlist gecontroleerd (SVG wordt geweigerd,
+  ook in de versievergelijking) en de frontend-container draait met een
+  alleen-lezen rootbestandssysteem.
+* `@nl-rvo/component-library-css` bijgewerkt naar 4.20.2 (met design-tokens
+  2.4.1); knoppen gemigreerd van `utrecht-button` naar `rvo-button`.
+* `publiccode.yml` bijgewerkt naar v0.5 en de landingspagina omgezet naar
+  invulhulpen.rijksapp.nl.
 * Externe links openen nu met `rel="noopener noreferrer"`.
 * Linkcontrole (lychee) robuuster gemaakt bij tijdelijke fouten en
   root-relatieve links; Dependabot bewaakt nu ook GitHub Actions,
   containers en de Python-pipeline (configuratie samengevoegd in
   `dependabot.yml`).
 * Diverse dependency-updates (@types/node 25, @vitejs/plugin-vue 6.0.6,
-  @types/pdfmake 0.3, string-strip-html 13.5).
+  @types/pdfmake 0.3, string-strip-html 13.5, en aanvullende npm-, GitHub
+  Actions- en Python-bumps).
 
 ## [0.1.3] - 2026-06-04
 
@@ -214,7 +231,8 @@ build) staan kort onder "Onder de motorkap".
 
 * Projectopzet en eerste dependency-configuratie.
 
-[Unreleased]: https://github.com/MinBZK/par-dpia-form/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/MinBZK/par-dpia-form/compare/v2026.6.20...HEAD
+[2026.6.20]: https://github.com/MinBZK/par-dpia-form/releases/tag/v2026.6.20
 [0.1.3]: https://github.com/MinBZK/par-dpia-form/releases/tag/v0.1.3
 [0.1.2]: https://github.com/MinBZK/par-dpia-form/releases/tag/v0.1.2
 [0.1.1]: https://github.com/MinBZK/par-dpia-form/releases/tag/v0.1.1


### PR DESCRIPTION
Bereidt de eerste CalVer-release **2026.6.20** voor. Verplaatst `[Unreleased]` naar een gedateerde sectie en vult de wijzigingen aan die ná de samenwerken-merge (#283) op `main` landden en nog niet in de changelog stonden.

## Aangevuld

**Toegevoegd (gebruiker-merkbaar)**
- Mobiele weergave: responsieve lay-out, opmerkingen-paneel als bottom-sheet, skip-link (`fe5327e`, `8bfd0ac`, `75e7de5`)
- Versie-informatie + statuspagina (#368, `7854ea6`)

**Onder de motorkap**
- Beveiliging: server-side state-validatie bij create + volledig, image-allowlist met SVG-weigering (ook in versiediff), `readOnlyRootFilesystem` (#343, `e0b03d1`/`80fafd9`)
- `@nl-rvo/component-library-css` 4.20.2 + design-tokens 2.4.1, button-migratie `utrecht-button` → `rvo-button` (#382, `ba7e016`)
- `publiccode.yml` v0.5 + landingURL → invulhulpen.rijksapp.nl (`bbe8432`, `6e2bb93`)
- Aanvullende npm-/GitHub Actions-/Python-bumps gebundeld in de bestaande dep-regel

## Verificatie
- `script/ci/changelog-section.sh 2026.6.20` → sectie wordt correct geëxtraheerd
- `script/ci/validate-calver-tag.sh v2026.6.20` → formaat OK

## Vervolg (na merge)
Na merge + groene `Deploy acceptatie` voor de merge-commit: tag `v2026.6.20` op die commit zetten en pushen — `release.yaml` maakt dan de GitHub-release en start `deploy-productie`.