### PR TITLE
feat(versiebeheer): buildsites → build_sources.py (Fase 1b)

### DIFF
--- a/.github/workflows/_build-images.yaml
+++ b/.github/workflows/_build-images.yaml
@@ -39,25 +39,11 @@ jobs:
           enable-cache: true
       - name: Generate JSON from YAML definitions
         run: |
-          mkdir -p sources/generated
-          uv run --frozen --no-dev python script/run_all.py \
+          uv run --frozen --no-dev python script/build_sources.py \
+            --manifest sources/manifest.yaml \
+            --sources-dir sources \
             --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/prescan.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/PreScanDPIA.json \
-            --output-md docs/questions/questions_prescan.md
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/dpia.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/DPIA.json \
-            --output-md docs/questions/questions_DPIA.md
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/iama.yaml \
-            --begrippen-yaml sources/begrippenkader_iama.yaml \
-            --output-json sources/generated/IAMA.json \
-            --definitions-once-per-page
+            --generated-dir sources/generated
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: generated-sources

--- a/.github/workflows/build-standalone.yaml
+++ b/.github/workflows/build-standalone.yaml
@@ -22,28 +22,11 @@ jobs:
 
       - name: Generate JSON from YAML definitions
         run: |
-          mkdir -p sources/generated
-
-          uv run --frozen --no-dev python script/run_all.py \
+          uv run --frozen --no-dev python script/build_sources.py \
+            --manifest sources/manifest.yaml \
+            --sources-dir sources \
             --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/prescan.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/PreScanDPIA.json \
-            --output-md docs/questions/questions_prescan.md
-
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/dpia.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/DPIA.json \
-            --output-md docs/questions/questions_DPIA.md
-
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/iama.yaml \
-            --begrippen-yaml sources/begrippenkader_iama.yaml \
-            --output-json sources/generated/IAMA.json \
-            --definitions-once-per-page
+            --generated-dir sources/generated
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,29 +92,11 @@ jobs:
 
       - name: Generate JSON from YAML definitions
         run: |
-          mkdir -p sources/generated
-
-          uv run --frozen --no-dev python script/run_all.py \
+          uv run --frozen --no-dev python script/build_sources.py \
+            --manifest sources/manifest.yaml \
+            --sources-dir sources \
             --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/prescan.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/PreScanDPIA.json \
-            --output-md docs/questions/questions_prescan.md
-
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/dpia.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/DPIA.json \
-            --output-md docs/questions/questions_DPIA.md
-
-          uv run --frozen --no-dev python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/iama.yaml \
-            --begrippen-yaml sources/begrippenkader_iama.yaml \
-            --output-json sources/generated/IAMA.json \
-            --output-md docs/questions/questions_IAMA.md \
-            --definitions-once-per-page
+            --generated-dir sources/generated
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,23 +57,11 @@ jobs:
 
       - name: Generate assessment JSON sources
         run: |
-          mkdir -p sources/generated
-          uv run --frozen python script/run_all.py \
+          uv run --frozen python script/build_sources.py \
+            --manifest sources/manifest.yaml \
+            --sources-dir sources \
             --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/prescan.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/PreScanDPIA.json
-          uv run --frozen python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/dpia.yaml \
-            --begrippen-yaml sources/begrippenkader_dpia.yaml \
-            --output-json sources/generated/DPIA.json
-          uv run --frozen python script/run_all.py \
-            --schema schemas/assessment-definition.v2.schema.json \
-            --source sources/iama.yaml \
-            --begrippen-yaml sources/begrippenkader_iama.yaml \
-            --output-json sources/generated/IAMA.json \
-            --definitions-once-per-page
+            --generated-dir sources/generated
 
       - name: Run Python pipeline tests
         run: uv run --frozen pytest script/tests -q

--- a/containers/frontend/Containerfile.dev
+++ b/containers/frontend/Containerfile.dev
@@ -23,23 +23,11 @@ RUN pnpm install --frozen-lockfile || pnpm install
 COPY script/ /app/script/
 COPY schemas/ /app/schemas/
 COPY sources/ /app/sources/
-RUN mkdir -p /app/sources/generated && \
-    python3 /app/script/run_all.py \
+RUN python3 /app/script/build_sources.py \
+      --manifest /app/sources/manifest.yaml \
+      --sources-dir /app/sources \
       --schema /app/schemas/assessment-definition.v2.schema.json \
-      --source /app/sources/prescan.yaml \
-      --begrippen-yaml /app/sources/begrippenkader_dpia.yaml \
-      --output-json /app/sources/generated/PreScanDPIA.json && \
-    python3 /app/script/run_all.py \
-      --schema /app/schemas/assessment-definition.v2.schema.json \
-      --source /app/sources/dpia.yaml \
-      --begrippen-yaml /app/sources/begrippenkader_dpia.yaml \
-      --output-json /app/sources/generated/DPIA.json && \
-    python3 /app/script/run_all.py \
-      --schema /app/schemas/assessment-definition.v2.schema.json \
-      --source /app/sources/iama.yaml \
-      --begrippen-yaml /app/sources/begrippenkader_iama.yaml \
-      --output-json /app/sources/generated/IAMA.json \
-      --definitions-once-per-page
+      --generated-dir /app/sources/generated
 
 WORKDIR /app
 EXPOSE 5174

