### PR TITLE
CSP #326: regressie-guard tegen inline styles + verificatie strikte style-src

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: CSP inline-style guard (#326)
+        run: pnpm check:csp
+
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "pnpm --filter standalone-form format",
     "db:generate": "pnpm --filter @overheid-assessment/boekhouding-backend db:generate",
     "db:migrate": "pnpm --filter @overheid-assessment/boekhouding-backend db:migrate",
+    "check:csp": "node --test scripts/check-inline-styles.test.mjs && node scripts/check-inline-styles.mjs",
     "test:e2e": "node tests/e2e/sync.spec.mjs",
     "test:coverage": "pnpm -r --if-present test:coverage"
   },

--- a/scripts/check-inline-styles.mjs
+++ b/scripts/check-inline-styles.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Regression guard for issue #326 (CSP hardening).
+//
+// The boekhouding-frontend ships `style-src 'self'` (no 'unsafe-inline'), so any
+// inline style that reaches the DOM as a *parsed* style — a literal `style=`
+// attribute, a `<style>` element in served HTML, or a `style=` inside v-html
+// content — is blocked by the browser. Dynamic values are routed through CSS
+// classes and `--custom-properties` instead (see base.css / app.css).
+//
+// This guard fails CI when a CSP-unsafe inline style is (re)introduced in the
+// strict-CSP surfaces. It allows the sanctioned escape hatch: a `:style` binding
+// that only sets custom properties (Vue applies those via the CSSOM, which CSP
+// does not gate, and the cascade lives in a 'self' stylesheet).
+//
+// The standalone-form is intentionally out of scope: it is built as a single
+// inlined file (viteSingleFile) and served with 'unsafe-inline'.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const MARKUP_EXTS = new Set(['.vue', '.html'])
+const SCRIPT_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.vue'])
+const YAML_EXTS = new Set(['.yaml', '.yml'])
+
+// A `:style` value is allowed only when it is an object literal whose every key
+// is a CSS custom property (`--foo`). Anything we cannot prove is custom-prop
+// only (a variable, a string, a mixed object) is conservatively rejected.
+function isCustomPropertyOnlyBinding(value) {
+  const v = value.trim()
+  if (!v.startsWith('{') || !v.endsWith('}')) return false
+  const inner = v.slice(1, -1).trim()
+  if (inner === '') return false
+  const customPropEntries =
+    /^(?:(['"])--[\w-]+\1\s*:\s*[^,{}]+)(?:\s*,\s*(['"])--[\w-]+\2\s*:\s*[^,{}]+)*\s*,?\s*$/
+  return customPropEntries.test(inner)
+}
+
+export function findInlineStyleViolations(content, ext) {
+  const violations = []
+  const lines = content.split('\n')
+  const add = (lineIdx, reason, line) =>
+    violations.push({ line: lineIdx + 1, reason, snippet: line.trim().slice(0, 120) })
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    if (MARKUP_EXTS.has(ext)) {
+      // Literal `style=` attribute (preceded by whitespace or `<`, never `:`).
+      if (/(^|[\s<])style\s*=\s*["']/.test(line)) {
+        add(i, 'literal style= attribute (move it to a CSS class)', line)
+      }
+      // Dynamic `:style` / `v-bind:style` bindings.
+      const dynRe = /(?::|v-bind:)style\s*=\s*"([^"]*)"|(?::|v-bind:)style\s*=\s*'([^']*)'/g
+      let m
+      while ((m = dynRe.exec(line)) !== null) {
+        const value = m[1] ?? m[2] ?? ''
+        if (!isCustomPropertyOnlyBinding(value)) {
+          add(i, ':style binding with a non-custom-property value (use a class or a --custom-property)', line)
+        }
+      }
+      // A `<style>` element only matters in served static HTML; in a `.vue` SFC
+      // it is compiled to a 'self' CSS asset.
+      if (ext === '.html' && /<style[\s>]/i.test(line)) {
+        add(i, '<style> element in static HTML', line)
+      }
+    }
+
+    if (YAML_EXTS.has(ext)) {
+      if (/(^|[\s<])style\s*=\s*["']/.test(line)) {
+        add(i, 'inline style= in content (rendered via v-html)', line)
+      }
+    }
+
+    if (SCRIPT_EXTS.has(ext)) {
+      if (/\.setAttribute\(\s*['"]style['"]/.test(line)) {
+        add(i, "setAttribute('style', …) writes the style attribute", line)
+      }
+      if (/\.cssText\s*=[^=]/.test(line)) {
+        add(i, '.cssText assignment writes the style attribute', line)
+      }
+    }
+  }
+  return violations
+}
+
+// --- CLI -------------------------------------------------------------------
+
+const CHECK_EXTS = new Set([...MARKUP_EXTS, ...SCRIPT_EXTS, ...YAML_EXTS])
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', 'generated', 'test', '__tests__'])
+
+// Strict-CSP surfaces only. standalone-form is excluded by design.
+const TARGETS = [
+  'apps/boekhouding-frontend/src',
+  'apps/boekhouding-frontend/index.html',
+  'packages/assessment-core/src',
+  'sources',
+]
+
+function collectFiles(absPath, root) {
+  const st = statSync(absPath)
+  if (st.isFile()) return CHECK_EXTS.has(extname(absPath)) ? [absPath] : []
+  const out = []
+  for (const entry of readdirSync(absPath, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue
+      out.push(...collectFiles(join(absPath, entry.name), root))
+    } else if (CHECK_EXTS.has(extname(entry.name))) {
+      out.push(join(absPath, entry.name))
+    }
+  }
+  return out
+}
+
+function main() {
+  const root = fileURLToPath(new URL('..', import.meta.url))
+  const findings = []
+  for (const target of TARGETS) {
+    const abs = join(root, target)
+    let files
+    try {
+      files = collectFiles(abs, root)
+    } catch {
+      continue // optional target (e.g. sources/) absent in this checkout
+    }
+    for (const file of files) {
+      const violations = findInlineStyleViolations(readFileSync(file, 'utf8'), extname(file))
+      for (const v of violations) findings.push({ file: file.slice(root.length), ...v })
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log('✓ CSP inline-style guard: no CSP-unsafe inline styles found.')
+    return
+  }
+
+  console.error(`✗ CSP inline-style guard: ${findings.length} violation(s) found.\n`)
+  console.error('These would break `style-src \'self\'` (issue #326). Move them to a')
+  console.error('CSS class, or — for a dynamic value — a `--custom-property`.\n')
+  for (const f of findings) {
+    console.error(`  ${f.file}:${f.line}  ${f.reason}`)
+    console.error(`      ${f.snippet}`)
+  }
+  process.exitCode = 1
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/scripts/check-inline-styles.test.mjs
+++ b/scripts/check-inline-styles.test.mjs
@@ -1,0 +1,98 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { findInlineStyleViolations } from './check-inline-styles.mjs'
+
+// A `.vue`/`.html` literal `style=` attribute is parsed as an inline style and
+// is blocked by `style-src 'self'` — must be flagged.
+test('flags a literal style= attribute in a .vue template', () => {
+  const violations = findInlineStyleViolations('<div style="color: red"></div>', '.vue')
+  assert.equal(violations.length, 1)
+  assert.match(violations[0].reason, /literal/i)
+  assert.equal(violations[0].line, 1)
+})
+
+// Vue applies `:style` via the CSSOM (not blocked by CSP), but project policy
+// (#326) routes every dynamic value through a class / custom property, so a
+// value-bearing binding is still a violation.
+test('flags a value-bearing :style object binding', () => {
+  const violations = findInlineStyleViolations('<div :style="{ color: x }"></div>', '.vue')
+  assert.equal(violations.length, 1)
+  assert.match(violations[0].reason, /:style/i)
+})
+
+test('flags a :style bound to a non-literal expression', () => {
+  const violations = findInlineStyleViolations('<div :style="someStyleObject"></div>', '.vue')
+  assert.equal(violations.length, 1)
+})
+
+test('flags v-bind:style the same as :style', () => {
+  const violations = findInlineStyleViolations('<div v-bind:style="{ width: w }"></div>', '.vue')
+  assert.equal(violations.length, 1)
+})
+
+// The sanctioned escape hatch: a `:style` whose object only sets CSS custom
+// properties (`--foo`). The actual cascade lives in a `'self'` stylesheet.
+test('allows a :style binding that only sets custom properties', () => {
+  const ok = findInlineStyleViolations(`<div :style="{ '--comment-top': entry.top + 'px' }"></div>`, '.vue')
+  assert.equal(ok.length, 0)
+})
+
+test('allows a :style binding with multiple custom properties', () => {
+  const ok = findInlineStyleViolations(`<div :style="{ '--a': a, '--b': b }"></div>`, '.vue')
+  assert.equal(ok.length, 0)
+})
+
+test('does not flag a plain class attribute', () => {
+  const ok = findInlineStyleViolations('<div class="form-field__fria-tag"></div>', '.vue')
+  assert.equal(ok.length, 0)
+})
+
+// `<style>` SFC blocks are compiled to `'self'` CSS assets by Vite, so they are
+// not a runtime inline style and must not be flagged.
+test('does not flag a <style> block in a .vue SFC', () => {
+  const ok = findInlineStyleViolations('<style>\n.foo { color: red }\n</style>', '.vue')
+  assert.equal(ok.length, 0)
+})
+
+// A `<style>` element in served static HTML is a real inline stylesheet blocked
+// by `style-src 'self'`.
+test('flags a <style> element in an .html file', () => {
+  const violations = findInlineStyleViolations('<head><style>.a{}</style></head>', '.html')
+  assert.equal(violations.length, 1)
+  assert.match(violations[0].reason, /<style>/i)
+})
+
+// YAML content is rendered via `v-html`; an inline style there reaches the DOM
+// as a parsed inline style.
+test('flags inline style= inside YAML content', () => {
+  const yaml = `description: |\n  <span style="font-weight: bold">x</span>\n`
+  const violations = findInlineStyleViolations(yaml, '.yaml')
+  assert.equal(violations.length, 1)
+  assert.equal(violations[0].line, 2)
+})
+
+// Programmatic mutation that writes the *style attribute* is CSP-relevant.
+test('flags setAttribute("style", ...) in TypeScript', () => {
+  const violations = findInlineStyleViolations(`el.setAttribute('style', 'color:red')`, '.ts')
+  assert.equal(violations.length, 1)
+})
+
+test('flags cssText assignment in TypeScript', () => {
+  const violations = findInlineStyleViolations('el.style.cssText = "color:red"', '.ts')
+  assert.equal(violations.length, 1)
+})
+
+// CSSOM custom-property writes are not blocked by CSP — the project's own
+// pattern (autoGrowTextarea) — must not be flagged.
+test('allows el.style.setProperty for a custom property', () => {
+  const ok = findInlineStyleViolations(`el.style.setProperty('--autogrow-height', '12px')`, '.ts')
+  assert.equal(ok.length, 0)
+})
+
+test('reports the correct 1-based line number for a multi-line file', () => {
+  const content = '<template>\n  <div>\n    <p style="margin:0">x</p>\n  </div>\n</template>'
+  const violations = findInlineStyleViolations(content, '.vue')
+  assert.equal(violations.length, 1)
+  assert.equal(violations[0].line, 3)
+})


### PR DESCRIPTION
## Context

De implementatie van #326 (inline styles → CSS-classes om `style-src 'unsafe-inline'` te schrappen) is al gemerged in **PR #348** (commit `d8dfae5`): de FRIA-tag, het ExportMenu-paneel, FormField/TaskSection/AppBanner/NavHeader, de `v-html`-strings én de IAMA-content in `sources/iama.yaml` zijn omgezet, de twee dynamische waarden (`--comment-top`, `--autogrow-height`) lopen via CSSOM-custom-properties, en `containers/frontend/default.conf` staat op `style-src 'self'`. De issue was alleen nooit gesloten (de commit gebruikte `(#326)` i.p.v. een `Closes`-keyword).

Deze PR voegt geen nieuwe omzettingen toe, maar maakt de hardening **duurzaam en geverifieerd**:

1. een **regressie-guard** die CI laat falen als er weer een CSP-onveilige inline style insluipt;
2. een **browser-verificatie** onder de echte strikte CSP.

## Regressie-guard

`scripts/check-inline-styles.mjs` scant de strikte-CSP-oppervlakken — `apps/boekhouding-frontend/src`, `packages/assessment-core/src` en `sources/` — en faalt op:

- een literal `style="…"`-attribuut (geparste inline style → geblokkeerd door `style-src 'self'`);
- een `<style>`-element in statische HTML;
- een `style=` in `v-html`/YAML-content;
- een **value-bearing** `:style`-binding.

Toegestaan blijft de gesanctioneerde uitzondering: een `:style` die **uitsluitend** `--custom-properties` zet. Vue patcht die via de CSSOM, en CSSOM-schrijfacties vallen niet onder `style-src` (zie verificatie). `apps/standalone-form` staat bewust buiten scope: die wordt als één geïnlined bestand (viteSingleFile) geserveerd met `'unsafe-inline'`.

Aanroep: `pnpm check:csp` (draait eerst de `node:test`-zelftest, dan de guard). Toegevoegd als fail-fast CI-stap in `test.yaml`. TDD: 14 unit-tests (rood → groen) en end-to-end bewezen tegen een geplante violation.

## Browser-verificatie (strikte `style-src 'self'`)

Productie-builds met externe CSS, geserveerd onder de exacte CSP, gedreven met Playwright:

- **Standalone form** (zelfde `assessment-core`-componenten als de boekhouding-app): landing, DPIA-shell, volledig DPIA-formulier, de markdown-preview-renderer (kop, vet/cursief, allowlist-link, lijsten, blockquote, code, gesaneerde task-list-checkboxes), herhaalbare groepen, selects, radios, en de IAMA-accordeons met de omgezette `.content-tag-link`/`.content-alert--flex`-content → **0 console-meldingen, en 0 elementen met een `style`-attribuut in de gerenderde DOM.**
- **CommentPanel-patroon** (`--comment-top`) bewezen CSP-veilig met een zelf-validerend micro-experiment onder `style-src 'self'`:
  - `el.style.setProperty('--comment-top','123px')` → toegepast, **geen** violation;
  - `el.setAttribute('style', …)` → **geblokkeerd** met een `style-src-attr`-violation (bewijst dat de meting gevoelig is).

De live boekhouding-shell liet zich niet in de browser laden omdat keycloak-js zonder draaiende Keycloak app-breed redirect (geen CSP-kwestie); de gedeelde render-oppervlakken zijn via de standalone volledig gedekt, de boekhouding-only views zijn statisch schoon en door de guard afgedekt.

## Testen voor de reviewer

```bash
pnpm check:csp        # zelftest + guard, exit 0 op een schone tree
```

Closes #326