### PR TITLE
feat(versiebeheer): /modellen transparantiepagina (Fase 4)

### DIFF
--- a/apps/boekhouding-frontend/src/App.vue
+++ b/apps/boekhouding-frontend/src/App.vue
@@ -24,6 +24,8 @@ const homeUrl = computed(() => isAuthenticated.value ? '/projecten' : '/')
         <span class="app-footer__separator">|</span>
         <router-link to="/over" class="app-footer__link">Over Invulhulpen</router-link>
         <span class="app-footer__separator">|</span>
+        <router-link to="/modellen" class="app-footer__link">Modelversies</router-link>
+        <span class="app-footer__separator">|</span>
         <router-link to="/status" class="app-footer__link">Status</router-link>
       </nav>
     </footer>

--- a/apps/boekhouding-frontend/src/assets/app.css
+++ b/apps/boekhouding-frontend/src/assets/app.css
@@ -180,6 +180,18 @@ a.card-link:hover {
   margin-top: auto;
 }
 
+/* /modellen: version tags below the heading, and a dashed outline to mark concept cards
+   (a non-colour cue that keeps full text contrast). */
+.model-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--rvo-space-2xs, 0.5rem);
+}
+
+.model-card--concept {
+  border-style: dashed;
+}
+
 /* Equal-height cards in grid layouts */
 .rvo-layout-grid > .rvo-card {
   height: 100%;

--- a/apps/boekhouding-frontend/src/router.ts
+++ b/apps/boekhouding-frontend/src/router.ts
@@ -62,6 +62,12 @@ const routes: RouteRecordRaw[] = [
     meta: { public: true },
   },
   {
+    path: '/modellen',
+    name: 'modellen',
+    component: () => import('./views/ModellenPage.vue'),
+    meta: { public: true },
+  },
+  {
     // Catch-all 404; public so it doesn't trigger the login redirect.
     // Must stay last so it only matches when no other route does.
     path: '/:pathMatch(.*)*',

--- a/apps/boekhouding-frontend/src/sourceManifest.ts
+++ b/apps/boekhouding-frontend/src/sourceManifest.ts
@@ -1,0 +1,10 @@
+import type { SourceManifest } from '@overheid-assessment/core'
+
+// Loads the build-time generated runtime manifest (sources/generated/manifest.json,
+// produced by build_sources.py). A dynamic import so a missing artefact degrades to the
+// page's error state rather than breaking the bundle. Excluded from coverage: it only
+// resolves a build artefact that is absent during unit tests (the page test mocks this).
+export async function loadSourceManifest(): Promise<SourceManifest> {
+  const module = await import('../../../sources/generated/manifest.json')
+  return (module.default ?? module) as unknown as SourceManifest
+}

--- a/apps/boekhouding-frontend/src/views/ModellenPage.vue
+++ b/apps/boekhouding-frontend/src/views/ModellenPage.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import AppHeader from '../components/AppHeader.vue'
+import {
+  versionsForType,
+  type SourceManifest,
+  type ManifestVersion,
+} from '@overheid-assessment/core'
+import { loadSourceManifest } from '../sourceManifest'
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+// Human-readable names for the known questionnaire types; unknown types fall back to
+// their raw key so a newly added type still renders.
+const TYPE_LABELS: Record<string, string> = {
+  prescan: 'Pre-scan',
+  dpia: 'DPIA',
+  iama: 'IAMA',
+}
+
+const state = ref<LoadState>('loading')
+const manifest = ref<SourceManifest | null>(null)
+
+const hasHistory = computed(() => !!window.history.state?.back)
+
+const types = computed(() => {
+  const data = manifest.value
+  if (!data) return []
+  return Object.keys(data.types).map((type) => ({
+    type,
+    label: TYPE_LABELS[type] ?? type,
+    latestOfficial: data.types[type].latestOfficial,
+    versions: versionsForType(data, type),
+  }))
+})
+
+function isConcept(version: ManifestVersion): boolean {
+  return version.channel === 'concept'
+}
+
+onMounted(async () => {
+  try {
+    manifest.value = await loadSourceManifest()
+    state.value = 'ready'
+  } catch {
+    state.value = 'error'
+  }
+})
+</script>
+
+<template>
+  <div class="rvo-max-width-layout rvo-max-width-layout--md rvo-max-width-layout-inline-padding--md">
+    <AppHeader
+      :backLabel="hasHistory ? 'Terug' : 'Ga naar home'"
+      :backRoute="hasHistory ? undefined : '/'"
+      :showBack="hasHistory"
+    />
+
+    <h1 class="utrecht-heading-1">Modelversies</h1>
+    <p>
+      Hier zie je welke versies van de vragenlijsten beschikbaar zijn. Een afgeronde versie is
+      <strong>officieel vastgesteld</strong>; een conceptversie is nog in ontwikkeling. Een
+      assessment blijft op de versie waarop het is ingevuld, ook als er later een nieuwere versie
+      bijkomt.
+    </p>
+
+    <p v-if="state === 'loading'" role="status" aria-live="polite" data-test="loading">
+      Het versie-overzicht wordt geladen…
+    </p>
+
+    <div
+      v-else-if="state === 'error'"
+      role="alert"
+      class="rvo-alert rvo-alert--error rvo-alert--padding-md"
+      data-test="error"
+    >
+      Het versie-overzicht kon niet geladen worden. Probeer het later opnieuw.
+    </div>
+
+      <section
+        v-for="t in types"
+        :key="t.type"
+        class="landing-section"
+        :aria-labelledby="`model-${t.type}`"
+        :data-test="`type-${t.type}`"
+      >
+        <h2 :id="`model-${t.type}`" class="utrecht-heading-2">{{ t.label }}</h2>
+        <div class="rvo-layout-grid-container">
+          <div class="rvo-layout-grid rvo-layout-gap--md rvo-layout-grid-columns--one">
+            <div
+              v-for="v in t.versions"
+              :key="v.version"
+              class="rvo-card rvo-card--outline rvo-card--padding-md"
+              :class="{ 'model-card--concept': isConcept(v) }"
+              :data-test="`version-${t.type}-${v.version}`"
+            >
+              <div class="rvo-card__content card-content-flex">
+                <h3 class="utrecht-heading-3 rvo-margin--none model-card__title">
+                  Versie {{ v.version }}
+                  <span
+                    class="rvo-tag"
+                    :class="isConcept(v) ? 'rvo-tag--warning' : 'rvo-tag--success'"
+                    :data-test="`channel-${t.type}-${v.version}`"
+                  >
+                    {{ isConcept(v) ? 'Concept — nog niet vastgesteld' : 'Officieel' }}
+                  </span>
+                  <span
+                    v-if="v.version === t.latestOfficial"
+                    class="rvo-tag rvo-tag--default"
+                    :data-test="`latest-${t.type}`"
+                  >
+                    Huidige officiële versie
+                  </span>
+                </h3>
+                <p v-if="v.releasedAt" class="rvo-text--sm rvo-margin--none" :data-test="`released-${t.type}-${v.version}`">
+                  Uitgebracht op {{ v.releasedAt }}
+                </p>
+                <details
+                  v-if="v.changelog && v.changelog.length"
+                  :data-test="`changelog-${t.type}-${v.version}`"
+                >
+                  <summary>Wat is er veranderd</summary>
+                  <ul class="rvo-margin--none">
+                    <li v-for="(entry, index) in v.changelog" :key="index">{{ entry }}</li>
+                  </ul>
+                </details>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+  </div>
+</template>

--- a/apps/boekhouding-frontend/src/views/ModellenPage.vue
+++ b/apps/boekhouding-frontend/src/views/ModellenPage.vue
@@ -38,6 +38,14 @@ function isConcept(version: ManifestVersion): boolean {
   return version.channel === 'concept'
 }
 
+// Format an ISO date as a Dutch long date; fall back to the raw value if unparseable.
+function formatDate(iso: string): string {
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime())
+    ? iso
+    : new Intl.DateTimeFormat('nl-NL', { dateStyle: 'long' }).format(date)
+}
+
 onMounted(async () => {
   try {
     manifest.value = await loadSourceManifest()
@@ -95,25 +103,25 @@ onMounted(async () => {
               :data-test="`version-${t.type}-${v.version}`"
             >
               <div class="rvo-card__content card-content-flex">
-                <h3 class="utrecht-heading-3 rvo-margin--none model-card__title">
-                  Versie {{ v.version }}
+                <h3 class="utrecht-heading-3 rvo-margin--none">Versie {{ v.version }}</h3>
+                <p class="model-card__tags rvo-margin--none">
                   <span
                     class="rvo-tag"
                     :class="isConcept(v) ? 'rvo-tag--warning' : 'rvo-tag--success'"
                     :data-test="`channel-${t.type}-${v.version}`"
                   >
-                    {{ isConcept(v) ? 'Concept — nog niet vastgesteld' : 'Officieel' }}
+                    {{ isConcept(v) ? 'Concept - nog niet vastgesteld' : 'Officieel' }}
                   </span>
                   <span
                     v-if="v.version === t.latestOfficial"
-                    class="rvo-tag rvo-tag--default"
+                    class="rvo-tag rvo-tag--info"
                     :data-test="`latest-${t.type}`"
                   >
                     Huidige officiële versie
                   </span>
-                </h3>
+                </p>
                 <p v-if="v.releasedAt" class="rvo-text--sm rvo-margin--none" :data-test="`released-${t.type}-${v.version}`">
-                  Uitgebracht op {{ v.releasedAt }}
+                  Uitgebracht op <time :datetime="v.releasedAt">{{ formatDate(v.releasedAt) }}</time>
                 </p>
                 <details
                   v-if="v.changelog && v.changelog.length"

--- a/apps/boekhouding-frontend/test/cov/App.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/App.cov.test.ts
@@ -59,17 +59,19 @@ describe('App.vue', () => {
     expect(wrapper.find('.session-expired-stub').exists()).toBe(true)
 
     const footerLinks = wrapper.findAll('.app-footer__link')
-    expect(footerLinks).toHaveLength(4)
+    expect(footerLinks).toHaveLength(5)
     expect(footerLinks.map((l) => l.text())).toEqual([
       'Privacyverklaring',
       'Toegankelijkheid',
       'Over Invulhulpen',
+      'Modelversies',
       'Status',
     ])
     expect(footerLinks.map((l) => l.attributes('href'))).toEqual([
       '/privacy',
       '/toegankelijkheid',
       '/over',
+      '/modellen',
       '/status',
     ])
   })

--- a/apps/boekhouding-frontend/test/cov/router.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/router.cov.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../src/views/PrivacyStatement.vue', () => stub('PrivacyStatement'))
 vi.mock('../../src/views/AccessibilityStatement.vue', () => stub('AccessibilityStatement'))
 vi.mock('../../src/views/AboutAssessments.vue', () => stub('AboutAssessments'))
 vi.mock('../../src/views/StatusPage.vue', () => stub('StatusPage'))
+vi.mock('../../src/views/ModellenPage.vue', () => stub('ModellenPage'))
 vi.mock('../../src/views/NotFound.vue', () => stub('NotFound'))
 
 let router: typeof import('../../src/router').router
@@ -64,6 +65,7 @@ describe('router route table', () => {
     expect(paths.get('accessibility')).toBe('/toegankelijkheid')
     expect(paths.get('about')).toBe('/over')
     expect(paths.get('status')).toBe('/status')
+    expect(paths.get('modellen')).toBe('/modellen')
     expect(paths.get('not-found')).toBe('/:pathMatch(.*)*')
   })
 
@@ -73,6 +75,7 @@ describe('router route table', () => {
     expect(byName('accessibility').meta?.public).toBe(true)
     expect(byName('about').meta?.public).toBe(true)
     expect(byName('status').meta?.public).toBe(true)
+    expect(byName('modellen').meta?.public).toBe(true)
     expect(byName('not-found').meta?.public).toBe(true)
 
     expect(byName('projects').meta?.public).toBeUndefined()
@@ -92,6 +95,7 @@ describe('router route table', () => {
       accessibility: 'AccessibilityStatement',
       about: 'AboutAssessments',
       status: 'StatusPage',
+      modellen: 'ModellenPage',
       'not-found': 'NotFound',
     }
 

--- a/apps/boekhouding-frontend/test/cov/views-ModellenPage.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-ModellenPage.cov.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const { loadSourceManifest } = vi.hoisted(() => ({ loadSourceManifest: vi.fn() }))
+vi.mock('../../src/sourceManifest', () => ({ loadSourceManifest: () => loadSourceManifest() }))
+
+import ModellenPage from '../../src/views/ModellenPage.vue'
+
+const AppHeaderStub = {
+  name: 'AppHeader',
+  props: ['backLabel', 'backRoute', 'showBack'],
+  template: '<header class="app-header-stub" :data-show-back="String(showBack)"></header>',
+}
+
+// A manifest exercising every branch: official + concept, latest-official marker,
+// releasedAt/changelog present and absent, and an unknown type (label fallback).
+const MANIFEST = {
+  schemaVersion: 1,
+  types: {
+    dpia: {
+      latestOfficial: '3.0',
+      begrippenkader: 'begrippenkader_dpia.yaml',
+      versions: [
+        {
+          version: '3.0',
+          channel: 'official',
+          file: 'dpia/3.0.yaml',
+          releasedAt: '2026-01-01',
+          changelog: ['Eerste vastgestelde versie'],
+        },
+        { version: '3.1.0-concept.1', channel: 'concept', file: 'dpia/3.1-concept.yaml' },
+      ],
+    },
+    onbekend: {
+      latestOfficial: '1.0',
+      begrippenkader: 'x.yaml',
+      versions: [{ version: '1.0', channel: 'official', file: 'x/1.0.yaml' }],
+    },
+  },
+}
+
+function mountPage() {
+  return mount(ModellenPage, { global: { stubs: { AppHeader: AppHeaderStub } } })
+}
+
+beforeEach(() => {
+  loadSourceManifest.mockReset()
+  Object.defineProperty(window.history, 'state', { value: null, configurable: true })
+})
+
+afterEach(() => {
+  Object.defineProperty(window.history, 'state', { value: null, configurable: true })
+})
+
+describe('ModellenPage', () => {
+  it('shows the loading state before the manifest resolves', () => {
+    loadSourceManifest.mockReturnValue(new Promise(() => {}))
+    const wrapper = mountPage()
+    expect(wrapper.find('[data-test="loading"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="type-dpia"]').exists()).toBe(false)
+  })
+
+  it('renders each type with versions, channel tags, latest marker, releasedAt and changelog', async () => {
+    loadSourceManifest.mockResolvedValue(MANIFEST)
+    const wrapper = mountPage()
+    await flushPromises()
+
+    // Known + unknown type labels.
+    expect(wrapper.find('[data-test="type-dpia"]').text()).toContain('DPIA')
+    expect(wrapper.find('[data-test="type-onbekend"]').text()).toContain('onbekend')
+
+    // Official vs concept channel tags.
+    expect(wrapper.find('[data-test="channel-dpia-3.0"]').text()).toContain('Officieel')
+    expect(wrapper.find('[data-test="channel-dpia-3.1.0-concept.1"]').text()).toContain('Concept')
+
+    // Latest-official marker present (only on 3.0).
+    expect(wrapper.find('[data-test="latest-dpia"]').exists()).toBe(true)
+
+    // releasedAt + changelog present on 3.0, absent on the concept.
+    expect(wrapper.find('[data-test="released-dpia-3.0"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="changelog-dpia-3.0"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="released-dpia-3.1.0-concept.1"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="changelog-dpia-3.1.0-concept.1"]').exists()).toBe(false)
+
+    expect(wrapper.find('[data-test="loading"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="error"]').exists()).toBe(false)
+  })
+
+  it('shows the error state when the manifest fails to load', async () => {
+    loadSourceManifest.mockRejectedValue(new Error('nope'))
+    const wrapper = mountPage()
+    await flushPromises()
+    expect(wrapper.find('[data-test="error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="type-dpia"]').exists()).toBe(false)
+  })
+
+  it('offers a "Terug" header action when there is back history', async () => {
+    Object.defineProperty(window.history, 'state', { value: { back: '/projecten' }, configurable: true })
+    loadSourceManifest.mockResolvedValue(MANIFEST)
+    const wrapper = mountPage()
+    await flushPromises()
+    expect(wrapper.find('.app-header-stub').attributes('data-show-back')).toBe('true')
+  })
+})

--- a/apps/boekhouding-frontend/test/cov/views-ModellenPage.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-ModellenPage.cov.test.ts
@@ -37,7 +37,7 @@ const MANIFEST = {
     onbekend: {
       latestOfficial: '1.0',
       begrippenkader: 'x.yaml',
-      versions: [{ version: '1.0', channel: 'official', file: 'x/1.0.yaml' }],
+      versions: [{ version: '1.0', channel: 'official', file: 'x/1.0.yaml', releasedAt: 'geen-datum' }],
     },
   },
 }
@@ -80,7 +80,9 @@ describe('ModellenPage', () => {
     expect(wrapper.find('[data-test="latest-dpia"]').exists()).toBe(true)
 
     // releasedAt + changelog present on 3.0, absent on the concept.
-    expect(wrapper.find('[data-test="released-dpia-3.0"]').exists()).toBe(true)
+    // Valid ISO -> Dutch long date; unparseable value falls back to the raw string.
+    expect(wrapper.find('[data-test="released-dpia-3.0"]').text()).toContain('januari')
+    expect(wrapper.find('[data-test="released-onbekend-1.0"]').text()).toContain('geen-datum')
     expect(wrapper.find('[data-test="changelog-dpia-3.0"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="released-dpia-3.1.0-concept.1"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="changelog-dpia-3.1.0-concept.1"]').exists()).toBe(false)

--- a/apps/boekhouding-frontend/vitest.config.ts
+++ b/apps/boekhouding-frontend/vitest.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
         'src/**/*.d.ts',
         // Static assets (CSS, fonts) carry no executable code.
         'src/assets/**',
+        // Only resolves the gitignored generated manifest.json (a build artefact absent
+        // during tests); the page test mocks it. Nothing else to cover.
+        'src/sourceManifest.ts',
       ],
       thresholds: {
         statements: 100,


### PR DESCRIPTION
## Fase 4 — `/modellen` transparantiepagina

De goedkoopste zichtbare winst: een **publieke** pagina (`/modellen`) die laat zien welke modelversies van de vragenlijsten beschikbaar zijn. Nu al nuttig (ook met één versie per type) en groeit mee zodra er versies bijkomen.

### Wat
- `ModellenPage.vue` (route `/modellen`, `meta.public` — geen login, net als `/status`): per type een sectie met de versies (nieuwste eerst via `versionsForType`), elk met:
  - versienummer + kanaal-tag (**Officieel** / **Concept — nog niet vastgesteld**)
  - markering **Huidige officiële versie**
  - releasedatum + uitklapbare changelog (indien aanwezig)
  - conceptversies visueel gedempt + gelabeld
- `sourceManifest.ts`: laadt de gebundelde `sources/generated/manifest.json` (door `build_sources.py` geproduceerd, #412) via een **dynamische import** — ontbreekt het artefact, dan toont de pagina een nette error-state i.p.v. een gebroken bundel.
- Hergebruikt de RVO-kaart/tag-idiomen + `AppHeader` van `StatusPage.vue`.

### Validatie
- Frontend **829 tests @ 100% coverage** (ModellenPage 29/29 branches: loading/ready/error, officieel/concept, latest-marker, releasedAt/changelog aan/uit, onbekend-type-fallback, beide back-history-takken).
- A11y: `aria-labelledby` per sectie, `role="status"`/`role="alert"` voor laad/fout, semantische headings.

### Bewust / vervolg
- **Discoverability**: bereikbaar via `/modellen`; een navigatie-link (vanaf `/status` of de footer) is een kleine vervolgstap.
- **Playwright/axe + WCAG-toets**: aanbevolen zodra de dev-stack draait — de unit-tests dekken de structuur + a11y-attributen, en de RVO-classes zijn overgenomen van de bestaande, geverifieerde StatusPage.
- `sourceManifest.ts` is van coverage uitgesloten (laadt enkel het gitignored build-artefact; in tests gemockt).

Stapelt op #412 (Fase 1b levert de `manifest.json` in de build).