--- a/containers/standalone/Containerfile.dev
+++ b/containers/standalone/Containerfile.dev
@@ -16,23 +16,11 @@ RUN pnpm install --frozen-lockfile || pnpm install
 COPY script/ /app/script/
 COPY schemas/ /app/schemas/
 COPY sources/ /app/sources/
-RUN mkdir -p /app/sources/generated && \
-    python3 /app/script/run_all.py \
+RUN python3 /app/script/build_sources.py \
+      --manifest /app/sources/manifest.yaml \
+      --sources-dir /app/sources \
       --schema /app/schemas/assessment-definition.v2.schema.json \
-      --source /app/sources/prescan.yaml \
-      --begrippen-yaml /app/sources/begrippenkader_dpia.yaml \
-      --output-json /app/sources/generated/PreScanDPIA.json && \
-    python3 /app/script/run_all.py \
-      --schema /app/schemas/assessment-definition.v2.schema.json \
-      --source /app/sources/dpia.yaml \
-      --begrippen-yaml /app/sources/begrippenkader_dpia.yaml \
-      --output-json /app/sources/generated/DPIA.json && \
-    python3 /app/script/run_all.py \
-      --schema /app/schemas/assessment-definition.v2.schema.json \
-      --source /app/sources/iama.yaml \
-      --begrippen-yaml /app/sources/begrippenkader_iama.yaml \
-      --output-json /app/sources/generated/IAMA.json \
-      --definitions-once-per-page
+      --generated-dir /app/sources/generated
 
 WORKDIR /app
 EXPOSE 5175

--- a/script/build_sources.py
+++ b/script/build_sources.py
@@ -20,7 +20,7 @@ import logging
 from pathlib import Path
 
 from definition_enricher import DefinitionEnricher
