### PR TITLE
feat(versiebeheer): D1 — officieel coarse, concept precies in de urn

### DIFF
--- a/apps/boekhouding-backend/test/cov/utils-validateState.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-validateState.cov.test.ts
@@ -115,4 +115,22 @@ describe('validateState', () => {
     const result = validateState(validState({ '0.1': answer({ data: 'javascript:alert(1)' }) }))
     expect(result.valid).toBe(false)
   })
+
+  it('accepts a concept (prerelease) urn — D1 stamps concept versions precise', () => {
+    const result = validateState({
+      $schema: SCHEMA_URL,
+      metadata: { urn: 'urn:nl:dpia:3.1.0-concept.2', createdAt: '2026-01-01T00:00:00.000Z' },
+      answers: {},
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects a 3-segment urn without a concept suffix (official stays MAJOR.MINOR)', () => {
+    const result = validateState({
+      $schema: SCHEMA_URL,
+      metadata: { urn: 'urn:nl:dpia:3.1.0', createdAt: '2026-01-01T00:00:00.000Z' },
+      answers: {},
+    })
+    expect(result.valid).toBe(false)
+  })
 })

--- a/packages/assessment-core/src/stores/schemas.ts
+++ b/packages/assessment-core/src/stores/schemas.ts
@@ -4,7 +4,7 @@ import { DPIA, FormType } from '../models/dpia'
 import * as t from 'io-ts'
 import { isRight } from 'fp-ts/lib/Either'
 import { createConclusionTask } from '../utils/taskUtils'
-import { coarseVersion, isPrerelease } from '../versioning/semver'
+import { canonicalVersion } from '../versioning/semver'
 import { namespaceFromUrn } from '../utils/importDetect'
 
 // Shared "Afronding" description for the DPIA and IAMA conclusion steps.
@@ -20,8 +20,9 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
   const isInitialized = ref(false)
   const hasErrors = ref(false)
   const errorMessage = ref<string | null>(null)
-  // Definitions keyed by their full canonical urn (e.g. 'urn:nl:dpia:3.1.0-concept.2'),
-  // so a specific version can be resolved independent of the active-per-type view.
+  // Definitions keyed by their canonical urn (official coarse MAJOR.MINOR, concept full —
+  // the same form getUrn stamps), so getByUrn(getUrn(ns)) resolves and a specific version
+  // can be looked up independent of the active-per-type view.
   const registry = ref(new Map<string, ValidatedDefinition>())
 
   // Decode a raw definition and append its conclusion task. Returns the validated
@@ -77,7 +78,7 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
     } else {
       validatedPreScan.value = validData
     }
-    registry.value.set(`${validData.urn}:${validData.version}`, validData)
+    registry.value.set(`${validData.urn}:${canonicalVersion(validData.version)}`, validData)
     return true
   }
 
@@ -108,11 +109,11 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
     }
     const validData = validateAndAugment(jsonData, schemaType)
     if (!validData) return false
-    registry.value.set(`${validData.urn}:${validData.version}`, validData)
+    registry.value.set(`${validData.urn}:${canonicalVersion(validData.version)}`, validData)
     return true
   }
 
-  // Look up a registered definition by its full canonical urn (urn + full version).
+  // Look up a registered definition by its canonical urn (the form getUrn stamps).
   function getByUrn(urn: string): ValidatedDefinition | null {
     return registry.value.get(urn) ?? null
   }
