### PR TITLE
feat(versiebeheer): versie-bewuste schemaStore (Fase 2a)

### DIFF
--- a/packages/assessment-core/src/stores/schemas.ts
+++ b/packages/assessment-core/src/stores/schemas.ts
@@ -5,30 +5,34 @@ import * as t from 'io-ts'
 import { isRight } from 'fp-ts/lib/Either'
 import { createConclusionTask } from '../utils/taskUtils'
 import { coarseVersion } from '../versioning/semver'
+import { namespaceFromUrn } from '../utils/importDetect'
 
 // Shared "Afronding" description for the DPIA and IAMA conclusion steps.
 const AFRONDING_DESCRIPTION =
   'Zorg dat alle stappen als voltooid gemarkeerd zijn, zodat het formulier compleet is. Als je nog niet klaar bent, kun je het formulier ook opslaan en later weer verder gaan. Indien je klaar bent, kun je het formulier als PDF exporteren.'
 
+type ValidatedDefinition = t.TypeOf<typeof DPIA>
+
 export const useSchemaStore = defineStore('SchemaStore', () => {
-  const validatedDpia = ref<t.TypeOf<typeof DPIA> | null>(null)
-  const validatedPreScan = ref<t.TypeOf<typeof DPIA> | null>(null)
-  const validatedIama = ref<t.TypeOf<typeof DPIA> | null>(null)
+  const validatedDpia = ref<ValidatedDefinition | null>(null)
+  const validatedPreScan = ref<ValidatedDefinition | null>(null)
+  const validatedIama = ref<ValidatedDefinition | null>(null)
   const isInitialized = ref(false)
   const hasErrors = ref(false)
   const errorMessage = ref<string | null>(null)
+  // Definitions keyed by their full canonical urn (e.g. 'urn:nl:dpia:3.1.0-concept.2'),
+  // so a specific version can be resolved independent of the active-per-type view.
+  const registry = ref(new Map<string, ValidatedDefinition>())
 
-  function processSchema(
-    jsonData: unknown,
-    schemaType: FormType
-  ): boolean {
+  // Decode a raw definition and append its conclusion task. Returns the validated
+  // definition, or null after recording the validation error.
+  function validateAndAugment(jsonData: unknown, schemaType: FormType): ValidatedDefinition | null {
     try {
       const validation = DPIA.decode(jsonData as any)
 
       if (isRight(validation)) {
         const validData = validation.right
 
-        // Add signing task if needed
         const hasSigningTask = validData.tasks.some(task =>
           task.type && task.type.includes('signing')
         )
@@ -42,36 +46,39 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
           }
         }
 
-        // Store in the appropriate ref
-        if (schemaType === FormType.DPIA) {
-          validatedDpia.value = validData
-        } else if (schemaType === FormType.IAMA) {
-          validatedIama.value = validData
-        } else {
-          validatedPreScan.value = validData
-        }
-
-        return true
-      } else {
-        // Validation failed
-        const errors = validation.left
-        const errorLocations = errors.map(err =>
-          err.context.map(c => c.key).join('.')
-        )
-
-        const errorMsg = `JSON schema validation failed at: ${errorLocations.join(', ')}`
-        console.error(errorMsg)
-        hasErrors.value = true
-        errorMessage.value = errorMsg
-
-        return false
+        return validData
       }
+
+      const errors = validation.left
+      const errorLocations = errors.map(err =>
+        err.context.map(c => c.key).join('.')
+      )
+      const errorMsg = `JSON schema validation failed at: ${errorLocations.join(', ')}`
+      console.error(errorMsg)
+      hasErrors.value = true
+      errorMessage.value = errorMsg
+      return null
     } catch (error) {
       console.error("Unexpected error during schema processing:", error)
       hasErrors.value = true
       errorMessage.value = error instanceof Error ? error.message : String(error)
-      return false
+      return null
     }
+  }
+
+  function processSchema(jsonData: unknown, schemaType: FormType): boolean {
+    const validData = validateAndAugment(jsonData, schemaType)
+    if (!validData) return false
+
+    if (schemaType === FormType.DPIA) {
+      validatedDpia.value = validData
+    } else if (schemaType === FormType.IAMA) {
+      validatedIama.value = validData
+    } else {
+      validatedPreScan.value = validData
+    }
+    registry.value.set(`${validData.urn}:${validData.version}`, validData)
+    return true
   }
 
   function init(schemas: { preScan: unknown; dpia: unknown; iama: unknown }) {
@@ -89,7 +96,32 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
     isInitialized.value = preScanSuccess || dpiaSuccess || iamaSuccess
   }
 
-  function getSchema(namespace: FormType): t.TypeOf<typeof DPIA> | null {
+  // Register an additional definition version into the registry (does not touch the
+  // active-per-type view). The assessment type is derived from the urn prefix.
+  function register(jsonData: unknown): boolean {
+    const rawUrn = (jsonData as { urn?: unknown } | null)?.urn
+    const schemaType = namespaceFromUrn(typeof rawUrn === 'string' ? rawUrn : undefined)
+    if (!schemaType) {
+      hasErrors.value = true
+      errorMessage.value = 'Cannot register definition: unknown or missing urn'
+      return false
+    }
+    const validData = validateAndAugment(jsonData, schemaType)
+    if (!validData) return false
+    registry.value.set(`${validData.urn}:${validData.version}`, validData)
+    return true
+  }
+
+  // Look up a registered definition by its full canonical urn (urn + full version).
+  function getByUrn(urn: string): ValidatedDefinition | null {
+    return registry.value.get(urn) ?? null
+  }
+
+  function registeredUrns(): string[] {
+    return Array.from(registry.value.keys())
+  }
+
+  function getSchema(namespace: FormType): ValidatedDefinition | null {
     if (namespace === FormType.DPIA) return validatedDpia.value
     if (namespace === FormType.PRE_SCAN) return validatedPreScan.value
     if (namespace === FormType.IAMA) return validatedIama.value
@@ -109,6 +141,9 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
     hasErrors,
     errorMessage,
     init,
+    register,
+    getByUrn,
+    registeredUrns,
     getSchema,
     getUrn
   }

--- a/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
+++ b/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
@@ -222,4 +222,68 @@ describe('useSchemaStore', () => {
       )
     })
   })