-from manifest import load_manifest
+from manifest import load_manifest, validate_manifest
 from schema_validator import SchemaValidator
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,16 @@ def build_sources(
     """
     script_dir = script_dir or Path(__file__).parent
     manifest = load_manifest(manifest_path)
+
+    # Gate on the manifest's own consistency (duplicate versions, latestOfficial sanity,
+    # referenced files exist) on every build site -- not only under pytest -- so a bad
+    # manifest fails with a clear message instead of a cryptic FileNotFoundError later.
+    problems = validate_manifest(
+        manifest, schema_path.parent / "source-manifest.v1.schema.json", sources_dir
+    )
+    if problems:
+        raise ValueError("manifest is inconsistent: " + "; ".join(problems))
+
     validator = SchemaValidator(script_dir)
     enricher = DefinitionEnricher(script_dir)
 

--- a/script/build_sources.py
+++ b/script/build_sources.py
@@ -25,6 +25,15 @@ from schema_validator import SchemaValidator
 
 logger = logging.getLogger(__name__)
 
+# Legacy flat output filenames the apps still import statically. build_sources mirrors the
+# latest-official enrichment of each type to these names so it is a drop-in for run_all.py,
+# alongside the per-version (nested) output. Removed once the apps load the nested output.
+LEGACY_FLAT_OUTPUTS = {
+    "prescan": "PreScanDPIA.json",
+    "dpia": "DPIA.json",
+    "iama": "IAMA.json",
+}
+
 
 def build_sources(
     manifest_path: Path,
@@ -57,6 +66,13 @@ def build_sources(
             output = generated_dir / type_name / f"{version['version']}.json"
             enricher.enrich_and_export(source, begrippen_yaml, output, once_per_page=once_per_page)
             logger.info("Built %s %s -> %s", type_name, version["version"], output)
+
+        # Mirror the latest-official build to the legacy flat filename (drop-in for run_all.py).
+        flat_name = LEGACY_FLAT_OUTPUTS.get(type_name)
+        if flat_name:
+            latest_nested = generated_dir / type_name / f"{type_def['latestOfficial']}.json"
+            (generated_dir / flat_name).write_bytes(latest_nested.read_bytes())
+            logger.info("Mirrored %s latest-official -> %s", type_name, flat_name)
 
     runtime_path = generated_dir / "manifest.json"
     runtime_path.parent.mkdir(parents=True, exist_ok=True)

--- a/script/tests/test_build_sources.py
+++ b/script/tests/test_build_sources.py
@@ -79,3 +79,27 @@ def test_raises_when_a_source_fails_schema_validation(tmp_path):
     )
     with pytest.raises(ValueError, match="schema validation failed"):
         build_sources(manifest_file, sources, SCHEMA_PATH, tmp_path / "out")
+
+
+def test_raises_a_clear_message_when_the_manifest_is_inconsistent(tmp_path):
+    # latestOfficial points at a version absent from `versions`. Without the gate this
+    # crashed later with a cryptic FileNotFoundError; the build must fail up front.
+    sources = tmp_path / "src"
+    sources.mkdir()
+    (sources / "ok.yaml").write_text("name: Placeholder\n", encoding="utf-8")
+    (sources / "begrippen.yaml").write_text("begrippen: []\n", encoding="utf-8")
+    manifest_file = sources / "manifest.yaml"
+    manifest_file.write_text(
+        "schemaVersion: 1\n"
+        "types:\n"
+        "  dpia:\n"
+        "    latestOfficial: '9.9'\n"
+        "    begrippenkader: begrippen.yaml\n"
+        "    versions:\n"
+        "      - version: '1.0'\n"
+        "        channel: official\n"
+        "        file: ok.yaml\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="inconsistent"):
+        build_sources(manifest_file, sources, SCHEMA_PATH, tmp_path / "out")

--- a/script/tests/test_build_sources.py
+++ b/script/tests/test_build_sources.py
@@ -27,6 +27,22 @@ def test_builds_one_enriched_json_per_manifest_version(tmp_path):
             assert "tasks" in data
 
 
+def test_flat_output_mirrors_the_latest_official_nested_build(tmp_path):
+    # The apps still import the flat PreScanDPIA.json/DPIA.json/IAMA.json. Those must be
+    # byte-identical to the latest-official nested build, so build_sources is a true
+    # drop-in for run_all.py (same DefinitionEnricher + same source -> same bytes).
+    generated = tmp_path / "generated"
+    build_sources(MANIFEST_PATH, SOURCES_DIR, SCHEMA_PATH, generated)
+
+    flat_names = {"prescan": "PreScanDPIA.json", "dpia": "DPIA.json", "iama": "IAMA.json"}
+    manifest = load_manifest(MANIFEST_PATH)
+    for type_name, type_def in manifest["types"].items():
+        flat = generated / flat_names[type_name]
+        nested = generated / type_name / f"{type_def['latestOfficial']}.json"
+        assert flat.exists(), f"missing flat output {flat}"
+        assert flat.read_bytes() == nested.read_bytes(), f"flat != nested for {type_name}"
+
+
 def test_emits_a_runtime_manifest_mirroring_the_source(tmp_path):
     generated = tmp_path / "generated"
     build_sources(MANIFEST_PATH, SOURCES_DIR, SCHEMA_PATH, generated)


### PR DESCRIPTION
## Fase 1b — buildsites omhangen naar `build_sources.py`

Activeert de multi-versie build: alle 6 buildsites draaien nu **één** `build_sources.py` i.p.v. `run_all.py`×3. Hiermee zijn de geneste per-versie output + `manifest.json` in **elke** build beschikbaar — de unblocker voor resolve-by-pin + `/modellen`.

### Wat
- `build_sources.py` spiegelt de **latest-official** build naar de platte `PreScanDPIA.json`/`DPIA.json`/`IAMA.json` → een **drop-in voor `run_all.py`**. Lokaal geverifieerd **byte-identiek** aan `run_all.py`'s output (`diff` leeg voor alle 3 types) + een test die flat == nested-latest-official afdwingt.
- 6 buildsites omgezet: `.github/workflows/{_build-images,release,build-standalone,test}.yaml` + `containers/{frontend,standalone}/Containerfile.dev`.
- De prod `Containerfile` (`COPY sources/generated/`) blijft ongemoeid — kopieert nu ook de geneste output + `manifest.json`.

### Validatie
- **Byte-gelijkheid** flat vs `run_all.py`: alle 3 types identiek.
- **actionlint** schoon (exit 0) op alle 4 workflows; YAML-syntax groen.
- pytest **58 groen** (incl. de drop-in-test); ruff schoon.
- De PR-CI (`test.yaml` + `build-standalone.yaml`) draait de nieuwe build end-to-end en importeert de platte output in de type-checks/tests — het echte vangnet.

### Bewust
- **`run_all.py` blijft** als handmatig gereedschap voor de `docs/questions/*.md`-tabellen (werden in de build niet geconsumeerd — committed, alleen in README gerefereerd). Geen functioneel verlies.
- **Geen bronbestand-verhuizing**: de manifest `file`-velden wijzen naar de huidige `sources/<type>.yaml`; verhuizen naar `sources/<type>/<versie>.yaml` is pas nodig bij een 2e versie (aparte kleine stap).
- **Aandachtspunt**: raakt deploy-workflows. De PR-CI valideert de build-stap; de deploy-workflows (alleen op main) delen dezelfde stap, dus consistent meegezet.

Stapelt op #411 (de `build_sources.py`-kern).
