### PR TITLE
Fix DPIA task wording typo

### DIFF
--- a/sources/dpia.yaml
+++ b/sources/dpia.yaml
@@ -524,7 +524,7 @@ tasks:
               type:
                 - text_input
               repeatable: false
-        - task: Aanvullende informatie toe over het juridische en beleidsmatig kader
+        - task: Aanvullende informatie over het juridische en beleidsmatig kader
           description: Gebruik dit optionele tekstveld voor extra toelichting op de ingevulde vragen.
           id: "9.2"
           type:


### PR DESCRIPTION
Fixes #417.

This updates the DPIA task text reported in the issue from:

`Aanvullende informatie toe over het juridische en beleidsmatig kader`

to:

`Aanvullende informatie over het juridische en beleidsmatig kader`

Validation:
- Confirmed the target line in `sources/dpia.yaml`.
- Ran `git diff --check`.