### PR TITLE
feat(versiebeheer): content-versiebeheer van vragenlijst-bronnen (epic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ sources/generated/
 .claude/settings.local.json
 .claude/worktrees/
 .superpowers/
+docs/superpowers/
 
 # Local podman compose overrides (per-machine port shifts etc.)
 containers/compose.override.yaml

--- a/packages/assessment-core/src/index.ts
+++ b/packages/assessment-core/src/index.ts
@@ -77,3 +77,9 @@ export { autoGrowTextarea } from './utils/autoGrowTextarea'
 
 // Security
 export { installTrustedTypesPolicy } from './security/trustedTypes'
+
+// Content versioning
+export { parseUrn, isPrerelease, coarseVersion, compareVersions } from './versioning/semver'
+export type { ParsedUrn, Channel } from './versioning/semver'
+export { versionsForType, latestOfficialVersion, findNewerVersion } from './versioning/manifest'
+export type { SourceManifest, ManifestType, ManifestVersion } from './versioning/manifest'

--- a/packages/assessment-core/src/stores/schemas.ts
+++ b/packages/assessment-core/src/stores/schemas.ts
@@ -4,6 +4,7 @@ import { DPIA, FormType } from '../models/dpia'
 import * as t from 'io-ts'
 import { isRight } from 'fp-ts/lib/Either'
 import { createConclusionTask } from '../utils/taskUtils'
+import { coarseVersion } from '../versioning/semver'
 
 // Shared "Afronding" description for the DPIA and IAMA conclusion steps.
 const AFRONDING_DESCRIPTION =
@@ -98,7 +99,9 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
   function getUrn(namespace: FormType): string {
     const schema = getSchema(namespace)
     if (!schema) throw new Error(`Schema not loaded for namespace: ${namespace}`)
-    return `${schema.urn}:${schema.version}`
+    // Coarsen to MAJOR.MINOR: the output schema constrains metadata.urn to that form,
+    // so a 3-segment or -concept source version must not leak into the stamped urn.
+    return `${schema.urn}:${coarseVersion(schema.version)}`
   }
 
   return {

--- a/packages/assessment-core/src/versioning/manifest.ts
+++ b/packages/assessment-core/src/versioning/manifest.ts
@@ -1,0 +1,50 @@
+// Runtime view of the source manifest (mirrors schemas/source-manifest.v1.schema.json)
+// plus pure query helpers used by version-upgrade detection and the transparency page.
+
+import { compareVersions, isPrerelease, type Channel } from './semver'
+
+export interface ManifestVersion {
+  version: string
+  channel: Channel
+  file: string
+  releasedAt?: string
+  changelog?: string[]
+}
+
+export interface ManifestType {
+  latestOfficial: string
+  begrippenkader: string
+  enrichOncePerPage?: boolean
+  versions: ManifestVersion[]
+}
+
+export interface SourceManifest {
+  schemaVersion: number
+  types: Record<string, ManifestType>
+}
+
+// Versions for a type, newest first. Empty for an unknown type.
+export function versionsForType(manifest: SourceManifest, type: string): ManifestVersion[] {
+  const def = manifest.types[type]
+  if (!def) return []
+  return [...def.versions].sort((a, b) => compareVersions(b.version, a.version))
+}
+
+// The version string unpinned consumers resolve to, or undefined for an unknown type.
+export function latestOfficialVersion(manifest: SourceManifest, type: string): string | undefined {
+  return manifest.types[type]?.latestOfficial
+}
+
+// The newest version strictly above `pinned`, considering concept versions only
+// when `allowConcept` is set. Returns undefined when nothing newer is available.
+export function findNewerVersion(
+  manifest: SourceManifest,
+  type: string,
+  pinned: string,
+  allowConcept = false,
+): ManifestVersion | undefined {
+  const candidates = versionsForType(manifest, type).filter(
+    (v) => (allowConcept || !isPrerelease(v.version)) && compareVersions(v.version, pinned) > 0,
+  )
+  return candidates[0]
+}

--- a/packages/assessment-core/src/versioning/semver.ts
+++ b/packages/assessment-core/src/versioning/semver.ts
@@ -1,0 +1,88 @@
+// Semver-with-prerelease helpers for content-version identifiers.
+// Versions look like '3.0', '3.1.0' or '3.1.0-concept.2'; the URN that carries
+// them looks like 'urn:nl:dpia:3.1.0-concept.2'. The stored metadata.urn stays
+// coarse (MAJOR.MINOR); the full version lives in the manifest and the pin.
+
+export type Channel = 'official' | 'concept'
+
+export interface ParsedUrn {
+  type: string
+  version: string
+  channel: Channel
+}
+
+// Deliberately looser than the authoring gate: the JSON schemas (assessment-definition,
+// source-manifest) only allow a `-concept[.N]` prerelease, but this parser/comparator
+// accepts any semver prerelease so the comparator stays general. The schemas are the
+// canonical authoring grammar; this is the permissive runtime view.
+const VERSION = String.raw`\d+(?:\.\d+){0,2}(?:-[0-9A-Za-z.-]+)?`
+const URN_RE = new RegExp(`^urn:nl:([a-z]+):(${VERSION})$`)
+
+// Parse a versioned URN into its type, full version and derived channel.
+// Returns null when the input is empty or not a well-formed nl-gov assessment URN.
+export function parseUrn(urn: string | null | undefined): ParsedUrn | null {
+  if (!urn) return null
+  const match = URN_RE.exec(urn)
+  if (!match) return null
+  const version = match[2]
+  return { type: match[1], version, channel: isPrerelease(version) ? 'concept' : 'official' }
+}
+
+// Whether a version carries a prerelease (concept) suffix.
+export function isPrerelease(version: string): boolean {
+  return version.includes('-')
+}
+
+// Reduce a full version to the MAJOR.MINOR form stamped into metadata.urn.
+export function coarseVersion(version: string): string {
+  const parts = version.split('-')[0].split('.')
+  return `${parts[0]}.${parts[1] ?? '0'}`
+}
+
+function splitVersion(version: string): { main: number[]; pre: string[] | null } {
+  const dash = version.indexOf('-')
+  const mainStr = dash === -1 ? version : version.slice(0, dash)
+  const pre = dash === -1 ? null : version.slice(dash + 1).split('.')
+  const main = mainStr.split('.').map(Number)
+  while (main.length < 3) main.push(0)
+  return { main, pre }
+}
+
+// Compare two prerelease identifiers per semver: numeric identifiers numerically,
+// numeric below alphanumeric, otherwise ASCII order.
+function compareIdentifiers(a: string, b: string): number {
+  const aNum = /^\d+$/.test(a)
+  const bNum = /^\d+$/.test(b)
+  if (aNum && bNum) {
+    const diff = Number(a) - Number(b)
+    return diff === 0 ? 0 : diff < 0 ? -1 : 1
+  }
+  if (aNum) return -1
+  if (bNum) return 1
+  if (a === b) return 0
+  return a < b ? -1 : 1
+}
+
+function comparePre(a: string[], b: string[]): number {
+  const len = Math.min(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    const cmp = compareIdentifiers(a[i], b[i])
+    if (cmp !== 0) return cmp
+  }
+  if (a.length === b.length) return 0
+  return a.length < b.length ? -1 : 1
+}
+
+// Compare two version strings (-1 | 0 | 1). A missing patch is treated as 0 and a
+// prerelease ranks below its corresponding release.
+export function compareVersions(a: string, b: string): number {
+  const va = splitVersion(a)
+  const vb = splitVersion(b)
+  for (let i = 0; i < 3; i++) {
+    if (va.main[i] !== vb.main[i]) return va.main[i] < vb.main[i] ? -1 : 1
+  }
+  if (va.pre === null && vb.pre === null) return 0
+  if (va.pre === null) return 1
+  if (vb.pre === null) return -1
+  return comparePre(va.pre, vb.pre)
+}

--- a/packages/assessment-core/test/cov/manifest.cov.test.ts
+++ b/packages/assessment-core/test/cov/manifest.cov.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import {
+  versionsForType,
+  latestOfficialVersion,
+  findNewerVersion,
+  type SourceManifest,
+} from '../../src/versioning/manifest'
+
+const manifest: SourceManifest = {
+  schemaVersion: 1,
+  types: {
+    dpia: {
+      latestOfficial: '3.0',
+      begrippenkader: 'begrippenkader_dpia.yaml',
+      versions: [
+        { version: '3.0', channel: 'official', file: 'dpia.yaml' },
+        { version: '2.5', channel: 'official', file: 'dpia-2.5.yaml' },
+        { version: '3.1.0-concept.2', channel: 'concept', file: 'dpia-3.1.yaml' },
+      ],
+    },
+    iama: {
+      latestOfficial: '2.0',
+      begrippenkader: 'begrippenkader_iama.yaml',
+      versions: [{ version: '2.0', channel: 'official', file: 'iama.yaml' }],
+    },
+  },
+}
+
+describe('versionsForType', () => {
+  it('returns the versions sorted newest first', () => {
+    expect(versionsForType(manifest, 'dpia').map((v) => v.version)).toEqual([
+      '3.1.0-concept.2',
+      '3.0',
+      '2.5',
+    ])
+  })
+
+  it('returns an empty list for an unknown type', () => {
+    expect(versionsForType(manifest, 'onbekend')).toEqual([])
+  })
+})
+
+describe('latestOfficialVersion', () => {
+  it('returns the latest official version string', () => {
+    expect(latestOfficialVersion(manifest, 'dpia')).toBe('3.0')
+  })
+
+  it('returns undefined for an unknown type', () => {
+    expect(latestOfficialVersion(manifest, 'onbekend')).toBeUndefined()
+  })
+})
+
+describe('findNewerVersion', () => {
+  it('returns a newer official version', () => {
+    expect(findNewerVersion(manifest, 'dpia', '2.5')?.version).toBe('3.0')
+  })
+
+  it('returns undefined when the pinned version is already the newest', () => {
+    expect(findNewerVersion(manifest, 'dpia', '3.1.0-concept.2', true)).toBeUndefined()
+  })
+
+  it('ignores concept versions unless concepts are allowed', () => {
+    expect(findNewerVersion(manifest, 'dpia', '3.0', false)).toBeUndefined()
+  })
+
+  it('returns a concept version when concepts are allowed', () => {
+    expect(findNewerVersion(manifest, 'dpia', '3.0', true)?.version).toBe('3.1.0-concept.2')
+  })
+
+  it('picks the highest candidate among several', () => {
+    expect(findNewerVersion(manifest, 'dpia', '2.5', true)?.version).toBe('3.1.0-concept.2')
+  })
+
+  it('returns undefined for an unknown type', () => {
+    expect(findNewerVersion(manifest, 'onbekend', '1.0')).toBeUndefined()
+  })
+})

--- a/packages/assessment-core/test/cov/semver.cov.test.ts
+++ b/packages/assessment-core/test/cov/semver.cov.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { parseUrn, isPrerelease, coarseVersion, compareVersions } from '../../src/versioning/semver'
+
+describe('parseUrn', () => {
+  it('parses an official versioned urn into type/version/channel', () => {
+    expect(parseUrn('urn:nl:dpia:3.0')).toEqual({ type: 'dpia', version: '3.0', channel: 'official' })
+  })
+
+  it('parses a concept (prerelease) urn as the concept channel', () => {
+    expect(parseUrn('urn:nl:dpia:3.1.0-concept.2')).toEqual({
+      type: 'dpia',
+      version: '3.1.0-concept.2',
+      channel: 'concept',
+    })
+  })
+
+  it('parses prescan and iama types', () => {
+    expect(parseUrn('urn:nl:prescan:2.0')?.type).toBe('prescan')
+    expect(parseUrn('urn:nl:iama:2.0')?.type).toBe('iama')
+  })
+
+  it('returns null for a bare urn without a version segment', () => {
+    expect(parseUrn('urn:nl:dpia')).toBeNull()
+  })
+
+  it('returns null for a wrong namespace prefix', () => {
+    expect(parseUrn('urn:other:dpia:3.0')).toBeNull()
+  })
+
+  it('returns null for a malformed version', () => {
+    expect(parseUrn('urn:nl:dpia:v3')).toBeNull()
+  })
+
+  it('returns null for undefined, null and empty input', () => {
+    expect(parseUrn(undefined)).toBeNull()
+    expect(parseUrn(null)).toBeNull()
+    expect(parseUrn('')).toBeNull()
+  })
+})
+
+describe('isPrerelease', () => {
+  it('is true when a prerelease suffix is present', () => {
+    expect(isPrerelease('3.1.0-concept.2')).toBe(true)
+  })
+
+  it('is false for two- and three-segment release versions', () => {
+    expect(isPrerelease('3.0')).toBe(false)
+    expect(isPrerelease('3.1.0')).toBe(false)
+  })
+})
+
+describe('coarseVersion', () => {
+  it('pads a single-segment version with minor 0', () => {
+    expect(coarseVersion('3')).toBe('3.0')
+  })
+
+  it('keeps an explicit major.minor', () => {
+    expect(coarseVersion('3.1')).toBe('3.1')
+  })
+
+  it('drops the patch segment', () => {
+    expect(coarseVersion('2.4.7')).toBe('2.4')
+  })
+
+  it('drops a prerelease suffix and patch', () => {
+    expect(coarseVersion('3.1.0-concept.2')).toBe('3.1')
+  })
+})
+
+describe('compareVersions', () => {
+  it('treats a missing patch as zero (3.0 equals 3.0.0)', () => {
+    expect(compareVersions('3.0', '3.0.0')).toBe(0)
+  })
+
+  it('orders by minor', () => {
+    expect(compareVersions('3.0', '3.1')).toBe(-1)
+    expect(compareVersions('3.1', '3.0')).toBe(1)
+  })
+
+  it('orders minor numerically, not lexically (3.2 < 3.10)', () => {
+    expect(compareVersions('3.2', '3.10')).toBe(-1)
+  })
+
+  it('orders by major', () => {
+    expect(compareVersions('2.9', '3.0')).toBe(-1)
+  })
+
+  it('orders by patch', () => {
+    expect(compareVersions('3.1.0', '3.1.1')).toBe(-1)
+  })
+
+  it('ranks a prerelease below its release (concept < final)', () => {
+    expect(compareVersions('3.1.0-concept.2', '3.1.0')).toBe(-1)
+    expect(compareVersions('3.1.0', '3.1.0-concept.2')).toBe(1)
+  })
+
+  it('orders numeric prerelease identifiers numerically (concept.2 < concept.10)', () => {
+    expect(compareVersions('3.1.0-concept.2', '3.1.0-concept.10')).toBe(-1)
+    expect(compareVersions('3.1.0-concept.10', '3.1.0-concept.2')).toBe(1)
+  })
+
+  it('ranks a numeric identifier below an alphanumeric one', () => {
+    expect(compareVersions('3.1.0-1', '3.1.0-alpha')).toBe(-1)
+    expect(compareVersions('3.1.0-alpha', '3.1.0-1')).toBe(1)
+  })
+
+  it('orders alphanumeric identifiers lexically', () => {
+    expect(compareVersions('3.1.0-alpha', '3.1.0-beta')).toBe(-1)
+    expect(compareVersions('3.1.0-beta', '3.1.0-alpha')).toBe(1)
+  })
+
+  it('ranks a smaller set of prerelease fields below a larger set', () => {
+    expect(compareVersions('3.1.0-alpha', '3.1.0-alpha.1')).toBe(-1)
+    expect(compareVersions('3.1.0-alpha.1', '3.1.0-alpha')).toBe(1)
+  })
+
+  it('returns 0 for identical versions including prerelease', () => {
+    expect(compareVersions('3.1.0-concept.2', '3.1.0-concept.2')).toBe(0)
+    expect(compareVersions('3.0', '3.0')).toBe(0)
+  })
+})

--- a/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
+++ b/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
@@ -203,6 +203,18 @@ describe('useSchemaStore', () => {
       expect(store.getUrn(FormType.PRE_SCAN)).toBe('urn:nl:prescan:2.0')
     })
 
+    it('coarsens the version to MAJOR.MINOR so metadata.urn stays output-schema valid', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '3.1.0-concept.2' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '2.0' }),
+      })
+
+      expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.1')
+      expect(store.getUrn(FormType.PRE_SCAN)).toBe('urn:nl:prescan:3.1')
+    })
+
     it('throws when the schema for the namespace is not loaded', () => {
       const store = useSchemaStore()
       expect(() => store.getUrn(FormType.DPIA)).toThrow(

--- a/schemas/assessment-definition.v2.schema.json
+++ b/schemas/assessment-definition.v2.schema.json
@@ -381,8 +381,8 @@
         },
         "version": {
             "type": "string",
-            "description": "The version of the DPIA model, supporting different formats (major, major.minor, or major.minor.patch)",
-            "pattern": "^\\d+(\\.\\d+)?(\\.\\d+)?$"
+            "description": "The version of the DPIA model: major, major.minor or major.minor.patch, optionally with a '-concept[.N]' prerelease suffix for in-development concept versions.",
+            "pattern": "^\\d+(\\.\\d+){0,2}(-concept(\\.\\d+)?)?$"
         },
         "urn": {
             "type": "string",

--- a/schemas/source-manifest.v1.schema.json
+++ b/schemas/source-manifest.v1.schema.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/MinBZK/par-dpia-form/blob/main/schemas/source-manifest.v1.schema.json",
+    "title": "Source Manifest",
+    "description": "Registry of versioned questionnaire source definitions (Pre-scan, DPIA, IAMA) and their channels. The begrippenkader is externally auto-synced and is referenced only as an enrichment input, never versioned here.",
+    "type": "object",
+    "required": ["schemaVersion", "types"],
+    "additionalProperties": false,
+    "properties": {
+        "schemaVersion": {
+            "const": 1,
+            "description": "Version of this manifest format."
+        },
+        "types": {
+            "type": "object",
+            "description": "Assessment types keyed by namespace (prescan, dpia, iama).",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "object",
+                "required": ["latestOfficial", "begrippenkader", "versions"],
+                "additionalProperties": false,
+                "properties": {
+                    "latestOfficial": {
+                        "$ref": "#/$defs/version",
+                        "description": "The version unpinned consumers resolve to. Must be an official-channel entry in versions."
+                    },
+                    "begrippenkader": {
+                        "type": "string",
+                        "description": "Begrippenkader YAML used as enrichment input (not versioned by this manifest)."
+                    },
+                    "enrichOncePerPage": {
+                        "type": "boolean",
+                        "description": "Inject each term definition once per page instead of at every occurrence (IAMA)."
+                    },
+                    "versions": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "required": ["version", "channel", "file"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "version": { "$ref": "#/$defs/version" },
+                                "channel": {
+                                    "enum": ["official", "concept"],
+                                    "description": "official = stable/published; concept = in-development prerelease."
+                                },
+                                "file": {
+                                    "type": "string",
+                                    "description": "Source YAML path, relative to sources/."
+                                },
+                                "releasedAt": {
+                                    "type": "string",
+                                    "description": "ISO date the version was published (optional)."
+                                },
+                                "changelog": {
+                                    "type": "array",
+                                    "description": "Curated, user-facing changes versus the previous version (plain text / markdown).",
+                                    "items": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "$defs": {
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+){0,2}(-concept(\\.\\d+)?)?$"
+        }
+    }
+}

--- a/script/manifest.py
+++ b/script/manifest.py
@@ -1,0 +1,76 @@
+"""Load and validate the source manifest (sources/manifest.yaml).
+
+The manifest is the single source of truth for which questionnaire versions exist,
+their channel, and which version is "latest official" per type. validate_manifest
+performs the structural (JSON Schema) check plus a semantic consistency lint
+(duplicate versions, latestOfficial sanity, referenced files exist). It runs in CI
+via pytest; wiring it into the build pipeline as a hard gate is a later step.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+
+def load_manifest(path: Path) -> dict:
+    with Path(path).open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _highest_official(versions: list[dict]) -> str | None:
+    # Official versions never carry a prerelease suffix, so a numeric tuple orders them.
+    officials = [
+        v["version"] for v in versions if v["channel"] == "official" and "-" not in v["version"]
+    ]
+    if not officials:
+        return None
+    return max(officials, key=lambda s: tuple(int(part) for part in s.split(".")))
+
+
+def validate_manifest(manifest: dict, schema_path: Path, sources_dir: Path) -> list[str]:
+    """Return a list of human-readable problems; empty means the manifest is valid."""
+    schema = json.loads(Path(schema_path).read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    schema_errors = [
+        f"schema: {error.message}" for error in sorted(validator.iter_errors(manifest), key=str)
+    ]
+    if schema_errors:
+        # Semantic checks assume a structurally valid manifest.
+        return schema_errors
+
+    errors: list[str] = []
+    for type_name, type_def in manifest["types"].items():
+        version_list = type_def["versions"]
+
+        seen: set[str] = set()
+        for version in version_list:
+            if version["version"] in seen:
+                errors.append(f"{type_name}: duplicate version '{version['version']}'")
+            seen.add(version["version"])
+
+        versions = {version["version"]: version for version in version_list}
+        latest = type_def["latestOfficial"]
+        if latest not in versions:
+            errors.append(f"{type_name}: latestOfficial '{latest}' is not in versions")
+        elif versions[latest]["channel"] != "official":
+            errors.append(f"{type_name}: latestOfficial '{latest}' is not an official version")
+        else:
+            highest = _highest_official(version_list)
+            if highest is not None and highest != latest:
+                errors.append(
+                    f"{type_name}: latestOfficial '{latest}' is below highest official '{highest}'"
+                )
+
+        if not (sources_dir / type_def["begrippenkader"]).exists():
+            errors.append(
+                f"{type_name}: begrippenkader file '{type_def['begrippenkader']}' does not exist"
+            )
+
+        for version in version_list:
+            if not (sources_dir / version["file"]).exists():
+                errors.append(f"{type_name}: source file '{version['file']}' does not exist")
+    return errors

--- a/script/tests/test_manifest.py
+++ b/script/tests/test_manifest.py
@@ -1,0 +1,79 @@
+"""Tests for the source-manifest loader and consistency lint."""
+
+import copy
+from pathlib import Path
+
+from manifest import load_manifest, validate_manifest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MANIFEST_PATH = REPO_ROOT / "sources" / "manifest.yaml"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "source-manifest.v1.schema.json"
+SOURCES_DIR = REPO_ROOT / "sources"
+
+
+def test_real_manifest_loads_with_all_types():
+    manifest = load_manifest(MANIFEST_PATH)
+    assert set(manifest["types"]) == {"prescan", "dpia", "iama"}
+
+
+def test_real_manifest_is_valid():
+    manifest = load_manifest(MANIFEST_PATH)
+    assert validate_manifest(manifest, SCHEMA_PATH, SOURCES_DIR) == []
+
+
+def test_flags_missing_source_file():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["versions"][0]["file"] = "does-not-exist.yaml"
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert any("does-not-exist.yaml" in e for e in errors)
+
+
+def test_flags_latest_official_absent():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["latestOfficial"] = "9.9"
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert any("latestOfficial '9.9'" in e for e in errors)
+
+
+def test_flags_latest_official_pointing_at_concept():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["versions"].append(
+        {"version": "3.1.0-concept.1", "channel": "concept", "file": "dpia.yaml"}
+    )
+    broken["types"]["dpia"]["latestOfficial"] = "3.1.0-concept.1"
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert any("not an official version" in e for e in errors)
+
+
+def test_schema_violation_short_circuits_semantic_checks():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["versions"][0]["version"] = "v3-bogus!"
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert errors
+    assert all(e.startswith("schema:") for e in errors)
+
+
+def test_flags_duplicate_version():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["versions"].append(
+        {"version": "3.0", "channel": "concept", "file": "dpia.yaml"}
+    )
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert any("duplicate" in e.lower() and "3.0" in e for e in errors)
+
+
+def test_flags_missing_begrippenkader():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["begrippenkader"] = "begrippenkader_dpai.yaml"  # typo
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert any("begrippenkader_dpai.yaml" in e for e in errors)
+
+
+def test_flags_stale_latest_official():
+    broken = copy.deepcopy(load_manifest(MANIFEST_PATH))
+    broken["types"]["dpia"]["versions"].append(
+        {"version": "3.1", "channel": "official", "file": "dpia.yaml"}
+    )
+    # latestOfficial stays 3.0 while a higher official 3.1 now exists.
+    errors = validate_manifest(broken, SCHEMA_PATH, SOURCES_DIR)
+    assert any("latestOfficial" in e and "3.1" in e for e in errors)

--- a/script/tests/test_schema_validation.py
+++ b/script/tests/test_schema_validation.py
@@ -72,3 +72,42 @@ def test_validator_rejects_urn_violating_pattern(tmp_path):
 
     assert is_valid is False
     assert errors
+
+
+def _validate_with_version(tmp_path: Path, version: str):
+    source = dict(VALID_SOURCE)
+    source["version"] = version
+    yaml_path = _write_yaml(tmp_path, source)
+    validator = SchemaValidator(REPO_ROOT)
+    return validator.validate_yaml(yaml_path, SCHEMA_PATH)
+
+
+def test_validator_accepts_concept_prerelease_version(tmp_path):
+    # The continuous concept file declares 'X.Y.Z-concept'; the build stamps the
+    # iteration. Both forms must validate or run_all aborts before generation.
+    is_valid, errors, _ = _validate_with_version(tmp_path, "3.1.0-concept")
+    assert is_valid is True, errors
+
+
+def test_validator_accepts_concept_iteration_version(tmp_path):
+    is_valid, errors, _ = _validate_with_version(tmp_path, "3.1.0-concept.4")
+    assert is_valid is True, errors
+
+
+def test_validator_still_accepts_release_versions(tmp_path):
+    for version in ("2", "3.0", "3.1.0"):
+        is_valid, errors, _ = _validate_with_version(tmp_path, version)
+        assert is_valid is True, f"{version}: {errors}"
+
+
+def test_validator_rejects_garbage_version(tmp_path):
+    is_valid, errors, _ = _validate_with_version(tmp_path, "v3-bogus!")
+    assert is_valid is False
+    assert errors
+
+
+def test_validator_rejects_non_concept_prerelease(tmp_path):
+    # -concept is the only authoring-allowed prerelease channel; -alpha/-rc must fail.
+    for version in ("3.1.0-alpha", "3.1.0-rc.1", "3.1.0-beta.2"):
+        is_valid, _, _ = _validate_with_version(tmp_path, version)
+        assert is_valid is False, f"{version} should be rejected"

--- a/sources/manifest.yaml
+++ b/sources/manifest.yaml
@@ -1,0 +1,37 @@
+# Registry of versioned questionnaire sources. Single source of truth for which
+# versions exist, their channel, and which version is "latest official" per type.
+# The begrippenkader is externally auto-synced and is referenced only as an
+# enrichment input here -- it is never versioned by this manifest.
+#
+# Files currently keep their original sources/<type>.yaml location; the move to
+# sources/<type>/<version>.yaml is a separate, later step.
+schemaVersion: 1
+types:
+  prescan:
+    latestOfficial: "2.0"
+    begrippenkader: begrippenkader_dpia.yaml
+    versions:
+      - version: "2.0"
+        channel: official
+        file: prescan.yaml
+        changelog:
+          - "Eerste gepubliceerde Pre-scan DPIA v2.0."
+  dpia:
+    latestOfficial: "3.0"
+    begrippenkader: begrippenkader_dpia.yaml
+    versions:
+      - version: "3.0"
+        channel: official
+        file: dpia.yaml
+        changelog:
+          - "DPIA Rapportagemodel Rijksdienst v3.0."
+  iama:
+    latestOfficial: "2.0"
+    begrippenkader: begrippenkader_iama.yaml
+    enrichOncePerPage: true
+    versions:
+      - version: "2.0"
+        channel: official
+        file: iama.yaml
+        changelog:
+          - "Impact Assessment Mensenrechten en Algoritmes v2.0."


### PR DESCRIPTION
## Epic: content-versiebeheer van vragenlijst-bronnen

Integratie-branch voor het **gefaseerd** invoeren van content-versiebeheer (Pre-scan/DPIA/IAMA): expliciete versies, concept-kanaal, per-assessment pinning, "nieuwere versie"-detectie + migratie, en een transparante modeloverzichtspagina. `main` blijft schoon; elke fase als sub-PR.

### Aanbevolen review-volgorde

**Stack A — Fase 2 core (gestapeld):**
1. **#408** — versie-bewuste `schemaStore`-registry (fundament)
2. **#409** — D1 (officieel coarse / concept precies) + canonical-urn-consistentie
3. **#410** — per-assessment **pin-kolom** + migratie 0004 + security-hardening *(jouw review-punt)*

**Stack B — Fase 1 build (gestapeld):**
4. **#411** — `build_sources.py` (manifest-gedreven multi-versie build, additief)
5. **#412** — buildsites omhangen naar `build_sources.py` + platte drop-in *(byte-identiek geverifieerd; raakt deploy-workflows)*

**Op stack B:**
6. **#413** — Fase 4: `/modellen` transparantiepagina (publiek, RVO, 100% getest)

**Los:** **#407** — afstemmingsplan (doc, voor het team)

### Status per fase
- [x] Fase 0 + manifest-fundament (#405, gemerged)
- [x] Fase 2a registry (#408) · D1+canonical (#409) · Fase 2b pin (#410) — core 1227 + backend 432 @ 100%
- [x] Fase 1a build_sources (#411) · Fase 1b buildsites (#412) — python 58, byte-identiek, actionlint groen
- [x] Fase 4 /modellen (#413) — frontend 829 @ 100%
- [x] Review-pass Fase 2 (13 bevindingen verwerkt) + review-pass Fase 1/4 (loopt)
- [ ] **resolve-by-pin** (editor laadt gepinde versie via registry + getUrn pin-bewust) — fixt latente urn-drift; dormant tot een 2e versie bestaat
- [ ] **Fase 3** — versie kiezen (project-default + per-assessment override op create)
- [ ] **Fase 5** — `useVersionUpgrade` detectie + "nieuwere versie"-banner
- [ ] **Manifest afslanken (DRY)** + bronbestand-verhuizing (`sources/<type>/<versie>.yaml`) — nodig bij de 2e versie
- [ ] Fase 6 (concept-kanaal/gating) · Fase 7 (migratie-engine) · Fase 8 ("terug")

### Stand
De **multi-versie build is nu actief** (#412): elke build levert geneste per-versie output + `manifest.json`. `/modellen` (#413) consumeert dat al. resolve-by-pin / picker / detectie zijn de volgende stappen — gedrag-loos tot er een echte 2e versie (bv. een DPIA-concept) aan het manifest wordt toegevoegd; de infrastructuur staat klaar.
