### PR TITLE
feat(versiebeheer): standalone version-pin op hervatten (P0 #2)

### DIFF
--- a/apps/standalone-form/src/App.vue
+++ b/apps/standalone-form/src/App.vue
@@ -29,6 +29,10 @@ const schemaStore = useSchemaStore()
 
 const currentView = ref<ViewState>(ViewState.Landing)
 
+// Non-blocking notice when a resumed assessment was filled against a definition
+// version that this build no longer bundles.
+const versionWarning = ref<string | null>(null)
+
 // Which assessments have saved progress in localStorage. Recomputed whenever
 // the landing page is shown, since localStorage is not reactive.
 const cachedTypes = ref<FormType[]>([])
@@ -40,8 +44,25 @@ const refreshCachedTypes = () => {
 refreshCachedTypes()
 
 const navigateTo = (view: ViewState) => {
-  if (view === ViewState.Landing) refreshCachedTypes()
+  if (view === ViewState.Landing) {
+    refreshCachedTypes()
+    versionWarning.value = null
+  }
   currentView.value = view
+}
+
+// Before opening a form, pin the bundled definition to the version a resumed
+// assessment was filled against, so the form, autosave and export keep that
+// version rather than silently adopting the bundled latest. If that version is
+// not bundled, keep the latest but warn — never silently restamp.
+const resolvePin = (ns: FormType) => {
+  const version = persistence.savedVersion(ns)
+  versionWarning.value = null
+  if (!version) return
+  const { fellBack } = schemaStore.activatePin(ns, version)
+  if (fellBack) {
+    versionWarning.value = `De opgeslagen versie (${version}) zit niet in deze versie van het formulier. Je werkt nu met de nieuwste versie; controleer je antwoorden voordat je verdergaat.`
+  }
 }
 
 const navigationFunctions: NavigationFunctions = {
@@ -50,18 +71,21 @@ const navigationFunctions: NavigationFunctions = {
     taskStore.setActiveNamespace(FormType.DPIA)
     answerStore.setActiveNamespace(FormType.DPIA)
     taskStore.isInitialized[FormType.DPIA] = false
+    resolvePin(FormType.DPIA)
     navigateTo(ViewState.DPIA)
   },
   goToPreScanDPIA: () => {
     taskStore.setActiveNamespace(FormType.PRE_SCAN)
     answerStore.setActiveNamespace(FormType.PRE_SCAN)
     taskStore.isInitialized[FormType.PRE_SCAN] = false
+    resolvePin(FormType.PRE_SCAN)
     navigateTo(ViewState.PreScanDPIA)
   },
   goToIAMA: () => {
     taskStore.setActiveNamespace(FormType.IAMA)
     answerStore.setActiveNamespace(FormType.IAMA)
     taskStore.isInitialized[FormType.IAMA] = false
+    resolvePin(FormType.IAMA)
     navigateTo(ViewState.IAMA)
   },
 }
@@ -91,6 +115,16 @@ const isResume = (type: FormType) => persistence.hasSavedState(type)
     :cached-types="cachedTypes"
     @start-fresh="startFresh"
   />
+
+  <!-- Version-mismatch notice when resuming an assessment filled against a version
+       this build no longer bundles. -->
+  <div
+    v-if="versionWarning"
+    class="rvo-alert rvo-alert--warning rvo-alert--padding-sm"
+    role="alert"
+  >
+    {{ versionWarning }}
+  </div>
 
   <!-- DPIA Form -->
   <Form

--- a/apps/standalone-form/src/LocalPersistence.ts
+++ b/apps/standalone-form/src/LocalPersistence.ts
@@ -11,6 +11,7 @@ import {
   migrateStateV1toV2,
   applyStateToStores,
   groupAnswers,
+  parseUrn,
 } from '@overheid-assessment/core'
 
 /** Loosely-typed shape of state read from storage: it may be a current flat
@@ -25,6 +26,9 @@ interface LoadedState {
 export interface LocalPersistence extends PersistenceProvider {
   /** Whether a non-empty saved state exists for the given assessment type. */
   hasSavedState(namespace: FormType): boolean
+  /** The definition version a saved state was filled against (from metadata.urn),
+   *  or null when there is no saved state or its urn is unparseable. */
+  savedVersion(namespace: FormType): string | null
 }
 
 function getStorageKey(namespace: string): string {
@@ -139,6 +143,17 @@ export function createLocalPersistence(): LocalPersistence {
     }
   }
 
+  function savedVersion(namespace: FormType): string | null {
+    try {
+      const data = localStorage.getItem(getStorageKey(namespace))
+      if (!data) return null
+      const parsed = JSON.parse(data) as { metadata?: { urn?: string } }
+      return parseUrn(parsed.metadata?.urn)?.version ?? null
+    } catch {
+      return null
+    }
+  }
+
   function clearSavedState(namespace?: FormType): void {
     const ns = namespace ?? taskStore.activeNamespace
     localStorage.removeItem(getStorageKey(ns))
@@ -185,6 +200,7 @@ export function createLocalPersistence(): LocalPersistence {
     loadAppState,
     applyAppState,
     hasSavedState,
+    savedVersion,
     clearSavedState,
     setupWatchers,
     restoreUiState,

--- a/apps/standalone-form/test/cov/App.cov.test.ts
+++ b/apps/standalone-form/test/cov/App.cov.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import {
   FormType,
   useTaskStore,
   useAnswerStore,
+  useSchemaStore,
   type NavigationFunctions,
 } from '@overheid-assessment/core'
 import App from '../../src/App.vue'
@@ -220,5 +221,63 @@ describe('App.vue — cached sessions (#322)', () => {
     expect(form.exists()).toBe(true)
     expect(form.props('namespace')).toBe(type)
     expect(form.props('autoStart')).toBe(true)
+  })
+})
+
+describe('App.vue — version pin on resume', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  function seedVersioned(ns: FormType, urn: string): void {
+    localStorage.setItem(storageKey(ns), JSON.stringify({
+      metadata: { urn },
+      answers: { '0.1': { value: 'X' } },
+    }))
+  }
+
+  it('activates the saved version on resume and shows no warning when it is bundled', async () => {
+    seedVersioned(FormType.DPIA, 'urn:nl:dpia:3.0')
+    const activatePin = vi.spyOn(useSchemaStore(), 'activatePin').mockReturnValue({ fellBack: false })
+
+    const wrapper = mountApp()
+    const nav = wrapper.findComponent(LandingStub).props('navigation') as NavigationFunctions
+    nav.goToDPIA()
+    await wrapper.vm.$nextTick()
+
+    expect(activatePin).toHaveBeenCalledWith(FormType.DPIA, '3.0')
+    expect(wrapper.find('.rvo-alert--warning').exists()).toBe(false)
+  })
+
+  it('warns without blocking when the saved version is not bundled (fellBack)', async () => {
+    seedVersioned(FormType.IAMA, 'urn:nl:iama:1.9')
+    vi.spyOn(useSchemaStore(), 'activatePin').mockReturnValue({ fellBack: true })
+
+    const wrapper = mountApp()
+    const nav = wrapper.findComponent(LandingStub).props('navigation') as NavigationFunctions
+    nav.goToIAMA!()
+    await wrapper.vm.$nextTick()
+
+    const warning = wrapper.find('.rvo-alert--warning')
+    expect(warning.exists()).toBe(true)
+    expect(warning.text()).toContain('1.9')
+    // Non-blocking: the form still renders.
+    expect(wrapper.findComponent(FormStub).exists()).toBe(true)
+  })
+
+  it('clears the warning when returning to the landing page', async () => {
+    seedVersioned(FormType.DPIA, 'urn:nl:dpia:2.9')
+    vi.spyOn(useSchemaStore(), 'activatePin').mockReturnValue({ fellBack: true })
+
+    const wrapper = mountApp()
+    const nav = wrapper.findComponent(LandingStub).props('navigation') as NavigationFunctions
+    nav.goToDPIA()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.rvo-alert--warning').exists()).toBe(true)
+
+    nav.goToLanding()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.rvo-alert--warning').exists()).toBe(false)
   })
 })

