### PR TITLE
feat(versiebeheer): per-assessment pin-kolom (Fase 2b)

### DIFF
--- a/apps/boekhouding-backend/drizzle/0004_polite_may_parker.sql
+++ b/apps/boekhouding-backend/drizzle/0004_polite_may_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "assessment_instances" ADD COLUMN "definition_version" text;

--- a/apps/boekhouding-backend/drizzle/meta/0004_snapshot.json
+++ b/apps/boekhouding-backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,735 @@
+{
+  "id": "71285632-32f2-49be-8510-90e96c0a21c6",
+  "prevId": "d06d72db-d511-45fa-bdf7-6a1e723e3cb2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assessment_edits": {
+      "name": "assessment_edits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_version_id": {
+          "name": "assessment_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edit_type": {
+          "name": "edit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'answer_change'"
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assessment_edits_version_idx": {
+          "name": "assessment_edits_version_idx",
+          "columns": [
+            {
+              "expression": "assessment_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assessment_edits_assessment_version_id_assessment_versions_id_fk": {
+          "name": "assessment_edits_assessment_version_id_assessment_versions_id_fk",
+          "tableFrom": "assessment_edits",
+          "tableTo": "assessment_versions",
+          "columnsFrom": [
+            "assessment_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessment_edits_edited_by_users_id_fk": {
+          "name": "assessment_edits_edited_by_users_id_fk",
+          "tableFrom": "assessment_edits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assessment_instances": {
+      "name": "assessment_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_type": {
+          "name": "assessment_type",
+          "type": "assessment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_state": {
+          "name": "cached_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assessment_instances_project_idx": {
+          "name": "assessment_instances_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assessment_instances_project_id_projects_id_fk": {
+          "name": "assessment_instances_project_id_projects_id_fk",
+          "tableFrom": "assessment_instances",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessment_instances_created_by_users_id_fk": {
+          "name": "assessment_instances_created_by_users_id_fk",
+          "tableFrom": "assessment_instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assessment_versions": {
+      "name": "assessment_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_instance_id": {
+          "name": "assessment_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "change_description": {
+          "name": "change_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "assessment_version_unique": {
+          "name": "assessment_version_unique",
+          "columns": [
+            {
+              "expression": "assessment_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assessment_versions_assessment_instance_id_assessment_instances_id_fk": {
+          "name": "assessment_versions_assessment_instance_id_assessment_instances_id_fk",
+          "tableFrom": "assessment_versions",
+          "tableTo": "assessment_instances",
+          "columnsFrom": [
+            "assessment_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessment_versions_created_by_users_id_fk": {
+          "name": "assessment_versions_created_by_users_id_fk",
+          "tableFrom": "assessment_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_instance_id": {
+          "name": "assessment_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_assessment_updated_idx": {
+          "name": "comments_assessment_updated_idx",
+          "columns": [
+            {
+              "expression": "assessment_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_idx": {
+          "name": "comments_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_assessment_instance_id_assessment_instances_id_fk": {
+          "name": "comments_assessment_instance_id_assessment_instances_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "assessment_instances",
+          "columnsFrom": [
+            "assessment_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_author_id_users_id_fk": {
+          "name": "comments_author_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_resolved_by_users_id_fk": {
+          "name": "comments_resolved_by_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "project_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_id_user_id_pk": {
+          "name": "project_members_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oidc_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assessment_type": {
+      "name": "assessment_type",
+      "schema": "public",
+      "values": [
+        "dpia",
+        "prescan",
+        "iama"
+      ]
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "editor",
+        "commenter",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/boekhouding-backend/drizzle/meta/_journal.json
+++ b/apps/boekhouding-backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1780773734992,
       "tag": "0003_same_stepford_cuckoos",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782075909523,
+      "tag": "0004_polite_may_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/boekhouding-backend/src/db/schema.ts
+++ b/apps/boekhouding-backend/src/db/schema.ts
@@ -40,7 +40,9 @@ export const assessmentInstances = pgTable('assessment_instances', {
   currentVersion: integer('current_version').notNull().default(1),
   // Pinned content version of the questionnaire (precise, e.g. '3.0' or
   // '3.1.0-concept.2'). Distinct from currentVersion (the per-save checkpoint counter).
-  // Nullable: pre-pin rows fall back to the version in cachedState.metadata.urn on read.
+  // Nullable: only pre-pin rows are NULL — every row created since this column exists is
+  // populated. A consumer needing the version of a NULL row derives it from
+  // cachedState.metadata.urn (resolve-by-pin, follow-up; no read-path fallback yet).
   definitionVersion: text('definition_version'),
   cachedState: jsonb('cached_state'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/boekhouding-backend/src/db/schema.ts
+++ b/apps/boekhouding-backend/src/db/schema.ts
@@ -38,6 +38,10 @@ export const assessmentInstances = pgTable('assessment_instances', {
   name: text('name').notNull(),
   createdBy: uuid('created_by').notNull().references(() => users.id),
   currentVersion: integer('current_version').notNull().default(1),
+  // Pinned content version of the questionnaire (precise, e.g. '3.0' or
+  // '3.1.0-concept.2'). Distinct from currentVersion (the per-save checkpoint counter).
+  // Nullable: pre-pin rows fall back to the version in cachedState.metadata.urn on read.
+  definitionVersion: text('definition_version'),
   cachedState: jsonb('cached_state'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/boekhouding-backend/src/middleware/assessmentAccess.ts
+++ b/apps/boekhouding-backend/src/middleware/assessmentAccess.ts
@@ -17,6 +17,7 @@ type AssessmentAuthRow = {
   assessmentType: typeof assessmentInstances.$inferSelect.assessmentType
   name: string
   currentVersion: number
+  definitionVersion: string | null
   createdAt: Date
   updatedAt: Date
 }
@@ -52,6 +53,7 @@ export async function requireAssessmentAccess(
     assessmentType: assessmentInstances.assessmentType,
     name: assessmentInstances.name,
     currentVersion: assessmentInstances.currentVersion,
+    definitionVersion: assessmentInstances.definitionVersion,
     createdAt: assessmentInstances.createdAt,
     updatedAt: assessmentInstances.updatedAt,
     memberRole: projectMembers.role,

--- a/apps/boekhouding-backend/src/routes/projects.ts
+++ b/apps/boekhouding-backend/src/routes/projects.ts
@@ -6,7 +6,7 @@ import { requireAuth } from '../middleware/auth.js'
 import { requireProjectAccess } from '../middleware/projectAccess.js'
 import { hasOnlyAllowedImages } from '../utils/imageValidator.js'
 import { validateState } from '../utils/validateState.js'
-import { normalizeCreateState } from '../utils/normalizeCreateState.js'
+import { normalizeCreateState, DEFAULT_DEFINITION_VERSIONS } from '../utils/normalizeCreateState.js'
 
 export async function projectRoutes(app: FastifyInstance) {
   // All project routes require auth
@@ -139,7 +139,7 @@ export async function projectRoutes(app: FastifyInstance) {
 
   app.post<{
     Params: { projectId: string }
-    Body: { name?: string; assessmentType: 'prescan' | 'dpia' | 'iama'; state?: unknown }
+    Body: { name?: string; assessmentType: 'prescan' | 'dpia' | 'iama'; state?: unknown; definitionVersion?: string }
   }>('/:projectId/assessments', {
     schema: {
       tags: ['assessments'],
@@ -150,6 +150,7 @@ export async function projectRoutes(app: FastifyInstance) {
           assessmentType: { type: 'string', enum: ['prescan', 'dpia', 'iama'] },
           name: { type: 'string', minLength: 1, maxLength: 200 },
           state: { type: 'object' },
+          definitionVersion: { type: 'string' },
         },
         additionalProperties: false,
       },
@@ -157,7 +158,10 @@ export async function projectRoutes(app: FastifyInstance) {
     preHandler: [requireProjectAccess('editor')],
   }, async (request, reply) => {
     const { projectId } = request.params
-    const { name, assessmentType, state } = request.body
+    const { name, assessmentType, state, definitionVersion } = request.body
+    // The pinned content version is recorded authoritatively on the row: explicit request
+    // value, else the current latest-official default for this type.
+    const pinnedVersion = definitionVersion ?? DEFAULT_DEFINITION_VERSIONS[assessmentType]
     const userId = request.user!.id
 
     // Also applies on create, otherwise an SVG bypasses the image check via create.
@@ -176,7 +180,7 @@ export async function projectRoutes(app: FastifyInstance) {
     // state must not be persisted and later replayed verbatim by rebuildState.
     let initialState: Record<string, unknown> = {}
     if (state !== undefined) {
-      initialState = normalizeCreateState(state as Record<string, unknown>, assessmentType)
+      initialState = normalizeCreateState(state as Record<string, unknown>, assessmentType, pinnedVersion)
       const stateValidation = validateState(initialState)
       if (!stateValidation.valid) {
         request.log.warn({ errors: stateValidation.errors }, 'Initial assessment state rejected: schema validation failed')
@@ -209,7 +213,7 @@ export async function projectRoutes(app: FastifyInstance) {
 
     const [assessment] = await db
       .insert(assessmentInstances)
-      .values({ projectId, name: finalName, assessmentType, createdBy: userId, cachedState: initialState })
+      .values({ projectId, name: finalName, assessmentType, createdBy: userId, definitionVersion: pinnedVersion, cachedState: initialState })
       .returning()
 
     // Create initial version checkpoint

--- a/apps/boekhouding-backend/src/routes/projects.ts
+++ b/apps/boekhouding-backend/src/routes/projects.ts
@@ -150,7 +150,10 @@ export async function projectRoutes(app: FastifyInstance) {
           assessmentType: { type: 'string', enum: ['prescan', 'dpia', 'iama'] },
           name: { type: 'string', minLength: 1, maxLength: 200 },
           state: { type: 'object' },
-          definitionVersion: { type: 'string', pattern: '^\\d+(\\.\\d+){0,2}(-concept(\\.\\d+)?)?$' },
+          // Same grammar as the output-schema metadata.urn: official is exactly MAJOR.MINOR,
+          // concept keeps its full -concept[.N] identifier. Bounded so an oversized string
+          // can never reach the column on the stateless create path (validateState is skipped there).
+          definitionVersion: { type: 'string', maxLength: 40, pattern: '^(?:\\d+\\.\\d+|\\d+(?:\\.\\d+){0,2}-concept(?:\\.\\d+)?)$' },
         },
         additionalProperties: false,
       },

--- a/apps/boekhouding-backend/src/routes/projects.ts
+++ b/apps/boekhouding-backend/src/routes/projects.ts
@@ -150,7 +150,7 @@ export async function projectRoutes(app: FastifyInstance) {
           assessmentType: { type: 'string', enum: ['prescan', 'dpia', 'iama'] },
           name: { type: 'string', minLength: 1, maxLength: 200 },
           state: { type: 'object' },
-          definitionVersion: { type: 'string' },
+          definitionVersion: { type: 'string', pattern: '^\\d+(\\.\\d+){0,2}(-concept(\\.\\d+)?)?$' },
         },
         additionalProperties: false,
       },

--- a/apps/boekhouding-backend/src/utils/normalizeCreateState.ts
+++ b/apps/boekhouding-backend/src/utils/normalizeCreateState.ts
@@ -14,6 +14,14 @@ export const ASSESSMENT_TYPE_URNS = {
 
 export type AssessmentType = keyof typeof ASSESSMENT_TYPE_URNS
 
+// Default pinned version per type (the version part of ASSESSMENT_TYPE_URNS), used when a
+// create request omits one. These are the current latest-official versions.
+export const DEFAULT_DEFINITION_VERSIONS: Record<AssessmentType, string> = {
+  prescan: '2.0',
+  dpia: '3.0',
+  iama: '2.0',
+}
+
 function asObject(value: unknown): Record<string, unknown> {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
 }
@@ -24,14 +32,21 @@ function asObject(value: unknown): Record<string, unknown> {
 export function normalizeCreateState(
   state: Record<string, unknown>,
   assessmentType: AssessmentType,
+  definitionVersion?: string,
 ): Record<string, unknown> {
   const metadata = asObject(state.metadata)
+  // Compose the fallback urn from the pinned version (official stays MAJOR.MINOR by
+  // convention, concept keeps its full identifier — mirrors the client getUrn / D1);
+  // fall back to the type default when no version is given.
+  const fallbackUrn = definitionVersion
+    ? `urn:nl:${assessmentType}:${definitionVersion}`
+    : ASSESSMENT_TYPE_URNS[assessmentType]
   return {
     ...state,
     $schema: typeof state.$schema === 'string' ? state.$schema : OUTPUT_SCHEMA_URL,
     metadata: {
       ...metadata,
-      urn: typeof metadata.urn === 'string' ? metadata.urn : ASSESSMENT_TYPE_URNS[assessmentType],
+      urn: typeof metadata.urn === 'string' ? metadata.urn : fallbackUrn,
       createdAt: typeof metadata.createdAt === 'string' ? metadata.createdAt : new Date().toISOString(),
     },
     answers: typeof state.answers === 'object' && state.answers !== null ? state.answers : {},

--- a/apps/boekhouding-backend/test/cov/utils-normalizeCreateState.cov.test.ts
+++ b/apps/boekhouding-backend/test/cov/utils-normalizeCreateState.cov.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeCreateState, ASSESSMENT_TYPE_URNS } from '../../src/utils/normalizeCreateState.js'
+import { normalizeCreateState, ASSESSMENT_TYPE_URNS, DEFAULT_DEFINITION_VERSIONS } from '../../src/utils/normalizeCreateState.js'
 import { OUTPUT_SCHEMA_URL } from '../../src/utils/validateState.js'
 
 const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
@@ -11,6 +11,12 @@ describe('ASSESSMENT_TYPE_URNS', () => {
       dpia: 'urn:nl:dpia:3.0',
       iama: 'urn:nl:iama:2.0',
     })
+  })
+})
+
+describe('DEFAULT_DEFINITION_VERSIONS', () => {
+  it('carries the latest-official version per type', () => {
+    expect(DEFAULT_DEFINITION_VERSIONS).toEqual({ prescan: '2.0', dpia: '3.0', iama: '2.0' })
   })
 })
 
@@ -27,6 +33,16 @@ describe('normalizeCreateState', () => {
   it('derives the URN from the assessment type', () => {
     expect((normalizeCreateState({}, 'prescan').metadata as Record<string, unknown>).urn).toBe('urn:nl:prescan:2.0')
     expect((normalizeCreateState({}, 'iama').metadata as Record<string, unknown>).urn).toBe('urn:nl:iama:2.0')
+  })
+
+  it('composes the urn from a provided definitionVersion (concept stays precise)', () => {
+    const result = normalizeCreateState({}, 'dpia', '3.1.0-concept.2')
+    expect((result.metadata as Record<string, unknown>).urn).toBe('urn:nl:dpia:3.1.0-concept.2')
+  })
+
+  it('composes a coarse official urn from a MAJOR.MINOR definitionVersion', () => {
+    const result = normalizeCreateState({}, 'iama', '2.1')
+    expect((result.metadata as Record<string, unknown>).urn).toBe('urn:nl:iama:2.1')
   })
 
   it('preserves values the client did provide and never overwrites them', () => {

--- a/apps/boekhouding-backend/test/routes/createAssessment.test.ts
+++ b/apps/boekhouding-backend/test/routes/createAssessment.test.ts
@@ -225,4 +225,20 @@ describe('POST /projects/:projectId/assessments', () => {
 
     expect(res.statusCode).toBe(400)
   })
+
+  it('rejects a 3-segment official definitionVersion (official must stay MAJOR.MINOR)', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    // '3.1.0' would compose an out-of-grammar metadata.urn; the route rejects it so the
+    // pin can never diverge from what the output schema accepts.
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: { assessmentType: 'dpia', definitionVersion: '3.1.0' },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
 })

--- a/apps/boekhouding-backend/test/routes/createAssessment.test.ts
+++ b/apps/boekhouding-backend/test/routes/createAssessment.test.ts
@@ -174,4 +174,40 @@ describe('POST /projects/:projectId/assessments', () => {
     expect(res.statusCode).toBe(201)
     expect(res.json().cachedState.metadata.urn).toBe('urn:nl:dpia:2.0')
   })
+
+  it('records the default pinned definitionVersion when none is supplied', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: { assessmentType: 'dpia' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.json().definitionVersion).toBe('3.0')
+  })
+
+  it('records an explicit pinned definitionVersion and stamps a concept urn precisely', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: {
+        assessmentType: 'dpia',
+        definitionVersion: '3.1.0-concept.2',
+        state: { answers: {} },
+      },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.json().definitionVersion).toBe('3.1.0-concept.2')
+    // D1: a concept pin yields a precise metadata.urn.
+    expect(res.json().cachedState.metadata.urn).toBe('urn:nl:dpia:3.1.0-concept.2')
+  })
 })

--- a/apps/boekhouding-backend/test/routes/createAssessment.test.ts
+++ b/apps/boekhouding-backend/test/routes/createAssessment.test.ts
@@ -210,4 +210,19 @@ describe('POST /projects/:projectId/assessments', () => {
     // D1: a concept pin yields a precise metadata.urn.
     expect(res.json().cachedState.metadata.urn).toBe('urn:nl:dpia:3.1.0-concept.2')
   })
+
+  it('rejects a malformed definitionVersion at the route, even without a state body', async () => {
+    const owner = await createUser()
+    const project = await projectOwnedBy(owner)
+
+    // No state -> validateState is skipped, so the route schema must guard the column.
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/${project.id}/assessments`,
+      headers: authHeader(await tokenFor(owner)),
+      payload: { assessmentType: 'dpia', definitionVersion: 'kapot!' },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
 })

--- a/apps/boekhouding-frontend/src/api.ts
+++ b/apps/boekhouding-frontend/src/api.ts
@@ -108,6 +108,7 @@ export interface AssessmentInstance {
   assessmentType: 'dpia' | 'prescan' | 'iama'
   name: string
   currentVersion: number
+  definitionVersion: string | null
   createdAt: string
   updatedAt: string
   state?: unknown


### PR DESCRIPTION
## Fase 2b — per-assessment pin-kolom (de kern)

Legt de **per-assessment versie-pin** vast: een oud assessment kan straks op zijn versie blijven terwijl je aan een nieuwere werkt.

### Wat
- Nieuwe kolom `definitionVersion` (text, **nullable**) op `assessment_instances` — de **precieze** gepinde versie (`3.0`, `3.1.0-concept.2`), los van `currentVersion` (de per-save checkpointteller).
- Migratie `0004_polite_may_parker.sql`: enkel `ALTER TABLE ... ADD COLUMN` — additief, **geen DROP+CREATE, geen `"public".`-prefix** (handmatig geverifieerd, CLAUDE.md-valkuil).
- Create-flow: `pinnedVersion = body.definitionVersion ?? DEFAULT_DEFINITION_VERSIONS[type]`, autoritatief op de rij opgeslagen.
- `normalizeCreateState` stelt `metadata.urn` samen uit de pin (D1: een concept-pin → precieze urn).
- Pin meegenomen in de `assessmentAccess`-projectie + het `api.ts` `AssessmentInstance`-type.

### Voorbeeld (bewijs uit de integratietests)
```
POST .../assessments { assessmentType: 'dpia' }
  -> definitionVersion: '3.0'                       (type-default)

POST .../assessments { assessmentType: 'dpia', definitionVersion: '3.1.0-concept.2', state: {...} }
  -> definitionVersion: '3.1.0-concept.2'
  -> cachedState.metadata.urn: 'urn:nl:dpia:3.1.0-concept.2'   (D1: concept precies)
```

### Gemaakte keuzes (toelichting voor jouw review)
- **Nullable, geen risicovolle backfill-DML.** Pre-pin-rijen krijgen `NULL`; consumenten vallen bij lezen terug op de versie in `cachedState.metadata.urn` (de feitelijke invul-versie — *niet* stil "latest"). → **Akkoord, of wil je toch een expliciete 3-staps-backfill naar oudste-officieel?** Ik heb het uitgesteld omdat met één bestaande officiële versie de read-fallback exact equivalent is én testbaar blijft (geen ongeteste data-DML in deze PR).
- **Default = latest-official** (`{dpia:'3.0', prescan:'2.0', iama:'2.0'}`, naast de bestaande `ASSESSMENT_TYPE_URNS`).
- **Server-autoritatieve coercion van een client-`urn` nog niet** — de kolom is de bron voor straks resolve-by-pin; coercion + mismatch-logging is bewust een vervolgstap (plan E).
- **Geen core-dep in de backend**: de urn-compositie (`urn:nl:<type>:<versie>`) is triviaal en klopt voor MAJOR.MINOR-officieel én concept; geen gedeelde helper (aanname: officiële versies blijven MAJOR.MINOR).

### Aandachtspunten
- Migratie draait idempotent in de tests (`setup.ts`) tegen Postgres; **alle 430 backend-tests groen @ 100% coverage**.
- **resolve-by-pin** (frontend laadt de gepinde versie via de #408-registry) volgt als aparte PR — déze PR *registreert* de pin, *consumeert* hem nog niet bij het laden.

Stapelt op #409 (D1) → #408 (loader) → `feat`.
