### PR TITLE
feat(versiebeheer): resolve-by-pin loader (Fase 2c)

### DIFF
--- a/apps/boekhouding-frontend/src/views/AssessmentEditor.vue
+++ b/apps/boekhouding-frontend/src/views/AssessmentEditor.vue
@@ -37,6 +37,8 @@ const calculationStore = useCalculationStore()
 const assessment = ref<(AssessmentInstance & { role?: string }) | null>(null)
 const loading = ref(true)
 const error = ref<string | null>(null)
+// Non-blocking notice when the assessment's pinned definition version is not bundled.
+const versionWarning = ref<string | null>(null)
 const canEdit = computed(() => assessment.value?.role === 'owner' || assessment.value?.role === 'editor')
 const isReadonly = computed(() => !canEdit.value)
 
@@ -227,6 +229,15 @@ onMounted(async () => {
     const namespace = assessmentTypeMap[assessment.value.assessmentType] || FormType.DPIA
     taskStore.setActiveNamespace(namespace)
     answerStore.setActiveNamespace(namespace)
+
+    // Resolve the version this assessment was filled against into the active slot, so the
+    // form, save and export work against the pinned definition rather than the bundled
+    // latest. If that version is not bundled, keep the latest but warn — never silently
+    // restamp to a different version.
+    const { fellBack } = schemaStore.activatePin(namespace, assessment.value.definitionVersion)
+    if (fellBack) {
+      versionWarning.value = `De vastgelegde modelversie (${assessment.value.definitionVersion}) is niet beschikbaar. Je werkt nu met de nieuwste versie; controleer of dit klopt voordat je wijzigingen opslaat.`
+    }
 
     // If this is a DPIA with embedded pre-scan answers, initialize the PRE_SCAN
     // task structure and load answers so usePreScanReferences can work.
@@ -447,6 +458,10 @@ const confirmDelete = async () => {
       </div>
       <div v-else-if="assessment.role === 'commenter'" class="rvo-alert rvo-alert--info rvo-alert--padding-sm rvo-margin-block-end--md" role="status">
         Je kunt opmerkingen plaatsen maar niet het formulier bewerken.
+      </div>
+
+      <div v-if="versionWarning" class="rvo-alert rvo-alert--warning rvo-alert--padding-sm rvo-margin-block-end--md" role="alert">
+        {{ versionWarning }}
       </div>
 
     </div>

--- a/apps/boekhouding-frontend/test/cov/views-AssessmentEditor.cov.test.ts
+++ b/apps/boekhouding-frontend/test/cov/views-AssessmentEditor.cov.test.ts
@@ -35,6 +35,7 @@ const {
     isInitialized: false,
     init: vi.fn(),
     getSchema: vi.fn(),
+    activatePin: vi.fn(() => ({ fellBack: false })),
   })
   const taskStore: any = reactive({
     activeNamespace: FormTypeMock.DPIA,
@@ -252,6 +253,8 @@ beforeEach(async () => {
 
   schemaStore.isInitialized = false
   schemaStore.getSchema.mockReset()
+  schemaStore.activatePin.mockReset()
+  schemaStore.activatePin.mockReturnValue({ fellBack: false })
   taskStore.activeNamespace = FormTypeMock.DPIA
   taskStore.currentRootTaskId = { dpia: '0', prescan: '0' }
   taskStore.isInitialized = { dpia: false, prescan: false }
@@ -332,6 +335,28 @@ describe('AssessmentEditor — onMounted initialization', () => {
     schemaStore.isInitialized = true
     const wrapper = await mountEditor()
     expect(schemaStore.init).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('activates the pinned definition version for the active namespace', async () => {
+    schemaStore.isInitialized = true
+    assessmentsApi.get.mockResolvedValueOnce(makeAssessment({ assessmentType: 'dpia', definitionVersion: '3.0' }))
+    const wrapper = await mountEditor()
+    expect(schemaStore.activatePin).toHaveBeenCalledWith(FormTypeMock.DPIA, '3.0')
+    expect(wrapper.find('.rvo-alert--warning').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('warns without blocking when the pinned version is not bundled (fellBack)', async () => {
+    schemaStore.isInitialized = true
+    schemaStore.activatePin.mockReturnValueOnce({ fellBack: true })
+    assessmentsApi.get.mockResolvedValueOnce(makeAssessment({ assessmentType: 'dpia', definitionVersion: '2.9' }))
+    const wrapper = await mountEditor()
+    const warning = wrapper.find('.rvo-alert--warning')
+    expect(warning.exists()).toBe(true)
+    expect(warning.text()).toContain('2.9')
+    // The form still renders: the warning is non-blocking.
+    expect(wrapper.find('.form-stub').exists()).toBe(true)
     wrapper.unmount()
   })
 

--- a/packages/assessment-core/src/stores/schemas.ts
+++ b/packages/assessment-core/src/stores/schemas.ts
@@ -137,6 +137,29 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
     return `${schema.urn}:${canonicalVersion(schema.version)}`
   }
 
+  function setActiveSlot(namespace: FormType, definition: ValidatedDefinition) {
+    if (namespace === FormType.DPIA) validatedDpia.value = definition
+    else if (namespace === FormType.IAMA) validatedIama.value = definition
+    else validatedPreScan.value = definition
+  }
+
+  // Resolve a per-assessment version pin into the active-per-type slot, so that all
+  // downstream consumers (getSchema/getUrn, task structure, save/export) work against the
+  // pinned definition rather than the bundled latest. A null pin keeps the loaded latest.
+  // When the pinned version is not bundled, the loaded latest is kept and `fellBack` is set
+  // so the caller can warn — the pin is never silently restamped to the wrong version.
+  function activatePin(namespace: FormType, pinnedVersion: string | null): { fellBack: boolean } {
+    const active = getSchema(namespace)
+    if (!active) throw new Error(`Schema not loaded for namespace: ${namespace}`)
+    if (!pinnedVersion) return { fellBack: false }
+
+    const pinned = registry.value.get(`${active.urn}:${canonicalVersion(pinnedVersion)}`)
+    if (!pinned) return { fellBack: true }
+
+    setActiveSlot(namespace, pinned)
+    return { fellBack: false }
+  }
+
   return {
     isInitialized,
     hasErrors,
@@ -146,6 +169,7 @@ export const useSchemaStore = defineStore('SchemaStore', () => {
     getByUrn,
     registeredUrns,
     getSchema,
-    getUrn
+    getUrn,
+    activatePin
   }
 })

--- a/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
+++ b/packages/assessment-core/test/cov/stores-schemas.cov.test.ts
@@ -316,4 +316,88 @@ describe('useSchemaStore', () => {
       expect(store.registeredUrns().filter(u => u === 'urn:nl:dpia:3.0')).toHaveLength(1)
     })
   })
+
+  describe('activatePin', () => {
+    it('switches the active-per-type slot to the pinned version so getUrn reflects the pin', () => {
+      const store = useSchemaStore()
+      // Bundled latest is 3.1; an older 3.0 is also registered (as a future multi-version
+      // bundle would do). Pinning to 3.0 must make the active view resolve to 3.0.
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '1.0' }),
+      })
+      store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.0' }))
+
+      const result = store.activatePin(FormType.DPIA, '3.0')
+
+      expect(result.fellBack).toBe(false)
+      expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.0')
+      expect(store.getSchema(FormType.DPIA)!.version).toBe('3.0')
+    })
+
+    it('pins the PRE_SCAN and IAMA slots too (covers all namespace branches)', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.1' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '2.1' }),
+      })
+      store.register(buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }))
+      store.register(buildSchema({ urn: 'urn:nl:iama', version: '2.0' }))
+
+      expect(store.activatePin(FormType.PRE_SCAN, '2.0').fellBack).toBe(false)
+      expect(store.activatePin(FormType.IAMA, '2.0').fellBack).toBe(false)
+      expect(store.getUrn(FormType.PRE_SCAN)).toBe('urn:nl:prescan:2.0')
+      expect(store.getUrn(FormType.IAMA)).toBe('urn:nl:iama:2.0')
+    })
+
+    it('canonicalizes the pin so a coarse pin resolves an official version', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '1.0' }),
+      })
+      store.register(buildSchema({ urn: 'urn:nl:dpia', version: '3.0.7' }))
+
+      // Pin "3.0" must resolve the official 3.0.x registered under coarse key urn:nl:dpia:3.0.
+      expect(store.activatePin(FormType.DPIA, '3.0').fellBack).toBe(false)
+      expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.0')
+    })
+
+    it('falls back to the loaded latest and reports fellBack when the pin is not bundled', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '1.0' }),
+      })
+
+      const result = store.activatePin(FormType.DPIA, '2.0')
+
+      expect(result.fellBack).toBe(true)
+      // Slot stays on the loaded latest: never silently restamp to a wrong version.
+      expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.1')
+    })
+
+    it('is a no-op (no fallback) when no pin is given', () => {
+      const store = useSchemaStore()
+      store.init({
+        dpia: buildSchema({ urn: 'urn:nl:dpia', version: '3.1.0' }),
+        preScan: buildSchema({ urn: 'urn:nl:prescan', version: '2.0' }),
+        iama: buildSchema({ urn: 'urn:nl:iama', version: '1.0' }),
+      })
+
+      expect(store.activatePin(FormType.DPIA, null).fellBack).toBe(false)
+      expect(store.getUrn(FormType.DPIA)).toBe('urn:nl:dpia:3.1')
+    })
+
+    it('throws when no schema is loaded for the namespace', () => {
+      const store = useSchemaStore()
+      expect(() => store.activatePin(FormType.DPIA, '3.0')).toThrow(
+        'Schema not loaded for namespace: dpia',
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Wat

Maakt de **loader versie-bewust**: de editor laadt voortaan de modelversie waarop een assessment is ingevuld (`definitionVersion`) in het actieve schema-slot, in plaats van altijd de gebundelde latest. Dit is de keystone van Fase 2 — zodra de build meerdere versies bundelt, werkt elk assessment automatisch tegen zijn gepinde definitie.

## Hoe

- **`schemaStore.activatePin(namespace, pinnedVersion)`** (core) resolvet de gepinde versie uit de registry (`#408`) en zet die in het actieve slot (`validatedDpia/PreScan/Iama`).
  - Pin gevonden → slot wisselt; `getSchema`/`getUrn` reflecteren de pin.
  - Pin **niet** gebundeld → latest blijft geladen, `fellBack: true` → de editor toont een niet-blokkerende waarschuwing. **Nooit stil herstempelen** naar een andere versie (kernbeslissing 2 / anti-self-correct).
  - Geen pin (`null`) → no-op, latest blijft.
- **`AssessmentEditor.vue`** roept `activatePin` aan na het zetten van de namespace, en surfaced de fallback als `rvo-alert--warning`.

Omdat `getUrn`/`getSchema` het actieve slot lezen, worden **formulier, save én export** hierdoor automatisch versie-bewust — zonder signatuurwijziging op `getUrn`.

## Aandachtspunten voor review

1. **Dormant met één versie.** Vandaag bundelt de build één versie per type, dus `activatePin('3.0')` resolvet de enige 3.0 → no-op (correct-by-construction). De interessante takken (pin-wissel, fallback-waarschuwing) zijn unit-getest met een 2-versie registry. End-to-end multi-versie-gedrag activeert pas wanneer de build-stack (`#411`/`#412`) meerdere versies bundelt.
2. **Single-slot ontwerp, bewust.** Ik wissel het bestaande per-type slot i.p.v. `getSchema`/`getUrn` een verplichte version-parameter te geven (de zwaardere invariant-refactor uit het plan). Dit is de minimale-blast-radius variant: alle bestaande consumenten blijven werken, en de pin propageert via het slot. De verplichte-parameter-invariant kan later additief.
3. **Standalone valt buiten scope.** De standalone-pin (P0 #2, eigen localStorage-drager) is een aparte, gedocumenteerde follow-up — deze PR raakt alleen de boekhouding-frontend + core.
4. **Waarschuwingstekst** (NL, je-vorm): "De vastgelegde modelversie (X) is niet beschikbaar. Je werkt nu met de nieuwste versie; controleer of dit klopt voordat je wijzigingen opslaat." — feedback welkom.

## Stack

Bovenop `#410` (pin-kolom, base) → `#409` (D1) → `#408` (registry) → fundament. Reviewvolgorde: #408 → #409 → #410 → **deze**.

## Tests

- core `stores-schemas.cov.test.ts`: 6 nieuwe tests voor `activatePin` (pin-wissel, alle 3 namespaces, coarse-canonicalisatie, fallback, null-no-op, niet-geladen-throw). 100% coverage op `schemas.ts`.
- frontend `views-AssessmentEditor.cov.test.ts`: 2 nieuwe tests (happy-path activatePin-aanroep + fellBack-waarschuwing). 100% coverage op `AssessmentEditor.vue`.
- Volledige suites groen: core 1110 ✓, frontend 100% ✓.