+
+  describe('version registry', () => {
+    it('registers a definition by its full canonical urn and looks it up, augmented', () => {
+      const store = useSchemaStore()
+      expect(
+        store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0-concept.2', tasks: [] })),
+      ).toBe(true)
+      const def = store.getByUrn('urn:nl:dpia:3.1.0-concept.2')
+      expect(def).not.toBeNull()
+      expect(def!.tasks).toHaveLength(1)
+      expect(def!.tasks[0].task).toBe('Afronding')
+      expect(store.registeredUrns()).toContain('urn:nl:dpia:3.1.0-concept.2')
+    })
+
+    it('derives the type from the urn prefix for the conclusion task', () => {
+      const store = useSchemaStore()
+      store.register(buildSchema({ urn: 'urn:nl:prescan', version: '2.0', tasks: [] }))
+      store.register(buildSchema({ urn: 'urn:nl:iama', version: '2.0', tasks: [] }))
+      expect(store.getByUrn('urn:nl:prescan:2.0')!.tasks[0].task).toBe('Resultaat pre-scan')
+      expect(store.getByUrn('urn:nl:iama:2.0')!.tasks[0].task).toBe('Afronding')
+    })
+
+    it('returns false for a definition with an unknown urn', () => {
+      const store = useSchemaStore()
+      expect(store.register(buildSchema({ urn: 'urn:nl:onbekend', version: '1.0' }))).toBe(false)
+    })
+
+    it('returns false when given a null or urn-less value', () => {
+      const store = useSchemaStore()
+      expect(store.register(null)).toBe(false)
+      expect(store.register({ version: '1.0' })).toBe(false)
+    })
+
+    it('returns false for an invalid definition shape', () => {
+      const store = useSchemaStore()
+      expect(store.register({ ...buildSchema({ urn: 'urn:nl:dpia' }), tasks: 'kapot' })).toBe(false)
+    })
+
+    it('returns null for an unregistered urn', () => {
+      const store = useSchemaStore()
+      expect(store.getByUrn('urn:nl:dpia:9.9')).toBeNull()
+    })
+
+    it('init also populates the registry', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '1.0' }),
+      })
+      expect(store.getByUrn('urn:nl:dpia:3.0')).not.toBeNull()
+      expect(store.registeredUrns()).toEqual(
+        expect.arrayContaining(['urn:nl:dpia:3.0', 'urn:nl:prescan:2.0', 'urn:nl:iama:1.0']),
+      )
+    })
+
+    it('keeps multiple versions of the same type side by side', () => {
+      const store = useSchemaStore()
+      store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.0' }))
+      store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0-concept.1' }))
+      expect(store.getByUrn('urn:nl:dpia:3.0')).not.toBeNull()
+      expect(store.getByUrn('urn:nl:dpia:3.1.0-concept.1')).not.toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Fase 2a — versie-bewuste schemaStore (loader-fundament)

Eerste stuk van **Fase 2** (de kern: per-assessment versie-pinning). Voegt een **versie-registry** toe aan `schemaStore`, zodat een specifieke definitie-versie op zijn volledige canonieke urn opgevraagd kan worden — náást de bestaande per-type view.

### Wat
- `register(def)` — registreert een definitie op `urn:nl:<type>:<volledige-versie>` (bv. `urn:nl:dpia:3.1.0-concept.2`); type afgeleid uit de urn-prefix.
- `getByUrn(urn)` / `registeredUrns()` — versie-precieze lookup.
- `init({preScan,dpia,iama})` blijft als **shim** en vult de registry mee.

### Eigenschappen
- **Additief & breaking-change-vrij**: alle 8 bestaande `FormType`-call-sites (`getSchema`/`getUrn`/`init`) werken ongewijzigd.
- Tests: `schemas.ts` 100% (39/39 branches), volledige core-suite **1222 tests @ 100% coverage**.

### Twijfels / open punten (graag jouw review)
- Dit is **fundament**: de registry wordt nog niet geconsumeerd (resolve-by-pin volgt). Bewust klein gehouden.
- **Vervolg**: resolve-by-pin in de app-loaders (consumeert `getByUrn`) → daarna de **per-assessment pin-kolom** (backend/DB-migratie — daar wil ik je review op vóór ik de save/create-flow raak) → Fase 1 (echte multi-versie-build, raakt CI; apart).
- **Sequencing**: ik leid bewust met de kern (Fase 2) i.p.v. Fase 4; Fase 1 minimaal. Kan los gereviewd worden.

Stapelt op de epic-branch `feat/sources-versiebeheer` (#406).