--- a/apps/standalone-form/test/cov/LocalPersistence.cov.test.ts
+++ b/apps/standalone-form/test/cov/LocalPersistence.cov.test.ts
@@ -438,3 +438,40 @@ describe('createLocalPersistence — restoreUiState', () => {
     expect(taskStore.currentRootTaskId[FormType.DPIA]).toBe('0')
   })
 })
+
+describe('createLocalPersistence — savedVersion', () => {
+  it('returns the version parsed from the saved metadata.urn', () => {
+    localStorage.setItem(storageKey(FormType.DPIA), JSON.stringify({
+      metadata: { urn: 'urn:nl:dpia:3.0' },
+      answers: { '0.1': { value: 'x' } },
+    }))
+    const provider = createLocalPersistence()
+    expect(provider.savedVersion(FormType.DPIA)).toBe('3.0')
+  })
+
+  it('returns the precise concept version when the saved urn carries a prerelease', () => {
+    localStorage.setItem(storageKey(FormType.IAMA), JSON.stringify({
+      metadata: { urn: 'urn:nl:iama:2.1.0-concept.3' },
+      answers: {},
+    }))
+    const provider = createLocalPersistence()
+    expect(provider.savedVersion(FormType.IAMA)).toBe('2.1.0-concept.3')
+  })
+
+  it('returns null when there is no saved state for the namespace', () => {
+    const provider = createLocalPersistence()
+    expect(provider.savedVersion(FormType.IAMA)).toBeNull()
+  })
+
+  it('returns null when the saved state has no parseable urn', () => {
+    localStorage.setItem(storageKey(FormType.DPIA), JSON.stringify({ answers: {} }))
+    const provider = createLocalPersistence()
+    expect(provider.savedVersion(FormType.DPIA)).toBeNull()
+  })
+
+  it('returns null when the saved state is malformed JSON', () => {
+    localStorage.setItem(storageKey(FormType.DPIA), '{not json')
+    const provider = createLocalPersistence()
+    expect(provider.savedVersion(FormType.DPIA)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Wat

De standalone-tegenhanger van resolve-by-pin (#415): de **offline single-file** respecteert nu bij het hervatten de modelversie waarop een assessment is ingevuld, in plaats van die stil tegen de gebundelde latest toe te passen.

## Waarom (P0 #2)

`saveAppState` stempelt de versie al in `metadata.urn` (bv. `urn:nl:dpia:3.0`), maar `loadAppState` negeerde die. Scenario: je vult offline een DPIA in met single-file vX (DPIA 3.0), download later single-file vY (DPIA 3.1), en opent je oude localStorage-sessie → die werd stil tegen 3.1 toegepast én bij de eerstvolgende autosave op 3.1 herstempeld. Voor een juridisch artefact een correctheidsprobleem.

## Hoe

- **`LocalPersistence.savedVersion(namespace)`** — leest de opgeslagen `metadata.urn` en geeft via `parseUrn` de versie terug (`null` als er geen state is of de urn onparseerbaar is).
- **`App.vue` resume-handlers** roepen vóór navigatie `resolvePin(ns)` aan: `savedVersion` → `schemaStore.activatePin(ns, version)`.
  - Versie gebundeld → slot wisselt, formulier/autosave/export blijven op de gepinde versie.
  - Versie **niet** gebundeld → latest blijft, niet-blokkerende `rvo-alert--warning`. **Nooit stil herstempelen.**
- De waarschuwing wordt gewist bij terug naar de landingspagina.

Hergebruikt `activatePin` uit #415 — online editor en standalone delen exact dezelfde resolutie-logica.

## Aandachtspunten voor review

1. **Architectuurverschil met de online editor.** De standalone geeft het schema als **prop** door aan `Form` (`:validData="schemaStore.getSchema(ns)"`), en `Form` bouwt de taakstructuur al op stap 3 — vóór `applyAppState`. Daarom moet de pin **op App.vue-niveau** vóór navigatie resolven (niet in `applyAppState`, dat is te laat). De online editor kon het in zijn eigen load-volgorde doen.
2. **Dormant met één gebundelde versie.** `savedVersion` == bundel-versie → `activatePin` no-op → geen waarschuwing. De fallback-tak is unit-getest met een geïnjecteerde mismatch en vuurt in productie pas bij een cross-single-file-download.
3. **Geen migratie (nog).** Bij een mismatch tonen we een waarschuwing maar migreren niet — de forward-migratie-engine is Fase 7. Dit is bewust "waarschuw, blokkeer niet".
4. **Waarschuwingstekst** (NL, je-vorm): "De opgeslagen versie (X) zit niet in deze versie van het formulier. Je werkt nu met de nieuwste versie; controleer je antwoorden voordat je verdergaat."

## Stack

Bovenop **#415** (resolve-by-pin / `activatePin`) → #410 → #409 → #408 → fundament.

## Tests

- `LocalPersistence.cov.test.ts`: 5 nieuwe tests voor `savedVersion` (coarse versie, concept-versie, geen-state, onparseerbare urn, kapotte JSON). 100% op `LocalPersistence.ts`.
- `App.cov.test.ts`: 3 nieuwe tests (activatePin-aanroep op resume, fellBack-waarschuwing, waarschuwing gewist bij terug naar landing). 100% op `App.vue`.
- Volledige standalone-suite groen: 100% coverage. Type-check (`vue-tsc --build`) groen.