### PR TITLE
fix: correct Dutch DPIA field label typo

### DIFF
--- a/docs/questions/questions_DPIA.md
+++ b/docs/questions/questions_DPIA.md
@@ -57,7 +57,7 @@
 | 9.1.1 |     Juridisch en beleidsmatig kader |  | task_group |  |  |
 | 9.1.1.1 |       Juridisch en/of beleidsmatig kader |  | text_input |  |  |
 | 9.1.1.2 |       Wetsartikelen |  | text_input |  |  |
-| 9.2 |   Aanvullende informatie toe over het juridische en beleidsmatig kader | Gebruik dit optionele tekstveld voor extra toelichting op de ingevulde vragen. | open_text |  |  |
+| 9.2 |   Aanvullende informatie over het juridische en beleidsmatig kader | Gebruik dit optionele tekstveld voor extra toelichting op de ingevulde vragen. | open_text |  |  |
 | 10 | Bewaartermijnen | Bepaal de bewaartermijnen van de persoonsgegevens aan de hand van de gegevensverwerkingen en de v... | task_group |  |  |
 | 10.1 |   Gegevensverwerking, verwerkingsdoeleinde, categorie betrokkene & persoonsgegevens, bewaartermijn archiveringsperiode & motivatie bewaartermijn |  | task_group |  | Copy from 3.1.1 |
 | 10.1.1 |     Bewaartermijnen |  | task_group |  |  |

--- a/docs/tasks/tasks_DPIA.md
+++ b/docs/tasks/tasks_DPIA.md
@@ -57,7 +57,7 @@
 | 9.1.1 |     Juridisch en beleidsmatig kader |  | task_group |  |  |
 | 9.1.1.1 |       Juridisch en/of beleidsmatig kader |  | text_input |  |  |
 | 9.1.1.2 |       Wetsartikelen |  | text_input |  |  |
-| 9.2 |   Aanvullende informatie toe over het juridische en beleidsmatig kader | Gebruik dit optionele tekstveld voor extra toelichting op de ingevulde vragen. | open_text |  |  |
+| 9.2 |   Aanvullende informatie over het juridische en beleidsmatig kader | Gebruik dit optionele tekstveld voor extra toelichting op de ingevulde vragen. | open_text |  |  |
 | 10 | Bewaartermijnen | Bepaal de bewaartermijnen van de persoonsgegevens aan de hand van de gegevensverwerkingen en de v... | task_group |  |  |
 | 10.1 |   Gegevensverwerking, verwerkingsdoeleinde, categorie betrokkene & persoonsgegevens, bewaartermijn archiveringsperiode & motivatie bewaartermijn |  | task_group |  | Copy from 3.1.1 |
 | 10.1.1 |     Bewaartermijnen |  | task_group |  |  |

--- a/sources/dpia.yaml
+++ b/sources/dpia.yaml
@@ -524,7 +524,7 @@ tasks:
               type:
                 - text_input
               repeatable: false
-        - task: Aanvullende informatie toe over het juridische en beleidsmatig kader
+        - task: Aanvullende informatie over het juridische en beleidsmatig kader
           description: Gebruik dit optionele tekstveld voor extra toelichting op de ingevulde vragen.
           id: "9.2"
           type:


### PR DESCRIPTION
# Description

Describe in detail the changes you are proposing, and the rationale.

This fixes the Dutch wording for field `9.2` by removing the stray `toe` in the label, and keeps the generated markdown docs in sync with the source YAML.

Link all GitHub issues fixed by this PR.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

Resolves #417

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have tested the changes locally and verified that they work as expected.
- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have read, understood and agree to the [Developer Certificate of Origin](/DCO.md), which this project utilizes.