@@ -131,10 +132,9 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
   function getUrn(namespace: FormType): string {
     const schema = getSchema(namespace)
     if (!schema) throw new Error(`Schema not loaded for namespace: ${namespace}`)
-    // D1: an official version is stamped coarse (MAJOR.MINOR) since its patches are
-    // compatible; a concept (prerelease) version keeps its full identifier so the exact
-    // in-development iteration stays visible and pinnable.
-    return `${schema.urn}:${isPrerelease(schema.version) ? schema.version : coarseVersion(schema.version)}`
+    // D1: official -> coarse MAJOR.MINOR, concept -> full identifier. Same canonical form
+    // as the registry key, so getByUrn(getUrn(ns)) round-trips.
+    return `${schema.urn}:${canonicalVersion(schema.version)}`
   }
 
   return {

--- a/packages/assessment-core/src/stores/schemas.ts
+++ b/packages/assessment-core/src/stores/schemas.ts
@@ -4,7 +4,7 @@ import { DPIA, FormType } from '../models/dpia'
 import * as t from 'io-ts'
 import { isRight } from 'fp-ts/lib/Either'
 import { createConclusionTask } from '../utils/taskUtils'
-import { coarseVersion } from '../versioning/semver'
+import { coarseVersion, isPrerelease } from '../versioning/semver'
 import { namespaceFromUrn } from '../utils/importDetect'
 
 // Shared "Afronding" description for the DPIA and IAMA conclusion steps.
@@ -131,9 +131,10 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
   function getUrn(namespace: FormType): string {
     const schema = getSchema(namespace)
     if (!schema) throw new Error(`Schema not loaded for namespace: ${namespace}`)
-    // Coarsen to MAJOR.MINOR: the output schema constrains metadata.urn to that form,
-    // so a 3-segment or -concept source version must not leak into the stamped urn.
-    return `${schema.urn}:${coarseVersion(schema.version)}`
+    // D1: an official version is stamped coarse (MAJOR.MINOR) since its patches are
+    // compatible; a concept (prerelease) version keeps its full identifier so the exact
+    // in-development iteration stays visible and pinnable.
+    return `${schema.urn}:${isPrerelease(schema.version) ? schema.version : coarseVersion(schema.version)}`
   }
 
   return {

--- a/packages/assessment-core/src/versioning/semver.ts
+++ b/packages/assessment-core/src/versioning/semver.ts
@@ -39,6 +39,14 @@ export function coarseVersion(version: string): string {
   return `${parts[0]}.${parts[1] ?? '0'}`
 }
 
+// The canonical version used both in the stamped urn (getUrn) and as the schemaStore
+// registry key: an official version is coarsened to MAJOR.MINOR (its patches are
+// compatible); a concept keeps its full prerelease identifier (D1). Deriving both sites
+// from this one function guarantees getByUrn(getUrn(...)) round-trips.
+export function canonicalVersion(version: string): string {
+  return isPrerelease(version) ? version : coarseVersion(version)
+}
+
 function splitVersion(version: string): { main: number[]; pre: string[] | null } {
   const dash = version.indexOf('-')
   const mainStr = dash === -1 ? version : version.slice(0, dash)
@@ -74,7 +82,8 @@ function comparePre(a: string[], b: string[]): number {
 }
 
 // Compare two version strings (-1 | 0 | 1). A missing patch is treated as 0 and a
-// prerelease ranks below its corresponding release.
+// prerelease ranks below its corresponding release. Main segments are assumed numeric
+// (guaranteed by the version schemas); non-numeric input yields undefined ordering.
 export function compareVersions(a: string, b: string): number {
   const va = splitVersion(a)
   const vb = splitVersion(b)

--- a/packages/assessment-core/test/cov/semver.cov.test.ts
+++ b/packages/assessment-core/test/cov/semver.cov.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseUrn, isPrerelease, coarseVersion, compareVersions } from '../../src/versioning/semver'
+import { parseUrn, isPrerelease, coarseVersion, canonicalVersion, compareVersions } from '../../src/versioning/semver'
 
 describe('parseUrn', () => {
   it('parses an official versioned urn into type/version/channel', () => {
@@ -64,6 +64,17 @@ describe('coarseVersion', () => {
 
   it('drops a prerelease suffix and patch', () => {
     expect(coarseVersion('3.1.0-concept.2')).toBe('3.1')
+  })
+})
+
+describe('canonicalVersion', () => {
+  it('coarsens an official version to MAJOR.MINOR', () => {
+    expect(canonicalVersion('3.0')).toBe('3.0')
+    expect(canonicalVersion('3.1.0')).toBe('3.1')
+  })
+
+  it('keeps a concept version in full', () => {
+    expect(canonicalVersion('3.1.0-concept.2')).toBe('3.1.0-concept.2')
   })
 })
 

--- a/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
+++ b/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
@@ -203,7 +203,7 @@ describe('useSchemaStore', () => {
       expect(store.getUrn(FormType.PRE_SCAN)).toBe('urn:nl:prescan:2.0')
     })
 
-    it('coarsens the version to MAJOR.MINOR so metadata.urn stays output-schema valid', () => {
+    it('stamps official versions coarse (MAJOR.MINOR) and concept versions precise (D1)', () => {
       const store = useSchemaStore()
       store.init({
         dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
@@ -211,8 +211,10 @@ describe('useSchemaStore', () => {
         iama: buildSchema({ urn: 'urn:nl:iama', version: '2.0' }),
       })
 
+      // Official: stable line -> MAJOR.MINOR is enough.
       expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.1')
-      expect(store.getUrn(FormType.PRE_SCAN)).toBe('urn:nl:prescan:3.1')
+      // Concept: in-flux -> keep the exact iteration.
+      expect(store.getUrn(FormType.PRE_SCAN)).toBe('urn:nl:prescan:3.1.0-concept.2')
     })
 
     it('throws when the schema for the namespace is not loaded', () => {

--- a/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
+++ b/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
@@ -287,5 +287,33 @@ describe('useSchemaStore', () => {
       expect(store.getByUrn('urn:nl:dpia:3.0')).not.toBeNull()
       expect(store.getByUrn('urn:nl:dpia:3.1.0-concept.1')).not.toBeNull()
     })
+
+    it('keys an official version by its coarse canonical urn so getByUrn(getUrn(...)) round-trips', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '1.0' }),
+      })
+      // 3.1.0 official is stamped AND keyed coarse as 3.1 (not 3.1.0).
+      expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.1')
+      expect(store.getByUrn(store.getUrn(FormType.DPIA))).not.toBeNull()
+      expect(store.registeredUrns()).toContain('urn:nl:dpia:3.1')
+      expect(store.getByUrn('urn:nl:dpia:3.1.0')).toBeNull()
+    })
+
+    it('register does not touch the active-per-type view', () => {
+      const store = useSchemaStore()
+      expect(store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0-concept.2' }))).toBe(true)
+      expect(store.getByUrn('urn:nl:dpia:3.1.0-concept.2')).not.toBeNull()
+      expect(store.getSchema(FormType.DPIA)).toBeNull()
+    })
+
+    it('register is last-write-wins for the same canonical urn (no duplicate keys)', () => {
+      const store = useSchemaStore()
+      store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.0' }))
+      store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.0' }))
+      expect(store.registeredUrns().filter(u => u === 'urn:nl:dpia:3.0')).toHaveLength(1)
+    })
   })
 })

--- a/schemas/assessment-output.v2.schema.json
+++ b/schemas/assessment-output.v2.schema.json
@@ -16,8 +16,8 @@
             "properties": {
                 "urn": {
                     "type": "string",
-                    "pattern": "^urn:nl:[a-z]+:[0-9]+\\.[0-9]+$",
-                    "description": "URN identifier of the assessment definition including version (e.g. 'urn:nl:dpia:3.0'). Composed from the definition's urn + version fields.",
+                    "pattern": "^urn:nl:[a-z]+:(?:[0-9]+\\.[0-9]+|[0-9]+(?:\\.[0-9]+){0,2}-concept(?:\\.[0-9]+)?)$",
+                    "description": "URN identifier of the assessment definition. Official versions are stamped coarse MAJOR.MINOR (e.g. 'urn:nl:dpia:3.0'); concept versions keep their full prerelease identifier (e.g. 'urn:nl:dpia:3.1.0-concept.2').",
                     "examples": ["urn:nl:dpia:3.0", "urn:nl:prescan:2.0"]
                 },
                 "createdAt": {


### PR DESCRIPTION
## D1 — identifier: officieel coarse, concept precies

Jouw voorgestelde aanpak: de granulariteit van `metadata.urn` volgt de **stabiliteit** van de versie.

| Versie | Kanaal | `metadata.urn` |
|--------|--------|----------------|
| `3.0` | officieel | `urn:nl:dpia:3.0` (coarse) |
| `3.1.0` | officieel | `urn:nl:dpia:3.1` (coarse — patch is compatibel) |
| `3.1.0-concept.2` | concept | `urn:nl:dpia:3.1.0-concept.2` (precies — exacte iteratie) |

### Wat
- `getUrn()` (core): concept (prerelease) → volledige versie; officieel → coarse MAJOR.MINOR.
- Output-schema `metadata.urn`-pattern verruimd naar `^urn:nl:[a-z]+:(?:X.Y | X[.Y[.Z]]-concept[.N])$`.

### Waarom zo (toelichting)
- **Zelf-beschrijvend**: aan de urn zie je of een assessment op een vastgestelde versie of een concept-iteratie is gemaakt — voor een juridisch artefact een plus.
- **Geen sidecar-veld nodig**: de precieze conceptversie zit in de urn zelf (DRY).
- **fieldId-veilig**: `parseFieldKey`/`rebuildState` is versie-agnostisch (negeert het versie-deel), dus de audit-strings blijven werken.
- **Backward-compat / no-op vandaag**: bestaande `urn:nl:dpia:3.0` blijft geldig; alle bronnen zijn nu MAJOR.MINOR, dus dit verandert niets tot er een echte concept-versie is.

### Aandachtspunten voor review
- Dit **verruimt de backend-validatie** (`metadata.urn`-pattern) voor álle assessments. Alle **425 backend-integratietests blijven groen**; een 3-segment-urn zónder `-concept` (bv. `urn:nl:dpia:3.1.0`) wordt nog steeds **afgewezen** (officieel is en blijft coarse).
- **Promotie concept→officieel** herschrijft t.z.t. de urn (`…-concept.N` → `X.Y`); bewuste transitie die in de pin/migratie-fase terugkomt.

Tests: core 1222 @ 100%, backend 425 @ 100%. Stapelt op #408 (`feat/sources-versiebeheer-2-loader`).
