### PR TITLE
fix(versie): toon CalVer-tag op standalone /zonder-account/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ build) staan kort onder "Onder de motorkap".
 
 ## [Unreleased]
 
+### Opgelost
+
+* Het standalone formulier op `/zonder-account/` toonde in productie
+  "ontwikkel" met een commit in plaats van de release-versie; het laat nu
+  dezelfde versie zien als de statuspagina.
+
 ## [2026.6.20] - 2026-06-20
 
 ### Toegevoegd

--- a/apps/standalone-form/env.d.ts
+++ b/apps/standalone-form/env.d.ts
@@ -1,4 +1,3 @@
 /// <reference types="vite/client" />
 
-declare const __APP_TAG__: string
-declare const __APP_COMMIT__: string
+declare const __APP_VERSION__: string

--- a/apps/standalone-form/src/components/LandingView.vue
+++ b/apps/standalone-form/src/components/LandingView.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { AppBanner, UiButton, ExportPdfInfo, FormType, type NavigationFunctions } from '@overheid-assessment/core'
-import { formatBuildVersion } from '@/version'
 
 const props = defineProps<{
   navigation: NavigationFunctions
@@ -12,7 +11,7 @@ const emit = defineEmits<{
   startFresh: [type: FormType]
 }>()
 
-const appVersion = formatBuildVersion(__APP_TAG__, __APP_COMMIT__)
+const appVersion = __APP_VERSION__
 
 interface AssessmentCard {
   type: FormType

--- a/apps/standalone-form/src/version.ts
+++ b/apps/standalone-form/src/version.ts
@@ -1,8 +1,12 @@
-// Build-time version constants (__APP_TAG__/__APP_COMMIT__) are injected via
-// Vite `define`; both default to the sentinel 'dev' when not baked in. The
-// channel is derived from those signals: a CalVer tag means a release, an
-// untagged build with a real commit is a development build, and the bare
-// local build has neither.
+// Formats the display version from a build-time tag and commit, both defaulting
+// to the sentinel 'dev' when not baked in. Called by vite.config.ts to inline
+// the result as __APP_VERSION__. The channel is derived from those signals: a
+// CalVer tag means a release, an untagged build with a real commit is a
+// development build, and the bare local build has neither.
+//
+// The untagged form deliberately renders as "ontwikkel (commit <7-hex>)" so the
+// production overlay (containers/frontend/overlay.Dockerfile) can sed-replace it
+// with the CalVer tag, which is unknown when the acceptatie image is built.
 export function formatBuildVersion(tag: string, commit: string): string {
   if (tag !== 'dev') return tag
   if (commit !== 'dev') return `ontwikkel (commit ${commit})`

--- a/apps/standalone-form/vite.config.ts
+++ b/apps/standalone-form/vite.config.ts
@@ -4,6 +4,16 @@ import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import { viteSingleFile } from 'vite-plugin-singlefile'
+import { formatBuildVersion } from './src/version'
+
+// Resolve the full display version at build time so it lands in the single-file
+// bundle as one string literal. The production overlay (containers/frontend/
+// overlay.Dockerfile) can then sed-replace the baked "ontwikkel (commit …)"
+// marker with the CalVer tag, since the tag is unknown when this image is built.
+const appVersion = formatBuildVersion(
+  process.env.RELEASE_TAG ?? 'dev',
+  (process.env.GIT_SHA ?? 'dev').slice(0, 7),
+)
 
 /** Inline favicon as data-URI in built HTML so the output is truly a single file. */
 function inlineFavicon(): Plugin {
@@ -49,8 +59,7 @@ export default defineConfig(({ mode }) => ({
   ],
   base: '/',
   define: {
-    __APP_TAG__: JSON.stringify(process.env.RELEASE_TAG ?? 'dev'),
-    __APP_COMMIT__: JSON.stringify((process.env.GIT_SHA ?? 'dev').slice(0, 7)),
+    __APP_VERSION__: JSON.stringify(appVersion),
   },
   resolve: {
     alias: {

--- a/apps/standalone-form/vitest.config.ts
+++ b/apps/standalone-form/vitest.config.ts
@@ -8,8 +8,7 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   define: {
-    __APP_TAG__: JSON.stringify('v2026.6.14'),
-    __APP_COMMIT__: JSON.stringify('abc1234'),
+    __APP_VERSION__: JSON.stringify('v2026.6.14'),
   },
   resolve: {
     alias: {

--- a/containers/frontend/overlay.Dockerfile
+++ b/containers/frontend/overlay.Dockerfile
@@ -4,4 +4,9 @@ ARG TAG=dev
 ARG COMMIT=dev
 USER root
 RUN printf '{"version":"%s","commit":"%s","channel":"productie"}\n' "$TAG" "$COMMIT" > /usr/share/nginx/html/version.json
+# The standalone form bakes its version into the single-file HTML at build time,
+# when the CalVer tag isn't known yet. Patch the baked "ontwikkel (commit <sha>)"
+# marker with the release tag so /zonder-account/ shows the same version as the
+# status page.
+RUN sed -i "s|ontwikkel (commit [0-9a-f]\{7\})|${TAG}|g" /usr/share/nginx/html/zonder-account/index.html
 USER 101


### PR DESCRIPTION
## Probleem

Het standalone formulier op `/zonder-account/` toont in productie
`ontwikkel (commit …)` in plaats van de release-versie (bijv. `v2026.6.20`),
terwijl de statuspagina (`/status`) de versie wél correct toont.

## Oorzaak

De twee plekken gebruiken verschillende versie-mechanismen, en maar één krijgt de CalVer-tag:

- **Statuspagina** (boekhouding-frontend) leest `version.json` op **runtime**. De productie-overlay herschrijft dat bestand ná promotie met de tag → correct.
- **Standalone** bakt de versie op **build-time** in (Vite `define`). De frontend-`Containerfile` bouwt het zónder `RELEASE_TAG` (die bestaat nog niet bij de acceptatie-build), en productie *promoot* dat image zonder herbouw. Dus blijft de tag `dev`.

De downloadbare standalone (release-asset uit `release.yaml`) was wél correct — die wordt apart mét `RELEASE_TAG` gebouwd. Alleen de in de container geserveerde kopie was fout.

## Oplossing

De volledige versiestring wordt nu als **één string-literal** in de single-file HTML gebakken (`__APP_VERSION__`), zodat de productie-overlay de `ontwikkel (commit <sha>)`-marker met de CalVer-tag kan vervangen — net zoals `version.json` al gepatcht wordt. Geen runtime-fetch, blijft volledig **offline-puur**. Acceptatie blijft bewust de commit tonen.

| Bestand | Wijziging |
|---|---|
| `vite.config.ts` | Berekent de volledige versiestring op build-time → inline als `__APP_VERSION__` |
| `LandingView.vue` | Gebruikt `__APP_VERSION__` direct i.p.v. runtime-formatting |
| `env.d.ts` / `vitest.config.ts` | `__APP_TAG__`/`__APP_COMMIT__` → `__APP_VERSION__` |
| `version.ts` | Comment bijgewerkt; `formatBuildVersion` ongewijzigd en nog steeds getest |
| `overlay.Dockerfile` | `sed` vervangt `ontwikkel (commit <7-hex>)` → `${TAG}` in `zonder-account/index.html` |

## Verificatie

- **Acceptatie-build** (geen `RELEASE_TAG`): bakt `ontwikkel (commit abc1234)` als één literal ✓
- **Overlay-`sed`** op die HTML: marker → 0, `v2026.6.20` aanwezig ✓
- **Release-asset-build** (`RELEASE_TAG` gezet): bakt direct `v2026.6.20` ✓
- **Tests**: 71 passed, **100% coverage** behouden · `vue-tsc --noEmit` exit 0 ✓

## Let op

Werkt pas bij de **volgende productie-release** (de overlay draait tijdens `deploy-productie`). Het reeds gedeployede `v2026.6.20`-image is vóór deze fix gebouwd; de live site verandert pas na een nieuwe release of re-promotie van die tag.