### PR TITLE
ci(links): auto-retry de flaky link-check eenmaal na afkoelpauze

### DIFF
--- a/.github/workflows/broken-link-and-begrippenkader-sync.yaml
+++ b/.github/workflows/broken-link-and-begrippenkader-sync.yaml
@@ -25,11 +25,15 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        # First attempt is allowed to fail; the retry step below clears the
+        # transient rate-limit/timeout failures that a manual re-run usually
+        # fixed. A real broken link still fails on the second attempt.
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Target specific files and improve the arguments
-          args: >-
+          args: &lychee_args >-
             --verbose
             --no-progress
             --root-dir "${{ github.workspace }}"
@@ -53,6 +57,22 @@ jobs:
           # Output file for creating issues
           output: ./lychee/out.md
           # Fail if any link is broken
+          fail: true
+
+      # Cool-down before the retry so rate-limit windows (HTTP 429) reset.
+      - name: Wait before link-check retry
+        if: steps.lychee.outcome == 'failure'
+        run: sleep 30
+
+      - name: Link Checker (retry)
+        id: lychee_retry
+        if: steps.lychee.outcome == 'failure'
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: *lychee_args
+          output: ./lychee/out.md
           fail: true
 
       - name: Update or create the broken-links issue (schedule/manual only)


### PR DESCRIPTION
De `check-links` job (lychee) in `broken-link-and-begrippenkader-sync.yaml` faalt geregeld op **transiente** oorzaken — rate-limiting (HTTP 429) en trage externe hosts. Een handmatige re-run van de job loste dat doorgaans op. Deze PR automatiseert die re-run.

## Aanpak
GitHub Actions kent geen native "retry deze job", dus dit is een **step-level retry** binnen dezelfde job:

1. Eerste lychee-poging draait met `continue-on-error: true` (faalt stil).
2. `sleep 30` als afkoeling zodat 429-rate-limitvensters resetten.
3. Tweede, identieke lychee-poging draait alleen als de eerste faalde (`if: steps.lychee.outcome == 'failure'`); deze faalt wél de job.

De args van beide stappen worden gedeeld via een YAML-anchor (`&lychee_args` / `*lychee_args`), dus geen duplicatie en gegarandeerd identieke check.

## Waarom dit veilig is
- Een **echt** kapotte link faalt nog steeds — op de tweede poging.
- `continue-on-error` op de eerste poging zorgt dat alleen een falende retry de job-`failure()` triggert, dus de bestaande "broken-links issue"-stap gedraagt zich ongewijzigd (issue alleen als beide pogingen falen, en met de retry-output).
- Lychee's eigen per-link retry (`--max-retries 3`) blijft staan; dit voegt een grovere, hele-run retry toe voor wat per-link niet opvangt.

## Verificatie
- `actionlint` groen op het workflow-bestand
- YAML-anchor resolveert: beide args-blokken zijn na parsen identiek